### PR TITLE
Refactor IRIW tests a bit

### DIFF
--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/volatiles/RelaxedIRIWTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/volatiles/RelaxedIRIWTest.java
@@ -34,16 +34,16 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.IIII_Result;
 
 @JCStressTest
-@Description("Tests the IRIW sequential consistency: strongest case.")
+@Description("Tests the IRIW sequential consistency: non-synchronized test.")
 @Outcome(id = "0, 1, 0, 1", expect = Expect.ACCEPTABLE, desc = "This is a rare event, because it requires precise juxtaposition of threads to observe.")
-@Outcome(id = "1, 0, 1, 0", expect = Expect.FORBIDDEN,  desc = "Threads see the updates in the inconsistent order")
+@Outcome(id = "1, 0, 1, 0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Threads see the updates in the inconsistent order")
 @Outcome(                   expect = Expect.ACCEPTABLE, desc = "All other cases are acceptable.")
 @Ref("http://cs.oswego.edu/pipermail/concurrency-interest/2013-January/010608.html")
 @State
-public class VolatileIRIWTest {
+public class RelaxedIRIWTest {
 
-    public volatile int x;
-    public volatile int y;
+    public int x;
+    public int y;
 
     @Actor
     public void actor1() {


### PR DESCRIPTION
This refactors the IRIW tests: makes sure the operands are in order, names unsyncronized test correct, introduces opaque test. Tested fine on x86_64 and PPC64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jcstress pull/20/head:pull/20`
`$ git checkout pull/20`

To update a local copy of the PR:
`$ git checkout pull/20`
`$ git pull https://git.openjdk.java.net/jcstress pull/20/head`
