### PR TITLE
CODETOOLS-7902858: jcstress: Clean up progress message

### DIFF
--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -52,7 +52,7 @@ public class SampleTestBench {
         Options opts = new Options(new String[]{"-v", "-iters", "1", "-time", "5000", "-deoptMode", "NONE"});
         opts.parse();
         PrintWriter pw = new PrintWriter(System.out, true);
-        ConsoleReportPrinter sink = new ConsoleReportPrinter(opts, pw, 1, 1);
+        ConsoleReportPrinter sink = new ConsoleReportPrinter(opts, pw, 1);
 
         String testName = SampleTest.class.getCanonicalName();
         String runnerName = SampleTest_jcstress.class.getCanonicalName();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -75,7 +75,7 @@ public class JCStress {
             return;
         }
 
-        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), tests.size(), configs.size());
+        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), configs.size());
         DiskWriteCollector diskCollector = new DiskWriteCollector(opts.getResultFile());
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);


### PR DESCRIPTION
Current progress message seems overloaded. Printing the number of tests and forks is misleading after multiple forks and multiple VMs are run per test. We can simplify the implementation considerably.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902858](https://bugs.openjdk.java.net/browse/CODETOOLS-7902858): jcstress: Clean up progress message


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/17/head:pull/17`
`$ git checkout pull/17`

To update a local copy of the PR:
`$ git checkout pull/17`
`$ git pull https://git.openjdk.java.net/jcstress pull/17/head`
