### PR TITLE
CODETOOLS-7902856: jcstress: Reconcile GC options

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -209,11 +209,6 @@ public class ReportUtils {
             return true;
         }
 
-        if (data.contains("Option MaxRAMFraction was deprecated in version") ||
-            data.contains("Option MinRAMFraction was deprecated in version")) {
-            return true;
-        }
-
         if (data.contains("compiler directives added")) {
             return true;
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -72,46 +72,38 @@ public class VMSupport {
                 "-XX:+UnlockDiagnosticVMOptions"
         );
 
-        // Rationale: every test VM uses at least 2 threads. Which means there are at max $CPU/2 VMs.
-        // Reserving half of the RSS of each VM to Java heap leaves enough space for native RSS and
-        // other processes. This means multiplying the factor by 2. These two adjustments cancel each
-        // other.
-        //
-        // It does not matter if user requested lower number of VMs, we still want to follow
-        // the global per-VM fraction. This would trim down the memory requirements along with
-        // CPU requirements.
-        //
-        // Setting -Xms/-Xmx explicitly is supposed to override these defaults.
-        //
-        int part = opts.getTotalCPUCount();
+        // Rationale for GC options: the tests are supposed to run in a very tight memory
+        // constraints.
 
-        detect("Trimming down the default VM heap size to 1/" + part + "-th of max RAM",
+        int part = 256;
+
+        detect("Trimming down the VM heap size to " + part + "M",
                 SimpleTestMain.class,
                 GLOBAL_JVM_FLAGS,
-                "-XX:MaxRAMFraction=" + part, "-XX:MinRAMFraction=" + part);
-
-        detect("Trimming down the number of compiler threads",
-                SimpleTestMain.class,
-                GLOBAL_JVM_FLAGS,
-                "-XX:CICompilerCount=2" // This is the absolute minimum for tiered configurations
-        );
+                "-Xms" + part + "M", "-Xmx" + part + "M");
 
         detect("Trimming down the number of parallel GC threads",
                 SimpleTestMain.class,
                 GLOBAL_JVM_FLAGS,
-                "-XX:ParallelGCThreads=4"
+                "-XX:ParallelGCThreads=2"
         );
 
         detect("Trimming down the number of concurrent GC threads",
                 SimpleTestMain.class,
                 GLOBAL_JVM_FLAGS,
-                "-XX:ConcGCThreads=4"
+                "-XX:ConcGCThreads=2"
         );
 
         detect("Trimming down the number of G1 concurrent refinement GC threads",
                 SimpleTestMain.class,
                 GLOBAL_JVM_FLAGS,
-                "-XX:G1ConcRefinementThreads=4"
+                "-XX:G1ConcRefinementThreads=2"
+        );
+
+        detect("Trimming down the number of compiler threads",
+                SimpleTestMain.class,
+                GLOBAL_JVM_FLAGS,
+                "-XX:CICompilerCount=2" // This is the absolute minimum for tiered configurations
         );
 
         detect("Testing @Contended works on all results and infra objects",


### PR DESCRIPTION
Current GC options are questionable: the heap size too probably too large to be practical on large machines, and 4 GC threads oversubscribes the system after VM is taskset-s 2 CPUs for 2-actor tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902856](https://bugs.openjdk.java.net/browse/CODETOOLS-7902856): jcstress: Reconcile GC options


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/15/head:pull/15`
`$ git checkout pull/15`

To update a local copy of the PR:
`$ git checkout pull/15`
`$ git pull https://git.openjdk.java.net/jcstress pull/15/head`
