### PR TITLE
CODETOOLS-7902877: jcstress: Fix C2-only configuration filtering

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -141,7 +141,7 @@ public class JCStress {
 
     private void forkedSplit(List<TestConfig> testConfigs, VMSupport.Config config, TestInfo info) {
         for (int cc : CompileMode.casesFor(info.threads(), VMSupport.c1Available(), VMSupport.c2Available())) {
-            if (config.onlyIfC2() && CompileMode.hasC2(cc, info.threads())) {
+            if (config.onlyIfC2() && !CompileMode.hasC2(cc, info.threads())) {
                 // This configuration is expected to run only when C2 is enabled,
                 // but compilation mode does not include C2. Can skip it to optimize
                 // testing time.


### PR DESCRIPTION
CODETOOLS-7902872 rewrote CompileMode code, and introduced a little regression here:
 https://github.com/openjdk/jcstress/commit/67158528f9abdf49f9ae23c704c068a76075b4fe?branch=67158528f9abdf49f9ae23c704c068a76075b4fe&diff=unified#diff-90c43d0da51e119c248c273763e3e5d3b6b14586492fb836c480ecd144af56e5L143-R144

The filter should say "config.onlyIfC2() && !hasC2". The "!" was accidentally dropped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902877](https://bugs.openjdk.java.net/browse/CODETOOLS-7902877): jcstress: Fix C2-only configuration filtering


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jcstress pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/25.diff">https://git.openjdk.java.net/jcstress/pull/25.diff</a>

</details>
