### PR TITLE
CODETOOLS-7902862: jcstress: Block execution of task/run loops until compiled code is available

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -190,6 +190,11 @@ public class TestExecutor {
             pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
             pw.println("    inline: \"+" + WorkerSync.class.getName() + "::*\",");
             pw.println("    inline: \"+java.util.concurrent.atomic.*::*\",");
+
+            // The test is running in resource-constrained JVM. Block the task loop execution until
+            // compiled code is available. This would allow compilers to work in relative peace.
+            pw.println("    BackgroundCompilation: false,");
+
             pw.println("  },");
 
             // Force inline everything from WorkerSync. WorkerSync does not use anything
@@ -197,6 +202,11 @@ public class TestExecutor {
             pw.println("  {");
             pw.println("    match: \"" + WorkerSync.class.getName() + "::*" + "\",");
             pw.println("    inline: \"+*::*\",");
+
+            // The test is running in resource-constrained JVM. Block the WorkerSync execution until
+            // compiled code is available. This would allow compilers to work in relative peace.
+            pw.println("    BackgroundCompilation: false,");
+
             pw.println("  },");
 
             // The run loops:
@@ -238,7 +248,7 @@ public class TestExecutor {
                 }
 
                 // The test is running in resource-constrained JVM. Block the run loop execution until
-                // compiled code is available. This would le compilers compile the code in relative peace.
+                // compiled code is available. This would allow compilers to work in relative peace.
                 pw.println("    BackgroundCompilation: false,");
 
                 pw.println("  },");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -232,9 +232,15 @@ public class TestExecutor {
                     pw.println("      Exclude: true,");
                     pw.println("    },");
                 }
+
                 if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly() && !cm.isInt(a)) {
                     pw.println("    PrintAssembly: true,");
                 }
+
+                // The test is running in resource-constrained JVM. Block the run loop execution until
+                // compiled code is available. This would le compilers compile the code in relative peace.
+                pw.println("    BackgroundCompilation: false,");
+
                 pw.println("  },");
             }
 


### PR DESCRIPTION
Forked JVMs run in resource-constrained environments, where background compilation of hot task/run loops competes with the test execution itself. Also, when C1/C2 compilation is requested, we are better wait until that compilation actually happens.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902862](https://bugs.openjdk.java.net/browse/CODETOOLS-7902862): jcstress: Block execution of task/run loops until compiled code is available


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/19/head:pull/19`
`$ git checkout pull/19`

To update a local copy of the PR:
`$ git checkout pull/19`
`$ git pull https://git.openjdk.java.net/jcstress pull/19/head`
