### PR TITLE
CODETOOLS-7902837: jcstress should support -XX:+StressCCP

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -145,6 +145,12 @@ public class VMSupport {
                 "-XX:+StressIGVN"
         );
 
+        detect("Unlocking C2 conditional constant propagation randomizer",
+                SimpleTestMain.class,
+                STRESS_C2_JVM_FLAGS,
+                "-XX:+StressCCP"
+        );
+
         detect("Testing allocation profiling",
                 AllocProfileMain.class,
                 null


### PR DESCRIPTION
JDK-8256535 added -XX:+StressCCP, jcstress should use it, as it already uses Stress{LCM,GCM,IGVN}.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902837](https://bugs.openjdk.java.net/browse/CODETOOLS-7902837): jcstress should support -XX:+StressCCP


### Download
`$ git fetch https://git.openjdk.java.net/jcstress pull/7/head:pull/7`
`$ git checkout pull/7`
