### PR TITLE
CODETOOLS-7902865: jcstress: Enable -XX:+DebugNonSafepoints if available to get more verbose disassembly

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -143,6 +143,12 @@ public class VMSupport {
             throw new IllegalStateException("Fatal error: WhiteBoxAPI JAR problems.", e);
         }
 
+        detect("Unlocking debug information for non-safepoints",
+                SimpleTestMain.class,
+                GLOBAL_JVM_FLAGS,
+                "-XX:+DebugNonSafepoints"
+        );
+
         detect("Unlocking C2 local code motion randomizer",
                 SimpleTestMain.class,
                 C2_STRESS_JVM_FLAGS,


### PR DESCRIPTION
CODETOOLS-7902854 added support for printing disassembly. Unfortunately, supplying PrintAssembly through compiler directives does not implicitly enables -XX:+DebugNonSafepoints, which makes disassembly less verbose: it misses PcDescs for non-safepoints.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902865](https://bugs.openjdk.java.net/browse/CODETOOLS-7902865): jcstress: Enable -XX:+DebugNonSafepoints if available to get more verbose disassembly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jcstress pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/21.diff">https://git.openjdk.java.net/jcstress/pull/21.diff</a>

</details>
