### PR TITLE
CODETOOLS-7902857: jcstress: Support split compilation modes

### DIFF
--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -57,7 +57,7 @@ public class SampleTestBench {
         String runnerName = SampleTest_jcstress.class.getCanonicalName();
 
         TestInfo ti = new TestInfo(testName, runnerName, "", 2, Arrays.asList("a1", "a2"), false);
-        TestConfig cfg = new TestConfig(opts, ti, TestConfig.RunMode.EMBEDDED, 1, Collections.emptyList());
+        TestConfig cfg = new TestConfig(opts, ti, TestConfig.RunMode.EMBEDDED, 1, Collections.emptyList(), CompileMode.UNIFIED);
 
         pool = Executors.newCachedThreadPool();
 

--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -25,6 +25,7 @@
 
 package org.openjdk.jcstress;
 
+import org.openjdk.jcstress.vm.CompileMode;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/CompileMode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/CompileMode.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress;
+
+import java.util.List;
+
+public class CompileMode {
+
+    public static final int VARIANTS = 3;
+    public static final int UNIFIED = -1;
+
+    private final int mode;
+    private final List<String> actorNames;
+    private final int actors;
+
+    public CompileMode(int mode, List<String> actorNames, int actors) {
+        this.mode = mode;
+        this.actorNames = actorNames;
+        this.actors = actors;
+    }
+
+    public static int casesFor(int actors) {
+        int cases = 1;
+        for (int c = 0; c < actors; c++) {
+            cases *= VARIANTS;
+        }
+        return cases;
+    }
+
+    private int actorMode(int actor) {
+        int m = mode;
+        for (int a = 0; a < actor; a++) {
+            m /= VARIANTS;
+        }
+        return m % VARIANTS;
+    }
+
+    public boolean isInt(int actor) {
+        return (mode != UNIFIED) && (actorMode(actor) == 0);
+    }
+
+    public boolean isC1(int actor) {
+        return (mode != UNIFIED) && (actorMode(actor) == 1);
+    }
+
+    public boolean isC2(int actor) {
+        return (mode != UNIFIED) && (actorMode(actor) == 2);
+    }
+
+    public boolean hasC2() {
+        if (mode == UNIFIED) {
+            return true;
+        }
+        for (int a = 0; a < actors; a++) {
+            if (isC2(a)) return true;
+        }
+        return false;
+    }
+
+    private String actorModeToString(int actor) {
+        int v = actorMode(actor);
+        switch (v) {
+            case 0: return "Interpreter";
+            case 1: return "C1";
+            case 2: return "C2";
+            default:
+                throw new IllegalStateException("Unhandled variant: " + v);
+        }
+    }
+
+    public String toString() {
+        if (mode == UNIFIED) {
+            return "unified across all actors";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("split; ");
+        for (int a = 0; a < actors; a++) {
+            if (a != 0) {
+                sb.append(", ");
+            }
+            sb.append("\"");
+            sb.append(actorNames.get(a));
+            sb.append("\"");
+            sb.append(": ");
+            sb.append(actorModeToString(a));
+        }
+        return sb.toString();
+    }
+
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -37,10 +37,7 @@ import org.openjdk.jcstress.vm.VMSupport;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Options.
@@ -64,8 +61,9 @@ public class Options {
     private SpinLoopStyle spinStyle;
     private String resultFile;
     private DeoptMode deoptMode;
-    private Collection<String> jvmArgs;
-    private Collection<String> jvmArgsPrepend;
+    private List<String> jvmArgs;
+    private List<String> jvmArgsPrepend;
+    private boolean splitCompilation;
 
     public Options(String[] args) {
         this.args = args;
@@ -134,6 +132,9 @@ public class Options {
                 "Either a single space-separated option line, or multiple options are accepted. " +
                 "This option only affects forked runs.")
                 .withRequiredArg().ofType(String.class).describedAs("string");
+
+        OptionSpec<Boolean> optSplitCompilation = parser.accepts("sc", "Use split per-actor compilation mode, if available.")
+                .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         parser.accepts("v", "Be verbose.");
         parser.accepts("vv", "Be extra verbose.");
@@ -240,10 +241,12 @@ public class Options {
         this.jvmArgs = processArgs(optJvmArgs, set);
         this.jvmArgsPrepend = processArgs(optJvmArgsPrepend, set);
 
+        this.splitCompilation = orDefault(set.valueOf(optSplitCompilation), true);
+
         return true;
     }
 
-    private Collection<String> processArgs(OptionSpec<String> op, OptionSet set) {
+    private List<String> processArgs(OptionSpec<String> op, OptionSet set) {
         if (set.hasArgument(op)) {
             try {
                 List<String> vals = op.values(set);
@@ -256,7 +259,7 @@ public class Options {
                 return StringUtils.splitQuotedEscape(op.value(set));
             }
         } else {
-            return null;
+            return Collections.emptyList();
         }
     }
 
@@ -348,11 +351,11 @@ public class Options {
         return resultFile;
     }
 
-    public Collection<String> getJvmArgs() {
+    public List<String> getJvmArgs() {
         return jvmArgs;
     }
 
-    public Collection<String> getJvmArgsPrepend() {
+    public List<String> getJvmArgsPrepend() {
         return jvmArgsPrepend;
     }
 
@@ -365,4 +368,7 @@ public class Options {
         return getHeapPerForkMb() / 2;
     }
 
+    public boolean isSplitCompilation() {
+        return splitCompilation;
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -33,6 +33,7 @@ import org.openjdk.jcstress.infra.runners.WorkerSync;
 import org.openjdk.jcstress.link.BinaryLinkServer;
 import org.openjdk.jcstress.link.ServerListener;
 import org.openjdk.jcstress.vm.CPULayout;
+import org.openjdk.jcstress.vm.CompileMode;
 import org.openjdk.jcstress.vm.OSSupport;
 import org.openjdk.jcstress.util.StringUtils;
 import org.openjdk.jcstress.vm.VMSupport;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -174,48 +174,89 @@ public class TestExecutor {
             }
         }
 
-        void generateDirectives() {
-            try {
-                PrintWriter pw = new PrintWriter(compilerDirectives);
-                pw.println("[");
+        void generateDirectives() throws IOException {
+            PrintWriter pw = new PrintWriter(compilerDirectives);
+            pw.println("[");
 
-                // The task loop:
-                //   - avoid inlining the run loop, it should be compiled as hot code
-                //   - force inline the auxiliary methods and classes in the run loop
+            // The task loop:
+            pw.println("  {");
+            pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.TASK_LOOP_PREFIX + "*\",");
+
+            // Avoid inlining the run loop, it should be compiled as separate hot code
+            pw.println("    inline: \"-" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + "*\",");
+
+            // Force inline the auxiliary methods and classes in the run loop
+            pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
+            pw.println("    inline: \"+" + WorkerSync.class.getName() + "::*\",");
+            pw.println("    inline: \"+java.util.concurrent.atomic.*::*\",");
+            pw.println("  },");
+
+            // Force inline everything from WorkerSync. WorkerSync does not use anything
+            // too deeply, so inlining everything is fine.
+            pw.println("  {");
+            pw.println("    match: \"" + WorkerSync.class.getName() + "::*" + "\",");
+            pw.println("    inline: \"+*::*\",");
+            pw.println("  },");
+
+            // The run loops:
+            CompileMode cm = task.getCompileMode();
+            for (int a = 0; a < task.threads; a++) {
+                String an = task.actorNames.get(a);
+
                 pw.println("  {");
-                pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.TASK_LOOP_PREFIX + "*\",");
-                pw.println("    inline: \"-" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + "*\",");
+                pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + an + "\",");
                 pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
-                pw.println("    inline: \"+" + WorkerSync.class.getName() + "::*\",");
-                pw.println("    inline: \"+java.util.concurrent.atomic.*::*\",");
-                pw.println("  },");
 
-                // Force inline everything from WorkerSync. WorkerSync does not use anything
-                // too deeply, so inlining everything is fine.
-                pw.println("  {");
-                pw.println("    match: \"" + WorkerSync.class.getName() + "::*" + "\",");
-                pw.println("    inline: \"+*::*\",");
-                pw.println("  },");
-
-                // The run loop:
-                //   - force inline of the workload methods
-                //   - force inline of sink methods
-                for (String an : task.actorNames) {
-                    pw.println("  {");
-                    pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + an + "\",");
+                // Force inline of actor methods if run in compiled mode: this would inherit
+                // compiler for them. Forbid inlining of actor methods in interpreted mode:
+                // this would make sure that while actor methods are running in interpreter,
+                // the run loop still runs in compiled mode, running faster. The call to interpreted
+                // method would happen anyway, even though through c2i transition.
+                if (cm.isInt(a)) {
+                    pw.println("    inline: \"-" + task.name + "::" + an + "\",");
+                } else {
                     pw.println("    inline: \"+" + task.name + "::" + an + "\",");
-                    pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
-                    if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly()) {
-                        pw.println("    PrintAssembly: true,");
-                    }
+                }
+
+                // Run loop should be compiled with C2? Forbid C1 compilation then.
+                if (cm.isC2(a)) {
+                    pw.println("    c1: {");
+                    pw.println("      Exclude: true,");
+                    pw.println("    },");
+                }
+
+                // Run loop should be compiled with C1? Forbid C2 compilation then.
+                if (cm.isC1(a)) {
+                    pw.println("    c2: {");
+                    pw.println("      Exclude: true,");
+                    pw.println("    },");
+                }
+                if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly() && !cm.isInt(a)) {
+                    pw.println("    PrintAssembly: true,");
+                }
+                pw.println("  },");
+            }
+
+            for (int a = 0; a < task.threads; a++) {
+                String an = task.actorNames.get(a);
+
+                // If this actor runs in interpreted mode, then actor method should not be compiled.
+                // Allow run loop to be compiled with the best compiler available.
+                if (cm.isInt(a)) {
+                    pw.println("  {");
+                    pw.println("    match: \"+" + task.name + "::" + an + "\",");
+                    pw.println("    c1: {");
+                    pw.println("      Exclude: true,");
+                    pw.println("    },");
+                    pw.println("    c2: {");
+                    pw.println("      Exclude: true,");
+                    pw.println("    },");
                     pw.println("  },");
                 }
-                pw.println("]");
-                pw.flush();
-                pw.close();
-            } catch (FileNotFoundException e) {
-                throw new IllegalStateException(e);
             }
+            pw.println("]");
+            pw.flush();
+            pw.close();
         }
 
         void start() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -109,15 +109,10 @@ public class ReportUtils {
     }
 
     public static void printDetails(PrintWriter pw, TestResult r, boolean inProgress) {
+        pw.format("    (compilation: %s)%n", r.getConfig().getCompileMode());
+        pw.format("    (JVM args: %s)%n", r.getConfig().jvmArgs);
         if (inProgress) {
-            pw.format("    (fork: #%d, JVM args: %s)%n",
-                    r.getConfig().forkId + 1,
-                    r.getConfig().jvmArgs
-            );
-        } else {
-            pw.format("    (JVM args: %s)%n",
-                    r.getConfig().jvmArgs
-            );
+            pw.format("    (fork: #%d)%n", r.getConfig().forkId + 1);
         }
 
         if (!r.hasSamples()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
-import org.openjdk.jcstress.CompileMode;
+import org.openjdk.jcstress.vm.CompileMode;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.vm.AllocProfileSupport;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
+import org.openjdk.jcstress.CompileMode;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.vm.AllocProfileSupport;
@@ -48,6 +49,7 @@ public class TestConfig implements Serializable {
     public final int forkId;
     public final int maxFootprintMB;
     public final List<String> actorNames;
+    public final int compileMode;
     public int minStride;
     public int maxStride;
     public StrideCap strideCap;
@@ -63,7 +65,7 @@ public class TestConfig implements Serializable {
         TIME,
     }
 
-    public TestConfig(Options opts, TestInfo info, RunMode runMode, int forkId, List<String> jvmArgs) {
+    public TestConfig(Options opts, TestInfo info, RunMode runMode, int forkId, List<String> jvmArgs, int compileMode) {
         this.runMode = runMode;
         this.forkId = forkId;
         this.jvmArgs = jvmArgs;
@@ -78,6 +80,7 @@ public class TestConfig implements Serializable {
         name = info.name();
         generatedRunnerName = info.generatedRunner();
         actorNames = info.actorNames();
+        this.compileMode = compileMode;
         strideCap = StrideCap.NONE;
     }
 
@@ -135,6 +138,10 @@ public class TestConfig implements Serializable {
         return StrideCap.NONE;
     }
 
+    public CompileMode getCompileMode() {
+        return new CompileMode(compileMode, actorNames, threads);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -149,6 +156,7 @@ public class TestConfig implements Serializable {
         if (iters != that.iters) return false;
         if (deoptMode != that.deoptMode) return false;
         if (threads != that.threads) return false;
+        if (compileMode != that.compileMode) return false;
         if (!name.equals(that.name)) return false;
         if (!jvmArgs.equals(that.jvmArgs)) return false;
         return runMode == that.runMode;
@@ -164,6 +172,7 @@ public class TestConfig implements Serializable {
         result = 31 * result + iters;
         result = 31 * result + deoptMode.hashCode();
         result = 31 * result + threads;
+        result = 31 * result + compileMode;
         result = 31 * result + name.hashCode();
         result = 31 * result + jvmArgs.hashCode();
         result = 31 * result + runMode.hashCode();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -50,7 +50,7 @@ public class StringUtils {
         }
     }
 
-    public static Collection<String> splitQuotedEscape(String src) {
+    public static List<String> splitQuotedEscape(String src) {
         List<String> results = new ArrayList<>();
 
         StringBuilder sb = new StringBuilder();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.jcstress;
+package org.openjdk.jcstress.vm;
 
 import java.util.List;
 
@@ -109,6 +109,5 @@ public class CompileMode {
         }
         return sb.toString();
     }
-
 
 }

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/CompileModeTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/CompileModeTest.java
@@ -2,6 +2,7 @@ package org.openjdk.jcstress;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openjdk.jcstress.vm.CompileMode;
 
 import java.util.Arrays;
 

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/CompileModeTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/CompileModeTest.java
@@ -1,0 +1,133 @@
+package org.openjdk.jcstress;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class CompileModeTest {
+
+    @Test
+    public void unified() {
+        CompileMode cm = new CompileMode(CompileMode.UNIFIED, Arrays.asList("actor1", "actor2"), 2);
+
+        for (int a = 0; a < 2; a++) {
+            Assert.assertTrue(!cm.isInt(a));
+            Assert.assertTrue(!cm.isC1(a));
+            Assert.assertTrue(!cm.isC2(a));
+        }
+
+        Assert.assertTrue(cm.hasC2());
+    }
+
+    @Test
+    public void splitComplete_1() {
+        int cases = CompileMode.casesFor(1);
+
+        CompileMode[] modes = new CompileMode[cases];
+
+        for (int c = 0; c < cases; c++) {
+            modes[c] = new CompileMode(c, Arrays.asList("actor1"), 1);
+        }
+
+        // Check all these configs are present:
+        for (int a0 = 0; a0 < CompileMode.VARIANTS; a0++) {
+            boolean ex = false;
+            for (CompileMode cm : modes) {
+                ex |= select(a0, cm, 0);
+            }
+            Assert.assertTrue("Mode does not exist: " + a0, ex);
+        }
+    }
+
+    @Test
+    public void splitComplete_2() {
+        int cases = CompileMode.casesFor(2);
+
+        CompileMode[] modes = new CompileMode[cases];
+
+        for (int c = 0; c < cases; c++) {
+            modes[c] = new CompileMode(c, Arrays.asList("actor1", "actor2"), 2);
+        }
+
+        // Check all these configs are present:
+        for (int a0 = 0; a0 < CompileMode.VARIANTS; a0++) {
+            for (int a1 = 0; a1 < CompileMode.VARIANTS; a1++) {
+                boolean ex = false;
+                for (CompileMode cm : modes) {
+                    ex |= select(a0, cm, 0) &&
+                          select(a1, cm, 1);
+                }
+                Assert.assertTrue("Mode does not exist: " + a0 + ", " + a1, ex);
+            }
+        }
+    }
+
+    @Test
+    public void splitComplete_3() {
+        int cases = CompileMode.casesFor(3);
+
+        CompileMode[] modes = new CompileMode[cases];
+
+        for (int c = 0; c < cases; c++) {
+            modes[c] = new CompileMode(c, Arrays.asList("actor1", "actor2", "actor3"), 3);
+        }
+
+        // Check all these configs are present:
+        for (int a0 = 0; a0 < CompileMode.VARIANTS; a0++) {
+            for (int a1 = 0; a1 < CompileMode.VARIANTS; a1++) {
+                for (int a2 = 0; a2 < CompileMode.VARIANTS; a2++) {
+                    boolean ex = false;
+                    for (CompileMode cm : modes) {
+                        ex |= select(a0, cm, 0) &&
+                              select(a1, cm, 1) &&
+                              select(a2, cm, 2);
+                    }
+                    Assert.assertTrue("Mode does not exist: " + a0 + ", " + a1 + ", " + a2, ex);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void splitComplete_4() {
+        int cases = CompileMode.casesFor(4);
+
+        CompileMode[] modes = new CompileMode[cases];
+
+        for (int c = 0; c < cases; c++) {
+            modes[c] = new CompileMode(c, Arrays.asList("actor1", "actor2", "actor3", "actor4"), 4);
+        }
+
+        // Check all these configs are present:
+        for (int a0 = 0; a0 < CompileMode.VARIANTS; a0++) {
+            for (int a1 = 0; a1 < CompileMode.VARIANTS; a1++) {
+                for (int a2 = 0; a2 < CompileMode.VARIANTS; a2++) {
+                    for (int a3 = 0; a3 < CompileMode.VARIANTS; a3++) {
+                        boolean ex = false;
+                        for (CompileMode cm : modes) {
+                            ex |= select(a0, cm, 0) &&
+                                  select(a1, cm, 1) &&
+                                  select(a2, cm, 2) &&
+                                  select(a3, cm, 3);
+                        }
+                        Assert.assertTrue("Mode does not exist: " + a0 + ", " + a1 + ", " + a2 + ", " + a3, ex);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean select(int m, CompileMode cm, int a) {
+        switch (m) {
+            case 0:
+                return cm.isInt(a);
+            case 1:
+                return cm.isC1(a);
+            case 2:
+                return cm.isC2(a);
+            default:
+                throw new IllegalStateException("Unknown mode");
+        }
+    }
+}

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
@@ -32,6 +32,7 @@ import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.InProcessCollector;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.runners.TestConfig;
+import org.openjdk.jcstress.vm.CompileMode;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/EmbeddedExecutorTest.java
@@ -64,7 +64,7 @@ public class EmbeddedExecutorTest {
         Options opts = new Options(new String[]{});
         opts.parse();
         TestInfo info = new TestInfo("", runnerClassName, "", 4, Arrays.asList("a1", "a2", "a3", "a4"), false);
-        return new TestConfig(opts, info, TestConfig.RunMode.FORKED, 1, Collections.emptyList());
+        return new TestConfig(opts, info, TestConfig.RunMode.FORKED, 1, Collections.emptyList(), CompileMode.UNIFIED);
     }
 
 }


### PR DESCRIPTION
The groundwork that uses CompilerDirectives facility finally allows us to compile the actor methods with different compilers. This should catch inconsistencies in different compilers using incompatible memory barrier schemes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902857](https://bugs.openjdk.java.net/browse/CODETOOLS-7902857): jcstress: Support split compilation modes


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/16/head:pull/16`
`$ git checkout pull/16`

To update a local copy of the PR:
`$ git checkout pull/16`
`$ git pull https://git.openjdk.java.net/jcstress pull/16/head`
