### PR TITLE
CODETOOLS-7902842: jcstress: fix numeric promotions

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -61,7 +61,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private final long printIntervalMs;
     private long lastPrint;
 
-    private boolean progressInteractive;
+    private final boolean progressInteractive;
     private int progressLen;
 
     private long passed;
@@ -69,7 +69,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private long softErrors;
     private long hardErrors;
 
-    public ConsoleReportPrinter(Options opts, PrintWriter pw, int expectedTests, int expectedForks) {
+    public ConsoleReportPrinter(Options opts, PrintWriter pw, long expectedTests, long expectedForks) {
         this.output = pw;
         this.expectedTests = expectedTests;
         this.expectedForks = expectedForks;

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/Phase.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/Phase.java
@@ -46,7 +46,13 @@ class Phase {
         this.count = count;
         this.vars = vars;
         this.threads = threads;
-        this.cases = (long) Math.pow(vars * threads * TYPES, count);
+
+        // Long-accurate Math.pow
+        long cases = 1L;
+        for (int c = 0; c < count; c++) {
+            cases *= vars * threads * TYPES;
+        }
+        this.cases = cases;
     }
 
     public List<MultiThread> run() {

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
@@ -51,8 +51,8 @@ public class UnsafeIntAtomicityTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
-    public static final int ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-    public static final int ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+    public static final long ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
+    public static final long ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
     /** Alignment constraint: 4-bytes is default, for integers */

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
@@ -51,8 +51,8 @@ public class UnsafeIntTearingTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
-    public static final int ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-    public static final int ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+    public static final long ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
+    public static final long ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
     /** Alignment constraint: 4-bytes is default, for integers */


### PR DESCRIPTION
SonarCloud instance reports multiple places where numeric promotions are problematic. We need to fix these.