### PR TITLE
CODETOOLS-7902851: jcstress: Provide the ability to capture VM output

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/EmbeddedExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/EmbeddedExecutor.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 public class EmbeddedExecutor {
 
@@ -83,11 +82,11 @@ public class EmbeddedExecutor {
                 o.run();
             } catch (ClassFormatError | NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
                 TestResult result = new TestResult(config, Status.API_MISMATCH);
-                result.addAuxData(StringUtils.getStacktrace(e));
+                result.addMessage(StringUtils.getStacktrace(e));
                 sink.add(result);
             } catch (Throwable ex) {
                 TestResult result = new TestResult(config, Status.TEST_ERROR);
-                result.addAuxData(StringUtils.getStacktrace(ex));
+                result.addMessage(StringUtils.getStacktrace(ex));
                 sink.add(result);
             } finally {
                 if (acquiredCPUs != null) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -45,21 +45,41 @@ public class TestResult implements Serializable {
     private final Status status;
     private final Multiset<String> states;
     private volatile Environment env;
-    private final List<String> auxData;
+    private final List<String> messages;
+    private final List<String> vmOut;
+    private final List<String> vmErr;
 
     public TestResult(TestConfig config, Status status) {
         this.config = config;
         this.status = status;
         this.states = new HashMultiset<>();
-        this.auxData = new ArrayList<>();
+        this.messages = new ArrayList<>();
+        this.vmOut = new ArrayList<>();
+        this.vmErr = new ArrayList<>();
     }
 
     public void addState(String result, long count) {
         states.add(result, count);
     }
 
-    public void addAuxData(String data) {
-        auxData.add(data);
+    public void addMessage(String msg) {
+        messages.add(msg);
+    }
+
+    public void addVMOut(String msg) {
+        vmOut.add(msg);
+    }
+
+    public void addVMOut(Collection<String> msg) {
+        vmOut.addAll(msg);
+    }
+
+    public void addVMErr(String msg) {
+        vmErr.add(msg);
+    }
+
+    public void addVMErr(Collection<String> msg) {
+        vmErr.addAll(msg);
     }
 
     public void setEnv(Environment e) {
@@ -78,8 +98,16 @@ public class TestResult implements Serializable {
         return status;
     }
 
-    public List<String> getAuxData() {
-        return auxData;
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public List<String> getVmOut() {
+        return vmOut;
+    }
+
+    public List<String> getVmErr() {
+        return vmErr;
     }
 
     public long getTotalCount() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -427,10 +427,10 @@ public class HTMLReportPrinter {
         o.println("<h3>Auxiliary data</h3>");
 
         for (TestResult r : sorted) {
-            if (!r.getAuxData().isEmpty()) {
+            if (!r.getMessages().isEmpty()) {
                 o.println("<p><b>" + r.getConfig() + "</b></p>");
                 o.println("<pre>");
-                for (String data : r.getAuxData()) {
+                for (String data : r.getMessages()) {
                     o.println(data);
                 }
                 o.println("</pre>");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -97,7 +97,7 @@ public abstract class Runner<R> {
     private TestResult prepareResult(Status status) {
         TestResult result = new TestResult(config, status);
         for (String msg : messages) {
-            result.addAuxData(msg);
+            result.addMessage(msg);
         }
         messages.clear();
         return result;
@@ -112,7 +112,7 @@ public abstract class Runner<R> {
     protected void dumpFailure(Status status, String message, Throwable aux) {
         messages.add(message);
         TestResult result = prepareResult(status);
-        result.addAuxData(StringUtils.getStacktrace(aux));
+        result.addMessage(StringUtils.getStacktrace(aux));
         collector.add(result);
     }
 

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
@@ -55,7 +55,7 @@ public class EmbeddedExecutorTest {
         TestResult testResult = sink.getTestResults().iterator().next();
         Assert.assertEquals("Should report a test error", Status.TEST_ERROR, testResult.status());
 
-        String errorMessage = testResult.getAuxData().get(0);
+        String errorMessage = testResult.getMessages().get(0);
         Assert.assertEquals("Should report the test error reason", "java.lang.ClassNotFoundException: my.missing.ClassName",
                 getFirstLine(errorMessage));
     }


### PR DESCRIPTION
In order to get PrintAssembly and other diagnostics from the forked VM, it would be instrumental for jcstress harness to capture the output from the forked VMs.

Example:

```
      [OK] o.o.j.t.fences.UnfencedDekkerTest
    (fork: #1, JVM args: [-Xlog:gc])
  Observed state   Occurrences              Expectation  Interpretation                                              
            0, 0       501,152   ACCEPTABLE_INTERESTING  Acceptable with no sequential consistency enforced          
            0, 1   137,897,148               ACCEPTABLE  Acceptable under sequential consistency                     
            1, 0   134,406,572               ACCEPTABLE  Acceptable under sequential consistency                     
            1, 1           229               ACCEPTABLE  Acceptable under sequential consistency                     

    VM output stream: 
        [0.003s][info][gc] Using G1
        [0.231s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 100M->9M(2012M) 19.354ms
        [2.351s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 106M->2M(2012M) 2.302ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902851](https://bugs.openjdk.java.net/browse/CODETOOLS-7902851): jcstress: Provide the ability to capture VM output


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/13/head:pull/13`
`$ git checkout pull/13`

To update a local copy of the PR:
`$ git checkout pull/13`
`$ git pull https://git.openjdk.java.net/jcstress pull/13/head`
