### PR TITLE
CODETOOLS-7902812: Fields can still be default initialized if class has only static intializers

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -676,6 +676,9 @@ public class JCStressTestProcessor extends AbstractProcessor {
                 if (t.getInitializer() != null) return false;
             }
             if (member.getKind() == Tree.Kind.BLOCK) {
+                BlockTree b = (BlockTree)member;
+                // static initializers are fine
+                if (b.isStatic()) continue;
                 // no instance initializers of any kind
                 return false;
             }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -676,7 +676,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
                 if (t.getInitializer() != null) return false;
             }
             if (member.getKind() == Tree.Kind.BLOCK) {
-                BlockTree b = (BlockTree)member;
+                BlockTree b = (BlockTree) member;
                 // no instance initializers of any kind
                 if (!b.isStatic()) return false;
             }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -677,10 +677,8 @@ public class JCStressTestProcessor extends AbstractProcessor {
             }
             if (member.getKind() == Tree.Kind.BLOCK) {
                 BlockTree b = (BlockTree)member;
-                // static initializers are fine
-                if (b.isStatic()) continue;
                 // no instance initializers of any kind
-                return false;
+                if (!b.isStatic()) return false;
             }
         }
         return true;


### PR DESCRIPTION
`JCStressTestProcessor` processes a jcstress test `X.java` and generates the corresponding `X_jcstress.java` wrapper class. In this class it generates a `jcstress_consume()` method which resets the status of the stress test after every iteration. If the initial `X.java` stress test class only has primitive fields, a default constructor and no instance initializer, it's fields can be simply reset to default values. Otherwise the method allocates a completely new `X` object.

The current check for default initialization of fields makes no distinction between instance and static (i.e. class) initializers and rejects default initialization of fields in the presence of each of them. Fields can however still be default initialized if a class only has static initializers. This saves some allocations and GC-cycles mostly for the VarHandle tests where the VarHandles are commonly initialized in static initializers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902812](https://bugs.openjdk.java.net/browse/CODETOOLS-7902812): Fields can still be default initialized if class has only static intializers


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to 90338a924513ff42c4392e54e733dacda8d7ed22


### Download
`$ git fetch https://git.openjdk.java.net/jcstress pull/5/head:pull/5`
`$ git checkout pull/5`
