### PR TITLE
CODETOOLS-7902850: jcstress: Rework internal interfaces to get one TestResult per VM invocation

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/EmbeddedExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/EmbeddedExecutor.java
@@ -82,11 +82,11 @@ public class EmbeddedExecutor {
                 Runner<?> o = (Runner<?>) cnstr.newInstance(config, sink, pool);
                 o.run();
             } catch (ClassFormatError | NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
-                TestResult result = new TestResult(config, Status.API_MISMATCH, 0);
+                TestResult result = new TestResult(config, Status.API_MISMATCH);
                 result.addAuxData(StringUtils.getStacktrace(e));
                 sink.add(result);
             } catch (Throwable ex) {
-                TestResult result = new TestResult(config, Status.TEST_ERROR, 0);
+                TestResult result = new TestResult(config, Status.TEST_ERROR);
                 result.addAuxData(StringUtils.getStacktrace(ex));
                 sink.add(result);
             } finally {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -131,7 +131,7 @@ public class TestExecutor {
                 if (!vm.checkTermination()) continue;
             } catch (ForkFailedException e) {
                 TestConfig task = vm.getTask();
-                TestResult result = new TestResult(task, Status.VM_ERROR, -1);
+                TestResult result = new TestResult(task, Status.VM_ERROR);
                 for (String i : e.getInfo()) {
                     result.addAuxData(i);
                 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -43,21 +43,15 @@ public class TestResult implements Serializable {
 
     private final TestConfig config;
     private final Status status;
-    private final int iterationId;
     private final Multiset<String> states;
     private volatile Environment env;
     private final List<String> auxData;
 
-    public TestResult(TestConfig config, Status status, int iterationId) {
+    public TestResult(TestConfig config, Status status) {
         this.config = config;
         this.status = status;
-        this.iterationId = iterationId;
         this.states = new HashMultiset<>();
         this.auxData = new ArrayList<>();
-    }
-
-    public int getIteration() {
-        return iterationId;
     }
 
     public void addState(String result, long count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -30,7 +30,6 @@ import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.util.StringUtils;
 
-import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -47,10 +46,10 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private final boolean verbose;
     private final PrintWriter output;
     private final long expectedTests;
-    private final long expectedIterations;
     private final long expectedForks;
+    private final long expectedResults;
 
-    private long observedIterations;
+    private long observedResults;
     private long observedCount;
 
     private final Set<String> observedTests = Collections.newSetFromMap(new HashMap<>());
@@ -73,7 +72,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         this.output = pw;
         this.expectedTests = expectedTests;
         this.expectedForks = expectedForks;
-        this.expectedIterations = expectedForks * (opts.getIterations() + 1); // +1 sanity check iteration #0
+        this.expectedResults = expectedForks;
         verbose = opts.isVerbose();
         progressLen = 1;
 
@@ -96,7 +95,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
         observedTests.add(r.getName());
         observedForks.add(new ConfigFork(r.getConfig()));
-        observedIterations++;
+        observedResults++;
         observedCount += r.getTotalCount();
 
         printResult(r);
@@ -154,12 +153,12 @@ public class ConsoleReportPrinter implements TestResultCollector {
         }
 
         if (shouldPrintStatusLine) {
-            String line = String.format("(ETA: %10s) (Sample Rate: %s) (Tests: %d of %d) (Forks: %2d of %d) (Iterations: %2d of %d; %d passed, %d failed, %d soft errs, %d hard errs) ",
+            String line = String.format("(ETA: %10s) (Sample Rate: %s) (Tests: %d of %d) (Forks: %2d of %d) (Results: %2d of %d; %d passed, %d failed, %d soft errs, %d hard errs) ",
                     computeETA(),
                     computeSpeed(),
                     observedTests.size(), expectedTests,
                     observedForks.size(), expectedForks,
-                    observedIterations, expectedIterations, passed, failed, softErrors, hardErrors
+                    observedResults, expectedResults, passed, failed, softErrors, hardErrors
             );
             progressLen = line.length();
             output.print(line);
@@ -201,12 +200,12 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
     private String computeETA() {
         long timeSpent = System.nanoTime() - firstTest;
-        long resultsGot = observedIterations;
+        long resultsGot = observedResults;
         if (resultsGot == 0) {
             return "n/a";
         }
 
-        long nsToGo = (long)(timeSpent * (1.0 * (expectedIterations - 1) / resultsGot - 1));
+        long nsToGo = (long)(timeSpent * (1.0 * (expectedResults - 1) / resultsGot - 1));
         if (nsToGo > 0) {
             String result = "";
             long days = TimeUnit.NANOSECONDS.toDays(nsToGo);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -94,7 +94,7 @@ public class ReportUtils {
             auxData.addAll(r.getAuxData());
         }
 
-        TestResult root = new TestResult(config, status, 0);
+        TestResult root = new TestResult(config, status);
 
         for (String s : stateCounts.keys()) {
             root.addState(s, stateCounts.count(s));
@@ -110,9 +110,8 @@ public class ReportUtils {
 
     public static void printDetails(PrintWriter pw, TestResult r, boolean inProgress) {
         if (inProgress) {
-            pw.format("    (fork: #%d, iteration #%d, JVM args: %s)%n",
+            pw.format("    (fork: #%d, JVM args: %s)%n",
                     r.getConfig().forkId + 1,
-                    r.getIteration(),
                     r.getConfig().jvmArgs
             );
         } else {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -767,12 +767,11 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println();
         pw.println("            if (results.count(Outcome.STALE) > 0) {");
         pw.println("                messages.add(\"Have stale threads, forcing VM to exit for proper cleanup.\");");
-        pw.println("                dump(c, results);");
+        pw.println("                dump(results);");
         pw.println("                System.exit(0);");
-        pw.println("            } else {");
-        pw.println("                dump(c, results);");
         pw.println("            }");
         pw.println("        }");
+        pw.println("        dump(results);");
         pw.println("    }");
         pw.println();
         pw.println("    @Override");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -69,13 +69,16 @@ public abstract class Runner<R> {
      * This method blocks until test is complete
      */
     public void run() {
+        @SuppressWarnings("unchecked")
+        Counter<R>[] results = (Counter<R>[]) new Counter[config.iters + 1];
+
         try {
-            dump(0, sanityCheck());
+            results[0] = sanityCheck();
         } catch (ClassFormatError | NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
-            dumpFailure(0, Status.API_MISMATCH, "Test sanity check failed, skipping", e);
+            dumpFailure(Status.API_MISMATCH, "Test sanity check failed, skipping", e);
             return;
         } catch (Throwable e) {
-            dumpFailure(0, Status.CHECK_TEST_ERROR, "Check test failed", e);
+            dumpFailure(Status.CHECK_TEST_ERROR, "Check test failed", e);
             return;
         }
 
@@ -86,12 +89,13 @@ public abstract class Runner<R> {
         }
 
         for (int c = 1; c <= config.iters; c++) {
-            dump(c, internalRun());
+            results[c] = internalRun();
         }
+        dump(results);
     }
 
-    private TestResult prepareResult(int iteration, Status status) {
-        TestResult result = new TestResult(config, status, iteration);
+    private TestResult prepareResult(Status status) {
+        TestResult result = new TestResult(config, status);
         for (String msg : messages) {
             result.addAuxData(msg);
         }
@@ -99,23 +103,25 @@ public abstract class Runner<R> {
         return result;
     }
 
-    protected void dumpFailure(int iteration, Status status, String message) {
+    protected void dumpFailure(Status status, String message) {
         messages.add(message);
-        TestResult result = prepareResult(iteration, status);
+        TestResult result = prepareResult(status);
         collector.add(result);
     }
 
-    protected void dumpFailure(int iteration, Status status, String message, Throwable aux) {
+    protected void dumpFailure(Status status, String message, Throwable aux) {
         messages.add(message);
-        TestResult result = prepareResult(iteration, status);
+        TestResult result = prepareResult(status);
         result.addAuxData(StringUtils.getStacktrace(aux));
         collector.add(result);
     }
 
-    protected void dump(int iteration, Counter<R> results) {
-        TestResult result = prepareResult(iteration, Status.NORMAL);
-        for (R e : results.elementSet()) {
-            result.addState(String.valueOf(e), results.count(e));
+    protected void dump(Counter<R>[] results) {
+        TestResult result = prepareResult(Status.NORMAL);
+        for (Counter<R> cnt : results) {
+            for (R e : cnt.elementSet()) {
+                result.addState(String.valueOf(e), cnt.count(e));
+            }
         }
         collector.add(result);
     }
@@ -135,7 +141,7 @@ public abstract class Runner<R> {
                 } catch (TimeoutException e) {
                     allStopped = false;
                 } catch (ExecutionException e) {
-                    dumpFailure(-1, Status.TEST_ERROR, "Unrecoverable error while running", e.getCause());
+                    dumpFailure(Status.TEST_ERROR, "Unrecoverable error while running", e.getCause());
                     return;
                 } catch (InterruptedException e) {
                     return;
@@ -144,7 +150,7 @@ public abstract class Runner<R> {
 
             long timeSpent = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
             if (timeSpent > Math.max(10*config.time, MIN_TIMEOUT_MS)) {
-                dumpFailure(-1, Status.TIMEOUT_ERROR, "Timeout waiting for tasks to complete: " + timeSpent + " ms");
+                dumpFailure(Status.TIMEOUT_ERROR, "Timeout waiting for tasks to complete: " + timeSpent + " ms");
                 return;
             }
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -116,6 +116,14 @@ public abstract class Runner<R> {
         collector.add(result);
     }
 
+    protected void dump(Counter<R> cnt) {
+        TestResult result = prepareResult(Status.NORMAL);
+        for (R e : cnt.elementSet()) {
+             result.addState(String.valueOf(e), cnt.count(e));
+        }
+        collector.add(result);
+    }
+
     protected void dump(Counter<R>[] results) {
         TestResult result = prepareResult(Status.NORMAL);
         for (Counter<R> cnt : results) {


### PR DESCRIPTION
Current jcstress code reports the TestResult for each iteration. While convenient to see the progress, it is ultimately noisy, and gets in the way of capturing the per-VM output. We can just accept a single test result per VM invocation, and rely on multiple forks to get verbose progress for long running tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902850](https://bugs.openjdk.java.net/browse/CODETOOLS-7902850): jcstress: Rework internal interfaces to get one TestResult per VM invocation


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/12/head:pull/12`
`$ git checkout pull/12`

To update a local copy of the PR:
`$ git checkout pull/12`
`$ git pull https://git.openjdk.java.net/jcstress pull/12/head`
