### PR TITLE
CODETOOLS-7902872: jcstress: check for C1/C2 availability and adjust configurations

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -24,7 +24,6 @@
  */
 package org.openjdk.jcstress;
 
-import jdk.internal.misc.VM;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.*;
 import org.openjdk.jcstress.infra.grading.ConsoleReportPrinter;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jcstress;
 
+import jdk.internal.misc.VM;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.*;
 import org.openjdk.jcstress.infra.grading.ConsoleReportPrinter;
@@ -140,9 +141,8 @@ public class JCStress {
     }
 
     private void forkedSplit(List<TestConfig> testConfigs, VMSupport.Config config, TestInfo info) {
-        for (int cc = 0; cc < CompileMode.casesFor(info.threads()); cc++) {
-            CompileMode cm = new CompileMode(cc, info.actorNames(), info.threads());
-            if (config.onlyIfC2() && !cm.hasC2()) {
+        for (int cc : CompileMode.casesFor(info.threads(), VMSupport.c1Available(), VMSupport.c2Available())) {
+            if (config.onlyIfC2() && CompileMode.hasC2(cc, info.threads())) {
                 // This configuration is expected to run only when C2 is enabled,
                 // but compilation mode does not include C2. Can skip it to optimize
                 // testing time.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -210,7 +210,7 @@ public class TestExecutor {
             pw.println("  },");
 
             // The run loops:
-            CompileMode cm = task.getCompileMode();
+            int cm = task.getCompileMode();
             for (int a = 0; a < task.threads; a++) {
                 String an = task.actorNames.get(a);
 
@@ -223,27 +223,27 @@ public class TestExecutor {
                 // this would make sure that while actor methods are running in interpreter,
                 // the run loop still runs in compiled mode, running faster. The call to interpreted
                 // method would happen anyway, even though through c2i transition.
-                if (cm.isInt(a)) {
+                if (CompileMode.isInt(cm, a)) {
                     pw.println("    inline: \"-" + task.name + "::" + an + "\",");
                 } else {
                     pw.println("    inline: \"+" + task.name + "::" + an + "\",");
                 }
 
                 // Run loop should be compiled with C2? Forbid C1 compilation then.
-                if (cm.isC2(a)) {
+                if (CompileMode.isC2(cm, a)) {
                     pw.println("    c1: {");
                     pw.println("      Exclude: true,");
                     pw.println("    },");
                 }
 
                 // Run loop should be compiled with C1? Forbid C2 compilation then.
-                if (cm.isC1(a)) {
+                if (CompileMode.isC1(cm, a)) {
                     pw.println("    c2: {");
                     pw.println("      Exclude: true,");
                     pw.println("    },");
                 }
 
-                if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly() && !cm.isInt(a)) {
+                if (VMSupport.printAssemblyAvailable() && verbosity.printAssembly() && !CompileMode.isInt(cm, a)) {
                     pw.println("    PrintAssembly: true,");
                 }
 
@@ -259,7 +259,7 @@ public class TestExecutor {
 
                 // If this actor runs in interpreted mode, then actor method should not be compiled.
                 // Allow run loop to be compiled with the best compiler available.
-                if (cm.isInt(a)) {
+                if (CompileMode.isInt(cm, a)) {
                     pw.println("  {");
                     pw.println("    match: \"+" + task.name + "::" + an + "\",");
                     pw.println("    c1: {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -32,6 +32,7 @@ import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.infra.runners.TestList;
 import org.openjdk.jcstress.util.*;
+import org.openjdk.jcstress.vm.CompileMode;
 
 import java.io.PrintWriter;
 import java.util.*;
@@ -118,7 +119,7 @@ public class ReportUtils {
     }
 
     public static void printDetails(PrintWriter pw, TestResult r, boolean inProgress) {
-        pw.format("    (compilation: %s)%n", r.getConfig().getCompileMode());
+        pw.format("    (compilation: %s)%n", CompileMode.description(r.getConfig().getCompileMode(), r.getConfig().actorNames));
         pw.format("    (JVM args: %s)%n", r.getConfig().jvmArgs);
         if (inProgress) {
             pw.format("    (fork: #%d)%n", r.getConfig().forkId + 1);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -138,8 +138,8 @@ public class TestConfig implements Serializable {
         return StrideCap.NONE;
     }
 
-    public CompileMode getCompileMode() {
-        return new CompileMode(compileMode, actorNames, threads);
+    public int getCompileMode() {
+        return compileMode;
     }
 
     @Override


### PR DESCRIPTION
Split compilation and other VM modes would futilely try to use C1 or C2 when not available. This affects Zero VM (has no C1/C2) and Minimal VM (has only C1). jcstress should autodetect the compiler availability and adjust itself accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902872](https://bugs.openjdk.java.net/browse/CODETOOLS-7902872): jcstress: check for C1/C2 availability and adjust configurations


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jcstress pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/22.diff">https://git.openjdk.java.net/jcstress/pull/22.diff</a>

</details>
