### PR TITLE
CODETOOLS-7902827: JCStress: Start testing with JDK 17 EA

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 16-ea]
-        run-java: [8, 11, 16-ea]
+        build-java: [11, 16-ea, 17-ea]
+        run-java: [8, 11, 16-ea, 17-ea]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}


### PR DESCRIPTION
JDK mainline had switched development to JDK 17 EA, we should be adding that version to pipelines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902827](https://bugs.openjdk.java.net/browse/CODETOOLS-7902827): JCStress: Start testing with JDK 17 EA


### Download
`$ git fetch https://git.openjdk.java.net/jcstress pull/6/head:pull/6`
`$ git checkout pull/6`
