### PR TITLE
CODETOOLS-7902861: jcstress: Optimize and clean up result handling

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -96,7 +96,9 @@ public class JCStress {
 
     public void parseResults() throws Exception {
         InProcessCollector collector = new InProcessCollector();
-        new DiskReadCollector(opts.getResultFile(), collector).dump();
+        DiskReadCollector drc = new DiskReadCollector(opts.getResultFile(), collector);
+        drc.dump();
+        drc.close();
 
         new TextReportPrinter(opts, collector).work();
         new HTMLReportPrinter(opts, collector).work();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -342,8 +342,8 @@ public class TestExecutor {
                 if (ecode != 0) {
                     dumpFailure(sink, out, err);
                 } else {
-                    result.addVMOut(out);
-                    result.addVMErr(err);
+                    result.addVMOuts(out);
+                    result.addVMErrs(err);
                     sink.add(result);
                 }
             } catch (InterruptedException ex) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.infra.collectors;
 
 import org.openjdk.jcstress.infra.Status;
+import org.openjdk.jcstress.infra.grading.ReportUtils;
 import org.openjdk.jcstress.infra.grading.TestGrading;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.util.Environment;
@@ -63,23 +64,36 @@ public class TestResult implements Serializable {
     }
 
     public void addMessage(String msg) {
+        if (ReportUtils.skipMessage(msg)) return;
         messages.add(msg);
     }
 
+    public void addMessages(Collection<String> msgs) {
+        for (String m : msgs) {
+            addMessage(m);
+        }
+    }
+
     public void addVMOut(String msg) {
+        if (ReportUtils.skipMessage(msg)) return;
         vmOut.add(msg);
     }
 
-    public void addVMOut(Collection<String> msg) {
-        vmOut.addAll(msg);
+    public void addVMOuts(Collection<String> msgs) {
+        for (String m : msgs) {
+            addVMOut(m);
+        }
     }
 
     public void addVMErr(String msg) {
+        if (ReportUtils.skipMessage(msg)) return;
         vmErr.add(msg);
     }
 
-    public void addVMErr(Collection<String> msg) {
-        vmErr.addAll(msg);
+    public void addVMErrs(Collection<String> msgs) {
+        for (String m : msgs) {
+            addVMErr(m);
+        }
     }
 
     public void setEnv(Environment e) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -53,7 +53,7 @@ public class HTMLReportPrinter {
     private final InProcessCollector collector;
     private int cellStyle = 1;
 
-    public HTMLReportPrinter(Options opts, InProcessCollector collector) throws FileNotFoundException {
+    public HTMLReportPrinter(Options opts, InProcessCollector collector) {
         this.collector = collector;
         this.resultDir = opts.getResultDest();
         new File(resultDir).mkdirs();
@@ -379,7 +379,7 @@ public class HTMLReportPrinter {
             keys.addAll(r.getStateKeys());
         }
 
-        o.println("<table width=100% cellpadding=5>");
+        o.println("<table cellpadding=5>");
         o.println("<tr>");
         o.println("<th>Observed state</th>");
         for (int c = 0; c < configs; c++) {
@@ -424,13 +424,41 @@ public class HTMLReportPrinter {
 
         o.println("</table>");
 
-        o.println("<h3>Auxiliary data</h3>");
+        o.println("<h3>Messages</h3>");
 
         for (TestResult r : sorted) {
             if (!r.getMessages().isEmpty()) {
                 o.println("<p><b>" + r.getConfig() + "</b></p>");
                 o.println("<pre>");
                 for (String data : r.getMessages()) {
+                    o.println(data);
+                }
+                o.println("</pre>");
+                o.println();
+            }
+        }
+
+        o.println("<h3>VM Output Streams</h3>");
+
+        for (TestResult r : sorted) {
+            if (!r.getVmOut().isEmpty()) {
+                o.println("<p><b>" + r.getConfig() + "</b></p>");
+                o.println("<pre>");
+                for (String data : r.getVmOut()) {
+                    o.println(data);
+                }
+                o.println("</pre>");
+                o.println();
+            }
+        }
+
+        o.println("<h3>VM Error Streams</h3>");
+
+        for (TestResult r : sorted) {
+            if (!r.getVmErr().isEmpty()) {
+                o.println("<p><b>" + r.getConfig() + "</b></p>");
+                o.println("<pre>");
+                for (String data : r.getVmErr()) {
                     o.println(data);
                 }
                 o.println("</pre>");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -81,7 +81,10 @@ public class ReportUtils {
     private static TestResult merged(TestConfig config, Collection<TestResult> mergeable) {
         Multiset<String> stateCounts = new HashMultiset<>();
 
-        List<String> auxData = new ArrayList<>();
+        List<String> messages = new ArrayList<>();
+
+        List<String> vmOuts = new ArrayList<>();
+        List<String> vmErrs = new ArrayList<>();
 
         Status status = Status.NORMAL;
         Environment env = null;
@@ -91,7 +94,9 @@ public class ReportUtils {
                 stateCounts.add(s, r.getCount(s));
             }
             env = r.getEnv();
-            auxData.addAll(r.getMessages());
+            messages.addAll(r.getMessages());
+            vmOuts.addAll(r.getVmOut());
+            vmErrs.addAll(r.getVmErr());
         }
 
         TestResult root = new TestResult(config, status);
@@ -102,9 +107,13 @@ public class ReportUtils {
 
         root.setEnv(env);
 
-        for (String data : auxData) {
+        for (String data : messages) {
             root.addMessage(data);
         }
+
+        root.addVMOuts(vmOuts);
+        root.addVMErrs(vmErrs);
+
         return root;
     }
 
@@ -195,7 +204,7 @@ public class ReportUtils {
         }
     }
 
-    private static boolean skipMessage(String data) {
+    public static boolean skipMessage(String data) {
         if (data == null) {
             return true;
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -149,6 +149,7 @@ public class TestConfig implements Serializable {
 
         TestConfig that = (TestConfig) o;
 
+        if (!name.equals(that.name)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
         if (minStride != that.minStride) return false;
         if (maxStride != that.maxStride) return false;
@@ -157,7 +158,6 @@ public class TestConfig implements Serializable {
         if (deoptMode != that.deoptMode) return false;
         if (threads != that.threads) return false;
         if (compileMode != that.compileMode) return false;
-        if (!name.equals(that.name)) return false;
         if (!jvmArgs.equals(that.jvmArgs)) return false;
         return runMode == that.runMode;
 
@@ -165,25 +165,11 @@ public class TestConfig implements Serializable {
 
     @Override
     public int hashCode() {
-        int result = spinLoopStyle.hashCode();
-        result = 31 * result + minStride;
-        result = 31 * result + maxStride;
-        result = 31 * result + time;
-        result = 31 * result + iters;
-        result = 31 * result + deoptMode.hashCode();
-        result = 31 * result + threads;
-        result = 31 * result + compileMode;
-        result = 31 * result + name.hashCode();
-        result = 31 * result + jvmArgs.hashCode();
-        result = 31 * result + runMode.hashCode();
-        return result;
+        return name.hashCode();
     }
 
     @Override
     public String toString() {
-        return "JVM options: " + jvmArgs + "\n" +
-                "Iterations: " + iters + "\n" +
-                "Time: " + time + "\n" +
-                "Stride: [" + minStride + ", " + maxStride + "] (capped by " + strideCap + ")";
+        return "JVM options: " + jvmArgs +"; Compile mode: " + getCompileMode();
     }
 }


### PR DESCRIPTION
After VM output capture was enabled, the results file became exceedingly large. It is mostly due to recording the Whitebox messages. But, we can also cleanup the whole thing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902861](https://bugs.openjdk.java.net/browse/CODETOOLS-7902861): jcstress: Optimize and clean up result handling


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/18/head:pull/18`
`$ git checkout pull/18`

To update a local copy of the PR:
`$ git checkout pull/18`
`$ git pull https://git.openjdk.java.net/jcstress pull/18/head`
