### PR TITLE
CODETOOLS-7902874: jcstress: Print messages and VM streams on VM failure

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -130,43 +130,41 @@ public class ReportUtils {
         }
         pw.println();
 
-        if (!r.hasSamples()) {
-            return;
+        if (r.hasSamples()) {
+            int idLen = "Observed state".length();
+            int occLen = "Occurrences".length();
+            int expectLen = "Expectation".length();
+            int descLen = 60;
+
+            for (String s : r.getStateKeys()) {
+                idLen = Math.max(idLen, s.length());
+                occLen = Math.max(occLen, String.format("%,d", r.getCount(s)).length());
+                expectLen = Math.max(expectLen, Expect.UNKNOWN.toString().length());
+            }
+
+            TestInfo test = TestList.getInfo(r.getName());
+            for (StateCase c : test.cases()) {
+                idLen = Math.max(idLen, c.matchPattern().length());
+                expectLen = Math.max(expectLen, c.expect().toString().length());
+            }
+            expectLen = Math.max(expectLen, test.unmatched().expect().toString().length());
+
+            idLen += 2;
+            occLen += 2;
+            expectLen += 2;
+
+            pw.printf("%" + idLen + "s %" + occLen + "s %" + expectLen + "s  %-" + descLen + "s%n", "Observed state", "Occurrences", "Expectation", "Interpretation");
+
+            for (GradingResult gradeRes : r.grading().gradingResults) {
+                pw.printf("%" + idLen + "s %," + occLen + "d %" + expectLen + "s  %-" + descLen + "s%n",
+                        StringUtils.cutoff(gradeRes.id, idLen),
+                        gradeRes.count,
+                        gradeRes.expect,
+                        StringUtils.cutoff(gradeRes.description, descLen));
+            }
+
+            pw.println();
         }
-
-        int idLen = "Observed state".length();
-        int occLen = "Occurrences".length();
-        int expectLen = "Expectation".length();
-        int descLen = 60;
-
-        for (String s : r.getStateKeys()) {
-            idLen = Math.max(idLen, s.length());
-            occLen = Math.max(occLen, String.format("%,d", r.getCount(s)).length());
-            expectLen = Math.max(expectLen, Expect.UNKNOWN.toString().length());
-        }
-
-        TestInfo test = TestList.getInfo(r.getName());
-        for (StateCase c : test.cases()) {
-            idLen = Math.max(idLen, c.matchPattern().length());
-            expectLen = Math.max(expectLen, c.expect().toString().length());
-        }
-        expectLen = Math.max(expectLen, test.unmatched().expect().toString().length());
-
-        idLen += 2;
-        occLen += 2;
-        expectLen += 2;
-
-        pw.printf("%" + idLen + "s %" + occLen +"s %" + expectLen + "s  %-" + descLen + "s%n", "Observed state", "Occurrences", "Expectation", "Interpretation");
-
-        for (GradingResult gradeRes : r.grading().gradingResults) {
-            pw.printf("%" + idLen + "s %," + occLen + "d %" + expectLen + "s  %-" + descLen + "s%n",
-                    StringUtils.cutoff(gradeRes.id, idLen),
-                    gradeRes.count,
-                    gradeRes.expect,
-                    StringUtils.cutoff(gradeRes.description, descLen));
-        }
-
-        pw.println();
 
         boolean errMsgsPrinted = false;
         for (String data : r.getMessages()) {


### PR DESCRIPTION
Currently, jcstress does not print those when VM fails, which hinders the debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902874](https://bugs.openjdk.java.net/browse/CODETOOLS-7902874): jcstress: Print messages and VM streams on VM failure


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jcstress pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/24.diff">https://git.openjdk.java.net/jcstress/pull/24.diff</a>

</details>
