### PR TITLE
CODETOOLS-7902854: jcstress: Print generated code assembly (optionally)

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -80,7 +80,7 @@ public class JCStress {
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
-        TestExecutor executor = new TestExecutor(opts.getCPUCount(), opts.verboseLevel(), sink, true);
+        TestExecutor executor = new TestExecutor(opts.getCPUCount(), opts.verbosity(), sink, true);
         executor.runAll(configs);
 
         sink.close();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -80,7 +80,7 @@ public class JCStress {
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
-        TestExecutor executor = new TestExecutor(opts.getCPUCount(), sink, true);
+        TestExecutor executor = new TestExecutor(opts.getCPUCount(), opts.verboseLevel(), sink, true);
         executor.runAll(configs);
 
         sink.close();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -57,7 +57,7 @@ public class Options {
     private final String[] args;
     private boolean parse;
     private boolean list;
-    private int verboseLevel;
+    private Verbosity verbosity;
     private int totalCpuCount;
     private int cpuCount;
     private int forks;
@@ -172,13 +172,13 @@ public class Options {
         }
         this.list = orDefault(set.has(list), false);
         if (set.has("vvv")) {
-            this.verboseLevel = 3;
+            this.verbosity = new Verbosity(3);
         } else if (set.has("vv")) {
-            this.verboseLevel = 2;
+            this.verbosity = new Verbosity(2);
         } else if (set.has("v")) {
-            this.verboseLevel = 1;
+            this.verbosity = new Verbosity(1);
         } else {
-            this.verboseLevel = 0;
+            this.verbosity = new Verbosity(0);
         }
 
         totalCpuCount = VMSupport.figureOutHotCPUs();
@@ -337,8 +337,8 @@ public class Options {
         return iters;
     }
 
-    public int verboseLevel() {
-        return verboseLevel;
+    public Verbosity verbosity() {
+        return verbosity;
     }
 
     public int getCPUCount() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -57,7 +57,7 @@ public class Options {
     private final String[] args;
     private boolean parse;
     private boolean list;
-    private boolean verbose;
+    private int verboseLevel;
     private int totalCpuCount;
     private int cpuCount;
     private int forks;
@@ -136,7 +136,9 @@ public class Options {
                 "This option only affects forked runs.")
                 .withRequiredArg().ofType(String.class).describedAs("string");
 
-        parser.accepts("v", "Be extra verbose.");
+        parser.accepts("v", "Be verbose.");
+        parser.accepts("vv", "Be extra verbose.");
+        parser.accepts("vvv", "Be extra extra verbose.");
         parser.accepts("h", "Print this help.");
 
         OptionSet set;
@@ -169,7 +171,15 @@ public class Options {
             this.resultFile = "jcstress-results-" + timestamp + ".bin.gz";
         }
         this.list = orDefault(set.has(list), false);
-        this.verbose = orDefault(set.has("v"), false);
+        if (set.has("vvv")) {
+            this.verboseLevel = 3;
+        } else if (set.has("vv")) {
+            this.verboseLevel = 2;
+        } else if (set.has("v")) {
+            this.verboseLevel = 1;
+        } else {
+            this.verboseLevel = 0;
+        }
 
         totalCpuCount = VMSupport.figureOutHotCPUs();
         cpuCount = orDefault(set.valueOf(cpus), totalCpuCount);
@@ -327,8 +337,8 @@ public class Options {
         return iters;
     }
 
-    public boolean isVerbose() {
-        return verbose;
+    public int verboseLevel() {
+        return verboseLevel;
     }
 
     public int getCPUCount() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -59,16 +59,16 @@ public class TestExecutor {
 
     private final BinaryLinkServer server;
     private final int maxThreads;
-    private final int verboseLevel;
+    private final Verbosity verbosity;
     private final TestResultCollector sink;
     private final EmbeddedExecutor embeddedExecutor;
     private final CPULayout cpuLayout;
 
     private final Map<String, VM> vmByToken;
 
-    public TestExecutor(int maxThreads, int verboseLevel, TestResultCollector sink, boolean possiblyForked) throws IOException {
+    public TestExecutor(int maxThreads, Verbosity verbosity, TestResultCollector sink, boolean possiblyForked) throws IOException {
         this.maxThreads = maxThreads;
-        this.verboseLevel = verboseLevel;
+        this.verbosity = verbosity;
         this.sink = sink;
         this.vmByToken = new ConcurrentHashMap<>();
 
@@ -205,7 +205,7 @@ public class TestExecutor {
                     pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + an + "\",");
                     pw.println("    inline: \"+" + task.name + "::" + an + "\",");
                     pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
-                    if (VMSupport.printAssemblyAvailable() && verboseLevel >= 2) {
+                    if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly()) {
                         pw.println("    PrintAssembly: true,");
                     }
                     pw.println("  },");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -59,14 +59,16 @@ public class TestExecutor {
 
     private final BinaryLinkServer server;
     private final int maxThreads;
+    private final int verboseLevel;
     private final TestResultCollector sink;
     private final EmbeddedExecutor embeddedExecutor;
     private final CPULayout cpuLayout;
 
     private final Map<String, VM> vmByToken;
 
-    public TestExecutor(int maxThreads, TestResultCollector sink, boolean possiblyForked) throws IOException {
+    public TestExecutor(int maxThreads, int verboseLevel, TestResultCollector sink, boolean possiblyForked) throws IOException {
         this.maxThreads = maxThreads;
+        this.verboseLevel = verboseLevel;
         this.sink = sink;
         this.vmByToken = new ConcurrentHashMap<>();
 
@@ -134,7 +136,7 @@ public class TestExecutor {
         }
     }
 
-    private static class VM {
+    private class VM {
         private final String host;
         private final int port;
         private final String token;
@@ -203,6 +205,9 @@ public class TestExecutor {
                     pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + an + "\",");
                     pw.println("    inline: \"+" + task.name + "::" + an + "\",");
                     pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
+                    if (VMSupport.printAssemblyAvailable() && verboseLevel >= 2) {
+                        pw.println("    PrintAssembly: true,");
+                    }
                     pw.println("  },");
                 }
                 pw.println("]");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Verbosity.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Verbosity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress;
+
+public class Verbosity {
+
+    private final int level;
+
+    public Verbosity(int level) {
+        this.level = level;
+    }
+
+    public boolean printAllTests() {
+        return level >= 1;
+    }
+
+    public boolean printAssembly() {
+        return level >= 2;
+    }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -43,7 +43,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
     private static final Integer PRINT_INTERVAL_MS = Integer.getInteger("jcstress.console.printIntervalMs");
 
-    private final boolean verbose;
+    private final int verboseLevel;
     private final PrintWriter output;
     private final long expectedTests;
     private final long expectedForks;
@@ -73,7 +73,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         this.expectedTests = expectedTests;
         this.expectedForks = expectedForks;
         this.expectedResults = expectedForks;
-        verbose = opts.isVerbose();
+        verboseLevel = opts.verboseLevel();
         progressLen = 1;
 
         progressInteractive = (System.console() != null);
@@ -131,7 +131,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
                 inHardError ||
                 !grading.isPassed ||
                 grading.hasInteresting ||
-                verbose;
+                verboseLevel >= 1;
 
         long currentTime = System.nanoTime();
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.infra.grading;
 
 import org.openjdk.jcstress.Options;
+import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.infra.runners.TestConfig;
@@ -43,7 +44,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
     private static final Integer PRINT_INTERVAL_MS = Integer.getInteger("jcstress.console.printIntervalMs");
 
-    private final int verboseLevel;
+    private final Verbosity verbosity;
     private final PrintWriter output;
     private final long expectedTests;
     private final long expectedForks;
@@ -73,7 +74,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         this.expectedTests = expectedTests;
         this.expectedForks = expectedForks;
         this.expectedResults = expectedForks;
-        verboseLevel = opts.verboseLevel();
+        verbosity = opts.verbosity();
         progressLen = 1;
 
         progressInteractive = (System.console() != null);
@@ -131,7 +132,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
                 inHardError ||
                 !grading.isPassed ||
                 grading.hasInteresting ||
-                verboseLevel >= 1;
+                verbosity.printAllTests();
 
         long currentTime = System.nanoTime();
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -26,6 +26,7 @@ package org.openjdk.jcstress.infra.grading;
 
 
 import org.openjdk.jcstress.Options;
+import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.InProcessCollector;
 import org.openjdk.jcstress.infra.collectors.TestResult;
@@ -44,14 +45,14 @@ import java.util.function.Predicate;
 public class TextReportPrinter {
 
     private final InProcessCollector collector;
-    private final int verboseLevel;
+    private final Verbosity verbosity;
     private final PrintWriter pw;
     private final Set<TestResult> emittedTests;
 
     public TextReportPrinter(Options opts, InProcessCollector collector) throws FileNotFoundException {
         this.collector = collector;
         this.pw = new PrintWriter(System.out, true);
-        this.verboseLevel = opts.verboseLevel();
+        this.verbosity = opts.verbosity();
         this.emittedTests = new HashSet<>();
     }
 
@@ -92,7 +93,7 @@ public class TextReportPrinter {
                 "All remaining tests",
                 "Tests that do not fall into any of the previous categories.",
                 r -> !emittedTests.contains(r),
-                verboseLevel >= 1);
+                verbosity.printAllTests());
 
         pw.println("------------------------------------------------------------------------------------------------------------------------");
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -44,14 +44,14 @@ import java.util.function.Predicate;
 public class TextReportPrinter {
 
     private final InProcessCollector collector;
-    private final boolean verbose;
+    private final int verboseLevel;
     private final PrintWriter pw;
     private final Set<TestResult> emittedTests;
 
     public TextReportPrinter(Options opts, InProcessCollector collector) throws FileNotFoundException {
         this.collector = collector;
         this.pw = new PrintWriter(System.out, true);
-        this.verbose = opts.isVerbose();
+        this.verboseLevel = opts.verboseLevel();
         this.emittedTests = new HashSet<>();
     }
 
@@ -92,7 +92,7 @@ public class TextReportPrinter {
                 "All remaining tests",
                 "Tests that do not fall into any of the previous categories.",
                 r -> !emittedTests.contains(r),
-                verbose);
+                verboseLevel >= 1);
 
         pw.println("------------------------------------------------------------------------------------------------------------------------");
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -37,7 +37,6 @@ import java.util.function.Consumer;
 public class TestConfig implements Serializable {
 
     public final SpinLoopStyle spinLoopStyle;
-    public final boolean verbose;
     public final int time;
     public final int iters;
     public final DeoptMode deoptMode;
@@ -73,7 +72,6 @@ public class TestConfig implements Serializable {
         maxStride = opts.getMaxStride();
         iters = opts.getIterations();
         spinLoopStyle = opts.getSpinStyle();
-        verbose = opts.isVerbose();
         deoptMode = opts.deoptMode();
         maxFootprintMB = opts.getMaxFootprintMb();
         threads = info.threads();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -47,6 +47,7 @@ public class VMSupport {
     private static final Collection<Collection<String>> AVAIL_JVM_MODES = new ArrayList<>();
     private static volatile boolean THREAD_SPIN_WAIT_AVAILABLE;
     private static volatile boolean COMPILER_DIRECTIVES_AVAILABLE;
+    private static volatile boolean PRINT_ASSEMBLY_AVAILABLE;
 
     public static boolean spinWaitHintAvailable() {
         return THREAD_SPIN_WAIT_AVAILABLE;
@@ -54,6 +55,10 @@ public class VMSupport {
 
     public static boolean compilerDirectivesAvailable() {
         return COMPILER_DIRECTIVES_AVAILABLE;
+    }
+
+    public static boolean printAssemblyAvailable() {
+        return PRINT_ASSEMBLY_AVAILABLE;
     }
 
     public static void initFlags(Options opts) {
@@ -88,7 +93,7 @@ public class VMSupport {
         detect("Trimming down the number of compiler threads",
                 SimpleTestMain.class,
                 GLOBAL_JVM_FLAGS,
-                "-XX:CICompilerCount=4"
+                "-XX:CICompilerCount=2" // This is the absolute minimum for tiered configurations
         );
 
         detect("Trimming down the number of parallel GC threads",
@@ -166,6 +171,13 @@ public class VMSupport {
                 detect("Testing Thread.onSpinWait",
                         ThreadSpinWaitTestMain.class,
                         null
+                );
+
+        PRINT_ASSEMBLY_AVAILABLE =
+                detect("Testing PrintAssembly",
+                        SimpleTestMain.class,
+                        null,
+                        "-XX:+PrintAssembly"
                 );
 
         try {


### PR DESCRIPTION
Following up on test failures is hard without the generated code. Doing -XX:+PrintAssembly would print the generated code for everything, which would be unnecessarily noisy. Luckily, we can now instruct jcstress to dump the generated code for the hot loops only.

Sample output:

```
$ java -jar tests-custom/target/jcstress.jar -t UnfencedDekker -vv --jvmArgs "-XX:-TieredCompilation"
Java Concurrency Stress Tests
---------------------------------------------------------------------------------
Rev: 728c24c414d9b9c2, built by shade with 11.0.12-testing at 2021-03-18T15:36:51Z

Burning up to figure out the exact CPU count....... done!

Probing the target OS:
 (all failures are non-fatal, but may affect testing accuracy)

----- [OK] Trying to set affinity with taskset

Initializing and probing the target VM: 
 (all failures are non-fatal, but may affect testing accuracy)

----- [OK] Unlocking diagnostic VM options
----- [OK] Trimming down the default VM heap size to 1/64-th of max RAM
----- [OK] Trimming down the number of compiler threads
----- [OK] Trimming down the number of parallel GC threads
----- [OK] Trimming down the number of concurrent GC threads
----- [OK] Trimming down the number of G1 concurrent refinement GC threads
----- [OK] Testing @Contended works on all results and infra objects
----- [OK] Unlocking Whitebox API for online de-optimization: all methods
----- [OK] Unlocking Whitebox API for online de-optimization: selected methods
----- [OK] Unlocking C2 local code motion randomizer
----- [OK] Unlocking C2 global code motion randomizer
----- [OK] Unlocking C2 iterative global value numbering randomizer
----- [OK] Unlocking C2 conditional constant propagation randomizer
----- [OK] Testing allocation profiling
----- [OK] Testing Thread.onSpinWait
----- [OK] Testing PrintAssembly
----- [OK] Testing compiler directives

Probing what VM modes are available:
 (failures are non-fatal, but may miss some interesting cases)

----- [OK] [-XX:-TieredCompilation]

  Hardware CPUs in use: 64, using Thread.onSpinWait()
  Test preset mode: "default"
  Writing the test results to "jcstress-results-2021-03-18-16-37-38.bin.gz"
  Parsing results to "results/"
  Running each test matching "UnfencedDekker" for 1 forks, 5 iterations, 1000 ms each
  Solo stride size will be autobalanced within [10, 10000] elements, but taking no more than 100 Mb.

  Attached the non-interactive output stream.
  Printing the progress line at least every 15000 milliseconds.


      [OK] o.o.j.t.fences.UnfencedDekkerTest
    (fork: #1, JVM args: [-XX:-TieredCompilation])
  Observed state   Occurrences              Expectation  Interpretation                                              
            0, 0     8,376,544   ACCEPTABLE_INTERESTING  Acceptable with no sequential consistency enforced          
            0, 1   476,317,773               ACCEPTABLE  Acceptable under sequential consistency                     
            1, 0   218,828,395               ACCEPTABLE  Acceptable under sequential consistency                     
            1, 1           799               ACCEPTABLE  Acceptable under sequential consistency                     

    VM output stream: 
        
        ============================= C2-compiled nmethod ==============================
        ----------------------------------- Assembly -----------------------------------
        
        Compiled method (c2)     222  128 %           org.openjdk.jcstress.tests.fences.UnfencedDekkerTest_jcstress::run_actor1 @ 12 (55 bytes)
         total in heap  [0x00007f783863b110,0x00007f783863b7a8] = 1688
         relocation     [0x00007f783863b270,0x00007f783863b2a0] = 48
         main code      [0x00007f783863b2a0,0x00007f783863b5e0] = 832
         stub code      [0x00007f783863b5e0,0x00007f783863b5f8] = 24
         oops           [0x00007f783863b5f8,0x00007f783863b600] = 8
         metadata       [0x00007f783863b600,0x00007f783863b630] = 48
         scopes data    [0x00007f783863b630,0x00007f783863b6f8] = 200
         scopes pcs     [0x00007f783863b6f8,0x00007f783863b788] = 144
         dependencies   [0x00007f783863b788,0x00007f783863b790] = 8
         nul chk table  [0x00007f783863b790,0x00007f783863b7a8] = 24
        
        --------------------------------------------------------------------------------
        [Constant Pool (empty)]
        
        --------------------------------------------------------------------------------
        
        [Verified Entry Point]
          # {method} {0x00007f7825812658} 'run_actor1' '([Lorg/openjdk/jcstress/tests/fences/UnfencedDekkerTest;[Lorg/openjdk/jcstress/infra/results/II_Result;)V' in 'org/openjdk/jcstress/tests/fences/UnfencedDekkerTest_jcstress'
          0x00007f783863b2a0:   callq  0x00007f784a5a1120           ;   {runtime_call os::breakpoint()}
          0x00007f783863b2a5:   data16 data16 nopw 0x0(%rax,%rax,1)
          0x00007f783863b2b0:   mov    %eax,-0x14000(%rsp)
          0x00007f783863b2b7:   push   %rbp
          0x00007f783863b2b8:   sub    $0x40,%rsp
          0x00007f783863b2bc:   mov    0x40(%rsi),%r10
          0x00007f783863b2c0:   mov    %r10,(%rsp)
          0x00007f783863b2c4:   mov    0x28(%rsi),%rbp
  ...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902854](https://bugs.openjdk.java.net/browse/CODETOOLS-7902854): jcstress: Print generated code assembly (optionally)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/14/head:pull/14`
`$ git checkout pull/14`

To update a local copy of the PR:
`$ git checkout pull/14`
`$ git pull https://git.openjdk.java.net/jcstress pull/14/head`
