### PR TITLE
CODETOOLS-7902848: jcstress: remove VM batching support

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -80,7 +80,7 @@ public class JCStress {
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
-        TestExecutor executor = new TestExecutor(opts.getCPUCount(), opts.getBatchSize(), sink, true);
+        TestExecutor executor = new TestExecutor(opts.getCPUCount(), sink, true);
         executor.runAll(configs);
 
         sink.close();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -67,7 +67,6 @@ public class Options {
     private DeoptMode deoptMode;
     private Collection<String> jvmArgs;
     private Collection<String> jvmArgsPrepend;
-    private int batchSize;
 
     public Options(String[] args) {
         this.args = args;
@@ -111,10 +110,6 @@ public class Options {
         OptionSpec<Integer> maxFootprint = parser.accepts("mf", "Maximum footprint for each test, in megabytes. This " +
                 "affects the stride size: maximum footprint will never be exceeded, regardless of min/max stride sizes.")
                 .withRequiredArg().ofType(Integer.class).describedAs("MB");
-
-        OptionSpec<Integer> batchSize = parser.accepts("bs", "Maximum number of tests to execute in a single VM. Larger " +
-                "values will improve test performance, at expense of testing accuracy")
-                .withRequiredArg().ofType(Integer.class).describedAs("#");
 
         OptionSpec<SpinLoopStyle> spinStyle = parser.accepts("spinStyle", "Busy loop wait style. " +
                 "HARD = hard busy loop; THREAD_YIELD = use Thread.yield(); THREAD_SPIN_WAIT = use Thread.onSpinWait(); LOCKSUPPORT_PARK_NANOS = use LockSupport.parkNanos().")
@@ -193,7 +188,6 @@ public class Options {
             this.time = 0;
             this.iters = 1;
             this.forks = 1;
-            this.batchSize = 500;
             this.minStride = 10;
             this.maxStride = 10;
             this.deoptMode = DeoptMode.NONE;
@@ -202,25 +196,21 @@ public class Options {
             this.time = 200;
             this.iters = 5;
             this.forks = 1;
-            this.batchSize = 20;
         } else
         if (this.mode.equalsIgnoreCase("default")) {
             this.time = 1000;
             this.iters = 5;
             this.forks = 1;
-            this.batchSize = 5;
         } else
         if (this.mode.equalsIgnoreCase("tough")) {
             this.time = 1000;
             this.iters = 10;
             this.forks = 10;
-            this.batchSize = 5;
         } else
         if (this.mode.equalsIgnoreCase("stress")) {
             this.time = 1000;
             this.iters = 50;
             this.forks = 10;
-            this.batchSize = 1;
         } else {
             System.err.println("Unknown test mode: " + this.mode);
             System.err.println();
@@ -232,7 +222,6 @@ public class Options {
         this.time = orDefault(set.valueOf(time), this.time);
         this.iters = orDefault(set.valueOf(iters), this.iters);
         this.forks = orDefault(set.valueOf(forks), this.forks);
-        this.batchSize = orDefault(set.valueOf(batchSize), this.batchSize);
         this.deoptMode = orDefault(set.valueOf(deoptMode), DeoptMode.ALL);
 
         this.minStride = orDefault(set.valueOf(minStride), 10);
@@ -276,7 +265,6 @@ public class Options {
         out.printf("  Writing the test results to \"%s\"%n", resultFile);
         out.printf("  Parsing results to \"%s\"%n", resultDir);
         out.printf("  Running each test matching \"%s\" for %d forks, %d iterations, %d ms each%n", getTestFilter(), getForks(), getIterations(), getTime());
-        out.printf("  Each JVM would execute at most %d tests in the row.%n", getBatchSize());
         out.printf("  Solo stride size will be autobalanced within [%d, %d] elements, but taking no more than %d Mb.%n", getMinStride(), getMaxStride(), getMaxFootprintMb());
 
         out.println();
@@ -367,7 +355,4 @@ public class Options {
         return maxFootprint;
     }
 
-    public int getBatchSize() {
-        return batchSize;
-    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -187,7 +187,7 @@ public class Options {
         if (this.mode.equalsIgnoreCase("sanity")) {
             this.time = 0;
             this.iters = 1;
-            this.forks = 1;
+            this.forks = 0;
             this.minStride = 10;
             this.maxStride = 10;
             this.deoptMode = DeoptMode.NONE;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -185,7 +185,7 @@ public class Options {
 
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {
-            this.time = 50;
+            this.time = 10;
             this.iters = 1;
             this.forks = 0;
             this.minStride = 10;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -185,7 +185,7 @@ public class Options {
 
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {
-            this.time = 0;
+            this.time = 50;
             this.iters = 1;
             this.forks = 0;
             this.minStride = 10;


### PR DESCRIPTION
jcstress allows running multiple test per VM in order to optimize run times. Unfortunately, this feature gets in the way for reproducibility (multiple test contaminate the VM), error reporting (runner has to guess which test failed), and new features (like controlling the compilers). Thus, it is should go.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902848](https://bugs.openjdk.java.net/browse/CODETOOLS-7902848): jcstress: remove VM batching support


### Download
`$ git fetch https://git.openjdk.java.net/jcstress pull/10/head:pull/10`
`$ git checkout pull/10`
