### PR TITLE
CODETOOLS-7902873: jcstress: Clean up text reporting

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -28,7 +28,6 @@ import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
-import org.openjdk.jcstress.util.StringUtils;
 
 import java.io.PrintWriter;
 import java.util.concurrent.TimeUnit;
@@ -141,9 +140,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
             if (!progressInteractive) {
                 output.println();
             }
-            output.printf("%10s %s%n", "[" + ReportUtils.statusToLabel(r) + "]", StringUtils.chunkName(r.getName()));
-            ReportUtils.printDetails(output, r, true);
-            ReportUtils.printMessages(output, r);
+            ReportUtils.printResult(output, r, true);
         }
 
         if (shouldPrintStatusLine) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -471,7 +471,7 @@ public class HTMLReportPrinter {
 
     public String selectHTMLColor(Expect type, boolean isZero) {
         String rgb = Integer.toHexString(selectColor(type, isZero).getRGB());
-        return "#" + rgb.substring(2, rgb.length());
+        return "#" + rgb.substring(2);
     }
 
     public Color selectColor(Expect type, boolean isZero) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -118,12 +118,17 @@ public class ReportUtils {
         return root;
     }
 
-    public static void printDetails(PrintWriter pw, TestResult r, boolean inProgress) {
-        pw.format("    (compilation: %s)%n", CompileMode.description(r.getConfig().getCompileMode(), r.getConfig().actorNames));
-        pw.format("    (JVM args: %s)%n", r.getConfig().jvmArgs);
+    public static void printResult(PrintWriter pw, TestResult r, boolean inProgress) {
+        String label = StringUtils.leftPadDash("[" + ReportUtils.statusToLabel(r) + "]", 10);
+        String testName = StringUtils.chunkName(r.getName());
+        pw.printf("%10s %s%n", label, testName);
+        pw.println();
+        pw.format("  Compilation: %s%n", CompileMode.description(r.getConfig().getCompileMode(), r.getConfig().actorNames));
+        pw.format("  JVM args: %s%n", r.getConfig().jvmArgs);
         if (inProgress) {
-            pw.format("    (fork: #%d)%n", r.getConfig().forkId + 1);
+            pw.format("  Fork: #%d%n", r.getConfig().forkId + 1);
         }
+        pw.println();
 
         if (!r.hasSamples()) {
             return;
@@ -162,17 +167,15 @@ public class ReportUtils {
         }
 
         pw.println();
-    }
 
-    public static void printMessages(PrintWriter pw, TestResult r) {
         boolean errMsgsPrinted = false;
         for (String data : r.getMessages()) {
             if (skipMessage(data)) continue;
             if (!errMsgsPrinted) {
-                pw.println("    Messages: ");
+                pw.println("  Messages: ");
                 errMsgsPrinted = true;
             }
-            pw.println("        " + data);
+            pw.println("    " + data);
         }
         if (errMsgsPrinted) {
             pw.println();
@@ -182,10 +185,10 @@ public class ReportUtils {
         for (String data : r.getVmOut()) {
             if (skipMessage(data)) continue;
             if (!vmOutPrinted) {
-                pw.println("    VM output stream: ");
+                pw.println("  VM output stream: ");
                 vmOutPrinted = true;
             }
-            pw.println("        " + data);
+            pw.println("    " + data);
         }
         if (vmOutPrinted) {
             pw.println();
@@ -195,10 +198,10 @@ public class ReportUtils {
         for (String data : r.getVmErr()) {
             if (skipMessage(data)) continue;
             if (!vmErrPrinted) {
-                pw.println("    VM error stream: ");
+                pw.println("  VM error stream: ");
                 vmErrPrinted = true;
             }
-            pw.println("        " + data);
+            pw.println("    " + data);
         }
         if (vmErrPrinted) {
             pw.println();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -118,4 +118,21 @@ public class StringUtils {
         }
         return src;
     }
+
+    static final String[] PADS;
+
+    static {
+        PADS = new String[10];
+        String p = "";
+        for (int c = 0; c < PADS.length; c++) {
+            PADS[c] = p;
+            p = p + ".";
+        }
+    }
+
+    public static String leftPadDash(String src, int count) {
+        int need = count - src.length() - 1;
+        if (need <= 0) return src;
+        return PADS[need] + " " + src;
+    }
 }


### PR DESCRIPTION
We can make the output a little bit better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902873](https://bugs.openjdk.java.net/browse/CODETOOLS-7902873): jcstress: Clean up text reporting


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jcstress pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/23.diff">https://git.openjdk.java.net/jcstress/pull/23.diff</a>

</details>
