### PR TITLE
CODETOOLS-7902879: jcstress: Reduce the number of auto-generated tests

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
@@ -202,6 +202,9 @@ public class Chapter0aTestGenerator {
         for (String modifier : modifiers) {
             String pack = PREFIX + "." + label + "." + (modifier.equals("") ? "plain" : modifier + "s");
             for (String type : TYPES) {
+                if (!alwaysAtomic(modifier, type, label)) continue;
+                if (!coherent(modifier, type, label)) continue;
+
                 String name = testName(type);
                 String res = Spp.spp(template,
                         keys(modifier, type, label),
@@ -232,12 +235,6 @@ public class Chapter0aTestGenerator {
     private static Set<String> keys(String modifier, String type, String label) {
         Set<String> set = new HashSet<>();
         set.add(type);
-        if (alwaysAtomic(modifier, type, label)) {
-            set.add("alwaysAtomic");
-        }
-        if (coherent(modifier, type, label)) {
-            set.add("coherent");
-        }
         set.add(modifier);
         return set;
     }

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1aTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1aTestGenerator.java
@@ -106,7 +106,6 @@ public class Chapter1aTestGenerator {
     }
 
     private enum VarHandleMode {
-        NAKED("plain"),
         OPAQUE("opaque"),
         ACQ_REL("acqrel"),
         VOLATILE("volatiles"),
@@ -169,11 +168,6 @@ public class Chapter1aTestGenerator {
         map.put("byteOrder", String.valueOf(bo));
 
         switch (mode) {
-            case NAKED: {
-                map.put("setOp", "set");
-                map.put("getOp", "get");
-                break;
-            }
             case OPAQUE: {
                 map.put("setOp", "setOpaque");
                 map.put("getOp", "getOpaque");
@@ -198,39 +192,7 @@ public class Chapter1aTestGenerator {
     private static Set<String> keys(String type, VarHandleMode mode) {
         Set<String> set = new HashSet<>();
         set.add(type);
-        if (alwaysAtomic(type, mode)) {
-            set.add("alwaysAtomic");
-        }
-        if (coherent(type, mode)) {
-            set.add("coherent");
-        }
         return set;
-    }
-
-    private static boolean alwaysAtomic(String type, VarHandleMode mode) {
-        switch (mode) {
-            case NAKED:
-                return !(type.equals("double") || type.equals("long"));
-            case ACQ_REL:
-            case OPAQUE:
-            case VOLATILE:
-                return true;
-            default:
-                throw new IllegalStateException(mode.toString());
-        }
-    }
-
-    private static boolean coherent(String type, VarHandleMode mode) {
-        switch (mode) {
-            case NAKED:
-                return false;
-            case OPAQUE:
-            case ACQ_REL:
-            case VOLATILE:
-                return true;
-            default:
-                throw new IllegalStateException(mode.toString());
-        }
     }
 
     private static String testName(String type) {

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1bTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1bTestGenerator.java
@@ -132,6 +132,8 @@ public class Chapter1bTestGenerator {
             BufferType bufferType, String templateName, String template)
             throws IOException {
         for (Type type : VIEW_SOURCE.supportedTypes()) {
+            if (!type.alwaysAtomic) continue;
+
             for (Operation operation : target.operations) {
                 if (!VIEW_SOURCE.supported(operation.method, type))
                     break;
@@ -165,10 +167,7 @@ public class Chapter1bTestGenerator {
     }
 
     private static Set<String> keys(Type type) {
-        if (type.alwaysAtomic)
-            return of("alwaysAtomic");
-        else
-            return of();
+        return of();
     }
 
     private static Map<String, String> commonVars(Type type, String object, String pkg, String testName) {

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1cTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1cTestGenerator.java
@@ -59,6 +59,8 @@ public class Chapter1cTestGenerator {
 
     private static void makeFieldTests(String dest, Target target, String templateName, String template) throws IOException {
         for (String type : TYPES) {
+            if (!alwaysAtomic(type)) continue;
+
             for (Operation operation : target.operations) {
                 String result = template.replaceAll(target.target, operation.operation);
 
@@ -78,10 +80,7 @@ public class Chapter1cTestGenerator {
     }
 
     private static Set<String> keys(String type) {
-        if (alwaysAtomic(type))
-            return of("alwaysAtomic");
-        else
-            return of();
+        return of();
     }
 
     private static Map<String, String> vars(String type, String object, String pkg, String testName) {

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1dTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter1dTestGenerator.java
@@ -84,8 +84,6 @@ public class Chapter1dTestGenerator {
     }
 
     private enum VarHandleMode {
-        NAKED("plain"),
-        OPAQUE("opaque"),
         ACQ_REL("acqrel"),
         VOLATILE("volatiles"),
         ;
@@ -103,8 +101,8 @@ public class Chapter1dTestGenerator {
     }
 
     private static void makeTests(String dest, String template, String label) throws IOException {
-        // Only care about the access-atomic guards
-        for (VarHandleMode gs : new VarHandleMode[] { VarHandleMode.OPAQUE, VarHandleMode.ACQ_REL, VarHandleMode.VOLATILE } ) {
+        // Only care about modes where acq/rel is expected
+        for (VarHandleMode gs : new VarHandleMode[] { VarHandleMode.ACQ_REL, VarHandleMode.VOLATILE } ) {
             String pack = PREFIX + "." + label + "." + gs;
             for (String typeG : TYPES_G) {
                 for (String typeV : TYPES_V) {
@@ -120,8 +118,8 @@ public class Chapter1dTestGenerator {
     }
 
     private static void makeBufferTests(String dest, String template, String label) throws IOException {
-        // Only care about the access-atomic guards
-        for (VarHandleMode gs : new VarHandleMode[] { VarHandleMode.OPAQUE, VarHandleMode.ACQ_REL, VarHandleMode.VOLATILE } ) {
+        // Only care about modes where acq/rel is expected
+        for (VarHandleMode gs : new VarHandleMode[] { VarHandleMode.ACQ_REL, VarHandleMode.VOLATILE } ) {
             for (ByteOrder bo : new ByteOrder[] { ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN }) {
                 String pack = PREFIX + "." + label + "." + bo.toString().toLowerCase().replace("_endian", "") + "." + gs;
                 for (String typeG : TYPES_VIEWS) {
@@ -163,16 +161,6 @@ public class Chapter1dTestGenerator {
         map.put("byteOrder", String.valueOf(bo));
 
         switch (mode) {
-            case NAKED: {
-                map.put("setOp", "set");
-                map.put("getOp", "get");
-                break;
-            }
-            case OPAQUE: {
-                map.put("setOp", "setOpaque");
-                map.put("getOp", "getOpaque");
-                break;
-            }
             case ACQ_REL: {
                 map.put("setOp", "setRelease");
                 map.put("getOp", "getAcquire");
@@ -192,26 +180,9 @@ public class Chapter1dTestGenerator {
     private static Set<String> keys(String modifier, String type, VarHandleMode mode) {
         Set<String> set = new HashSet<>();
         set.add(type);
-        if (racy(mode)) {
-            set.add("racy");
-        }
         set.add(modifier);
         return set;
     }
-
-    private static boolean racy(VarHandleMode mode) {
-        switch (mode) {
-            case NAKED:
-            case OPAQUE:
-                return true;
-            case ACQ_REL:
-            case VOLATILE:
-                return false;
-            default:
-                throw new IllegalStateException(mode.toString());
-        }
-    }
-
 
     private static String testName(String typeG, String typeV) {
         return StringUtils.upcaseFirst(typeG) + StringUtils.upcaseFirst(typeV) + "Test";

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter2aTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter2aTestGenerator.java
@@ -120,6 +120,7 @@ public class Chapter2aTestGenerator {
         for (String modifier : modifiers) {
             String pack = PREFIX + "." + label + "." + (modifier.equals("") ? "plain" : modifier + "s");
             for (String type : TYPES) {
+                if (!alwaysAtomic(modifier, type, label)) continue;
                 String name = testName(type);
                 String res = Spp.spp(template,
                         keys(modifier, type, label),
@@ -149,9 +150,6 @@ public class Chapter2aTestGenerator {
     private static Set<String> keys(String modifier, String type, String label) {
         Set<String> set = new HashSet<>();
         set.add(type);
-        if (alwaysAtomic(modifier, type, label)) {
-            set.add("alwaysAtomic");
-        }
         if (safe(modifier, type, label)) {
             set.add("safe");
         }

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/AcqType.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/AcqType.java
@@ -26,12 +26,7 @@ package org.openjdk.jcstress.generator;
 
 public enum AcqType {
     get,
-    CAS,
-    incrementAndGet,
-    getAndIncrement,
-    decrementAndGet,
-    getAndDecrement,
-    addAndGet,
+    compareAndSet,
     getAndAdd,
     getAndSet,
 }

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_Updater_X.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_Updater_X.java
@@ -57,7 +57,7 @@ public class Atomic_Updater_X implements Primitive {
     @Override
     public String printAcquire(String region) {
         switch (acqType) {
-            case CAS:
+            case compareAndSet:
                 return String.format("r.r1 = g.compareAndSet(this, %s, %s) ? %s : %s; \n" + region,
                         setValue,
                         defaultValue,
@@ -66,16 +66,6 @@ public class Atomic_Updater_X implements Primitive {
                 );
             case get:
                 return "r.r1 = g.get(this) == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case incrementAndGet:
-                return "r.r1 = g.incrementAndGet(this) == (" + defaultValue + " + " + unitValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
-            case getAndIncrement:
-                return "r.r1 = g.getAndIncrement(this) == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case decrementAndGet:
-                return "r.r1 = g.decrementAndGet(this) == (" + defaultValue + " - " + unitValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
-            case getAndDecrement:
-                return "r.r1 = g.getAndDecrement(this) == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case addAndGet:
-                return "r.r1 = g.addAndGet(this, " + rValue + ") == (" + defaultValue + " + " + rValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
             case getAndAdd:
                 return "r.r1 = g.getAndAdd(this, " + rValue + ") == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
             case getAndSet:
@@ -90,18 +80,8 @@ public class Atomic_Updater_X implements Primitive {
         switch (relType) {
             case set:
                 return region + "g.set(this, " +setValue + ");";
-            case CAS:
+            case compareAndSet:
                 return region + "g.compareAndSet(this, " + defaultValue + ", " +setValue + ");";
-            case incrementAndGet:
-                return region + "g.incrementAndGet(this);";
-            case getAndIncrement:
-                return region + "g.getAndIncrement(this);";
-            case decrementAndGet:
-                return region + "g.decrementAndGet(this);";
-            case getAndDecrement:
-                return region + "g.getAndDecrement(this);";
-            case addAndGet:
-                return region + "g.addAndGet(this, " + rValue + ");";
             case getAndAdd:
                 return region + "g.getAndAdd(this, " + rValue + ");";
             case getAndSet:

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_X.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_X.java
@@ -51,8 +51,8 @@ public class Atomic_X implements Primitive {
         setValue = TestGenerator.getSetValue(primType);
 
         if (guardType == AtomicBoolean.class) {
-            if (!EnumSet.of(AcqType.get, AcqType.CAS).contains(acqType) ||
-                !EnumSet.of(RelType.set, RelType.CAS).contains(relType)) {
+            if (!EnumSet.of(AcqType.get, AcqType.compareAndSet).contains(acqType) ||
+                !EnumSet.of(RelType.set, RelType.compareAndSet).contains(relType)) {
                 throw new IllegalArgumentException();
             }
         }
@@ -66,7 +66,7 @@ public class Atomic_X implements Primitive {
     @Override
     public String printAcquire(String region) {
         switch (acqType) {
-            case CAS:
+            case compareAndSet:
                 return String.format("r.r1 = g.compareAndSet(%s, %s) ? %s : %s; \n" + region,
                         setValue,
                         defaultValue,
@@ -75,16 +75,6 @@ public class Atomic_X implements Primitive {
                 );
             case get:
                 return "r.r1 = g.get() == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case incrementAndGet:
-                return "r.r1 = g.incrementAndGet() == (" + defaultValue + " + " + unitValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
-            case getAndIncrement:
-                return "r.r1 = g.getAndIncrement() == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case decrementAndGet:
-                return "r.r1 = g.decrementAndGet() == (" + defaultValue + " - " + unitValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
-            case getAndDecrement:
-                return "r.r1 = g.getAndDecrement() == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
-            case addAndGet:
-                return "r.r1 = g.addAndGet(" + rValue + ") == (" + defaultValue + " + " + rValue + ") ? " + defaultValue + " : " + setValue + "; \n" + region;
             case getAndAdd:
                 return "r.r1 = g.getAndAdd(" + rValue + ") == " + defaultValue + "? " + defaultValue + " : " + setValue + " ; \n" + region;
             case getAndSet:
@@ -99,18 +89,8 @@ public class Atomic_X implements Primitive {
         switch (relType) {
             case set:
                 return region + "g.set(" +setValue + ");";
-            case CAS:
+            case compareAndSet:
                 return region + "g.compareAndSet(" + defaultValue + ", " +setValue + ");";
-            case incrementAndGet:
-                return region + "g.incrementAndGet();";
-            case getAndIncrement:
-                return region + "g.getAndIncrement();";
-            case decrementAndGet:
-                return region + "g.decrementAndGet();";
-            case getAndDecrement:
-                return region + "g.getAndDecrement();";
-            case addAndGet:
-                return region + "g.addAndGet(" + rValue + ");";
             case getAndAdd:
                 return region + "g.getAndAdd(" + rValue + ");";
             case getAndSet:

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/RelType.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/RelType.java
@@ -26,12 +26,7 @@ package org.openjdk.jcstress.generator;
 
 public enum RelType {
     set,
-    CAS,
-    incrementAndGet,
-    getAndIncrement,
-    decrementAndGet,
-    getAndDecrement,
-    addAndGet,
+    compareAndSet,
     getAndAdd,
     getAndSet,
 }

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
@@ -53,8 +53,8 @@ public class TestGenerator {
     }
 
     public void generateMemoryEffects() throws IOException {
-        for (Class<?> varType : Types.SUPPORTED_PRIMITIVES) {
-            for (Class<?> guardType : Types.SUPPORTED_PRIMITIVES) {
+        for (Class<?> varType : Types.VAR_PRIMITIVE_TYPES) {
+            for (Class<?> guardType : Types.GUARD_PRIMITIVE_TYPES) {
                 generate(new Types(guardType, varType), new VolatileReadWrite(guardType), "volatile_" + guardType + "_" + varType, "org.openjdk.jcstress.tests.memeffects.basic.volatiles");
             }
             generate(new Types(int.class, varType), new SynchronizedBlock(), "lock_" + varType, "org.openjdk.jcstress.tests.memeffects.basic.lock");
@@ -203,9 +203,13 @@ public class TestGenerator {
     }
 
     public static class Types {
-        public static final Class<?>[] SUPPORTED_PRIMITIVES =
+        public static final Class<?>[] GUARD_PRIMITIVE_TYPES =
                 new Class<?>[] { boolean.class, byte.class, short.class, char.class,
-                                 int.class, long.class, float.class, double.class};
+                                 int.class, long.class, float.class, double.class };
+
+        // At least one per data width, plus both shapes of floating point
+        public static final Class<?>[] VAR_PRIMITIVE_TYPES =
+                new Class<?>[] { byte.class, short.class, int.class, long.class, float.class, double.class };
 
         public static final Class<?>[] SUPPORTED_ATOMICS =
                 new Class<?>[] { AtomicInteger.class, AtomicLong.class, AtomicBoolean.class };

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
@@ -56,20 +56,31 @@ public class SeqCstTraceGenerator {
          */
         List<MultiThread> multiThreads = new ArrayList<>();
 
-        final int COUNT_THRESH = 6;
-        final int VAR_THRESH = 3;
-        final int THREAD_THRESH = 4;
+        // (ops, variables, threads)
+        int[][] triplets = {
+                {2, 1, 2},
 
-        for (int c = 1; c <= COUNT_THRESH; c++) {
-            int minVars = 1;
-            int maxVars = c;
-            for (int v = minVars; v <= Math.min(maxVars, VAR_THRESH); v++) {
-                int minThreads = Math.max(2, c / 2);
-                int maxThreads = c;
-                for (int t = minThreads; t <= Math.min(maxThreads, THREAD_THRESH); t++) {
-                    multiThreads.addAll(new Phase(c, v, t).run());
-                }
-            }
+                {3, 1, 2},
+
+                {4, 1, 2},
+                {4, 2, 2},
+                {4, 2, 3},
+                {4, 2, 4},
+
+                {5, 1, 3},
+                {5, 1, 4},
+                {5, 2, 3},
+                {5, 2, 4},
+
+                {6, 1, 4},
+                {6, 2, 4},
+                {6, 3, 3},
+                {6, 3, 4},
+        };
+
+        for (int[] tri : triplets) {
+            List<MultiThread> p = new Phase(tri[0], tri[1], tri[2]).run();
+            multiThreads.addAll(p);
         }
 
         System.out.println(multiThreads.size() + " interesting testcases");

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-ArrayAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-ArrayAtomicityTest.java.template
@@ -35,12 +35,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the element. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldAtomicityTest.java.template
@@ -35,12 +35,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldConflictAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldConflictAtomicityTest.java.template
@@ -35,12 +35,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Full store from T1.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "Full store from T2.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Conflicting stores: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Conflicting stores, persisting non-atomic result.")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleArrayAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleArrayAtomicityTest.java.template
@@ -38,12 +38,8 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
 @Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleByteArrayViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleByteArrayViewAtomicityTest.java.template
@@ -40,12 +40,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleDirectByteBufferViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleDirectByteBufferViewAtomicityTest.java.template
@@ -40,12 +40,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleFieldAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleFieldAtomicityTest.java.template
@@ -38,12 +38,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleHeapByteBufferViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleHeapByteBufferViewAtomicityTest.java.template
@@ -40,12 +40,7 @@ import org.openjdk.jcstress.infra.results.*;
 @JCStressTest
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "The value set by the actor thread. Observer sees the complete update.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleArrayAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleArrayAcqRelTest.java.template
@@ -46,17 +46,10 @@ import org.openjdk.jcstress.infra.results.*;
         "$defaultV$, $setV$, $setG$",
         "$setV$, $setV$, $setG$",
     }, expect = Expect.ACCEPTABLE, desc = "Observing the value for guard, allowed to see latest value.")
-#if[racy]
-@Outcome(id = {
-        "$defaultV$, $defaultV$, $setG$",
-        "$setV$, $defaultV$, $setG$",
-    }, expect = Expect.ACCEPTABLE, desc = "Seeing previous writes, allowed with racy guard.")
-#else[racy]
 @Outcome(id = {
         "$defaultV$, $defaultV$, $setG$",
         "$setV$, $defaultV$, $setG$",
     }, expect = Expect.FORBIDDEN, desc = "Seeing previous writes, forbidden with proper guard.")
-#end[racy]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleByteArrayViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleByteArrayViewAcqRelTest.java.template
@@ -48,17 +48,10 @@ import org.openjdk.jcstress.infra.results.*;
         "$defaultV$, $setV$, $setG$",
         "$setV$, $setV$, $setG$",
     }, expect = Expect.ACCEPTABLE, desc = "Observing the value for guard, allowed to see latest value.")
-#if[racy]
-@Outcome(id = {
-        "$defaultV$, $defaultV$, $setG$",
-        "$setV$, $defaultV$, $setG$",
-    }, expect = Expect.ACCEPTABLE, desc = "Seeing previous writes, allowed with racy guard.")
-#else[racy]
 @Outcome(id = {
         "$defaultV$, $defaultV$, $setG$",
         "$setV$, $defaultV$, $setG$",
     }, expect = Expect.FORBIDDEN, desc = "Seeing previous writes, forbidden with proper guard.")
-#end[racy]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleDirectByteBufferViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleDirectByteBufferViewAcqRelTest.java.template
@@ -48,17 +48,10 @@ import org.openjdk.jcstress.infra.results.*;
         "$defaultV$, $setV$, $setG$",
         "$setV$, $setV$, $setG$",
     }, expect = Expect.ACCEPTABLE, desc = "Observing the value for guard, allowed to see latest value.")
-#if[racy]
-@Outcome(id = {
-        "$defaultV$, $defaultV$, $setG$",
-        "$setV$, $defaultV$, $setG$",
-    }, expect = Expect.ACCEPTABLE, desc = "Seeing previous writes, allowed with racy guard.")
-#else[racy]
 @Outcome(id = {
         "$defaultV$, $defaultV$, $setG$",
         "$setV$, $defaultV$, $setG$",
     }, expect = Expect.FORBIDDEN, desc = "Seeing previous writes, forbidden with proper guard.")
-#end[racy]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleFieldAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleFieldAcqRelTest.java.template
@@ -46,17 +46,10 @@ import org.openjdk.jcstress.infra.results.*;
         "$defaultV$, $setV$, $setG$",
         "$setV$, $setV$, $setG$",
     }, expect = Expect.ACCEPTABLE, desc = "Observing the value for guard, allowed to see latest value.")
-#if[racy]
-@Outcome(id = {
-        "$defaultV$, $defaultV$, $setG$",
-        "$setV$, $defaultV$, $setG$",
-    }, expect = Expect.ACCEPTABLE, desc = "Seeing previous writes, allowed with racy guard.")
-#else[racy]
 @Outcome(id = {
         "$defaultV$, $defaultV$, $setG$",
         "$setV$, $defaultV$, $setG$",
     }, expect = Expect.FORBIDDEN, desc = "Seeing previous writes, forbidden with proper guard.")
-#end[racy]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleHeapByteBufferViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleHeapByteBufferViewAcqRelTest.java.template
@@ -48,17 +48,10 @@ import org.openjdk.jcstress.infra.results.*;
         "$defaultV$, $setV$, $setG$",
         "$setV$, $setV$, $setG$",
     }, expect = Expect.ACCEPTABLE, desc = "Observing the value for guard, allowed to see latest value.")
-#if[racy]
-@Outcome(id = {
-        "$defaultV$, $defaultV$, $setG$",
-        "$setV$, $defaultV$, $setG$",
-    }, expect = Expect.ACCEPTABLE, desc = "Seeing previous writes, allowed with racy guard.")
-#else[racy]
 @Outcome(id = {
         "$defaultV$, $defaultV$, $setG$",
         "$setV$, $defaultV$, $setG$",
     }, expect = Expect.FORBIDDEN, desc = "Seeing previous writes, forbidden with proper guard.")
-#end[racy]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-ArrayCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-ArrayCoherenceTest.java.template
@@ -36,15 +36,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-FieldCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-FieldCoherenceTest.java.template
@@ -36,15 +36,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleArrayCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleArrayCoherenceTest.java.template
@@ -39,15 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleByteArrayViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleByteArrayViewCoherenceTest.java.template
@@ -41,15 +41,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleDirectByteBufferViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleDirectByteBufferViewCoherenceTest.java.template
@@ -41,15 +41,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleFieldCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleFieldCoherenceTest.java.template
@@ -39,15 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleHeapByteBufferViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleHeapByteBufferViewCoherenceTest.java.template
@@ -41,15 +41,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$, $default$", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Allowed to see this: data race.")
 @Outcome(id = "$default$, $set$", expect = Expect.ACCEPTABLE, desc = "Observe second read, but not first: sequential consistency.")
 @Outcome(id = "$set$, $set$", expect = Expect.ACCEPTABLE, desc = "Observers sees both read.")
-#if[alwaysAtomic]
-#if[coherent]
 @Outcome(id = "$set$, $default$", expect = Expect.FORBIDDEN, desc = "Seeing first read, but not second: coherence violation.")
-#else[coherent]
-@Outcome(id = "$set$, $default$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Seeing first read, but not second: non-coherent.")
-#end[coherent]
-#else[alwaysAtomic]
-@Outcome(id = ".*, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic accesses are allowed.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-Arraycopy.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-Arraycopy.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 1, $default$", expect = Expect.ACCEPTABLE, desc = "Seeing array, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "true, 1, $set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = "true, 1, .*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-ArraysCopyOf.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-ArraysCopyOf.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 1, $default$", expect = Expect.ACCEPTABLE, desc = "Seeing array, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "true, 1, $set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = "true, 1, .*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-Clone.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-Clone.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 1, $default$", expect = Expect.ACCEPTABLE, desc = "Seeing array, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "true, 1, $set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = "true, 1, .*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraycopy.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraycopy.java.template
@@ -42,11 +42,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
 @Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-#if[alwaysAtomic]
 @Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
-#else[alwaysAtomic]
-@Outcome(id = "true, 2097152, 3", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default/weird")
-#end[alwaysAtomic]
 #end[safe]
 @State
 public class $name$ {

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraysCopyOf.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraysCopyOf.java.template
@@ -42,11 +42,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
 @Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-#if[alwaysAtomic]
 @Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
-#else[alwaysAtomic]
-@Outcome(id = "true, 2097152, 3", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default/weird")
-#end[alwaysAtomic]
 #end[safe]
 @State
 public class $name$ {

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeClone.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeClone.java.template
@@ -42,11 +42,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
 @Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-#if[alwaysAtomic]
 @Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
-#else[alwaysAtomic]
-@Outcome(id = "true, 2097152, 3", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default/weird")
-#end[alwaysAtomic]
 #end[safe]
 @State
 public class $name$ {

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeManual.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeManual.java.template
@@ -42,11 +42,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
 @Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-#if[alwaysAtomic]
 @Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
-#else[alwaysAtomic]
-@Outcome(id = "true, 2097152, 3", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default/weird")
-#end[alwaysAtomic]
 #end[safe]
 @State
 public class $name$ {

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-Manual.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-Manual.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "true, 1, $default$", expect = Expect.ACCEPTABLE, desc = "Seeing array, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "true, 1, $set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = "true, 1, .*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/objects/X-Clone.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/objects/X-Clone.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Seeing object, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = ".*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/copy/objects/X-Manual.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/objects/X-Manual.java.template
@@ -39,11 +39,7 @@ import org.openjdk.jcstress.infra.results.*;
 #else[safe]
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Seeing object, but not its contents.")
 #end[safe]
-#if[alwaysAtomic]
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "Seeing the complete update.")
-#else[alwaysAtomic]
-@Outcome(id = ".*", expect = Expect.ACCEPTABLE, desc = "Observing non-atomic write/read.")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-LoadLoadFenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-LoadLoadFenceTest.java.template
@@ -35,13 +35,7 @@ import java.lang.invoke.VarHandle;
 @Outcome(id = "$value0$, $value1$", expect = Expect.ACCEPTABLE, desc = "actor2 observe the variables after x is already updated but var hasn't yet")
 @Outcome(id = "$value1$, $value0$", expect = Expect.FORBIDDEN,  desc = "var won't be observed to be updated before x is updated")
 @Outcome(id = "$value1$, $value1$", expect = Expect.ACCEPTABLE,  desc = "actor2 observe the variables after actor1 update completely")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(id = "$value0$, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, when load x in actor2 before fullFence in actor1")
-@Outcome(id = ".*, $value1$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, if r1 is half-value, load x must get a full-value")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest1.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest1.java.template
@@ -35,12 +35,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$_Result;
 @Outcome(id = "$value1$, $value0$", expect = Expect.ACCEPTABLE, desc = "store $value1$ to var in actor1 before load var in actor2")
 @Outcome(id = "$value1$, $value1$", expect = Expect.FORBIDDEN,  desc = "can't load x after store var in actor1.")
 @Outcome(id = "$value0$, $value1$", expect = Expect.FORBIDDEN,  desc = "this won't happen even if load x after store var because only if r1 = $value1$ x may be assigned to $value1$ and then r2 can be $value1$ from x.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(id = ".*, $value0$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, r2 only can be assigned to 0.")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest2.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest2.java.template
@@ -35,12 +35,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$_Result;
 @Outcome(id = "$value1$, $value0$", expect = Expect.ACCEPTABLE, desc = "store $value1$ to y in actor1 before load y in actor2")
 @Outcome(id = "$value1$, $value1$", expect = Expect.FORBIDDEN,  desc = "can't load var after store y in actor1.")
 @Outcome(id = "$value0$, $value1$", expect = Expect.FORBIDDEN,  desc = "this won't happen even if load var after store y because only if r1 = $value1$ var may be assigned to $value1$ and then r2 can be $value1$ from var.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(id = ".*, $value0$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, r2 only can be assigned to 0.")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-StoreLoadFenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-StoreLoadFenceTest.java.template
@@ -36,14 +36,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$_Result;
 @Outcome(id = "$value0$, $value1$", expect = Expect.ACCEPTABLE,  desc = "actor2 observe actor1 update, actor1 not yet observe actor2 update")
 @Outcome(id = "$value1$, $value1$", expect = Expect.ACCEPTABLE,  desc = "both actor1 and actor2 observe each other update")
 @Outcome(id = "$value0$, $value0$", expect = Expect.FORBIDDEN, desc = "if r1 = 0, store var must be submitted already before fullFence in actor2, r2 must get the update")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-//if r1 is half-value or value0, store var is submitted before fullFence in actor2, r2 must be full-value, vice versa.
-@Outcome(id = "$value1$, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec.")
-@Outcome(id = ".*, $value1$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-StoreStoreFenceTest1.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-StoreStoreFenceTest1.java.template
@@ -36,13 +36,7 @@ import java.lang.invoke.VarHandle;
 @Outcome(id = "$value0$, $value1$", expect = Expect.ACCEPTABLE, desc = "actor2 observe the variables after x is already updated but var hasn't yet")
 @Outcome(id = "$value1$, $value0$", expect = Expect.FORBIDDEN,  desc = "var won't be observed to be updated before x is updated")
 @Outcome(id = "$value1$, $value1$", expect = Expect.ACCEPTABLE,  desc = "actor2 observe the variables after actor1 update completely")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(id = "$value0$, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, when load x in actor2 before storestore Fence in actor1")
-@Outcome(id = ".*, $value1$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, if r1 is half-value, load x must get a full-value")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/fences/X-StoreStoreFenceTest2.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-StoreStoreFenceTest2.java.template
@@ -36,13 +36,7 @@ import java.lang.invoke.VarHandle;
 @Outcome(id = "$value0$, $value1$", expect = Expect.ACCEPTABLE, desc = "actor2 observe the variables after var is already updated but y hasn't yet")
 @Outcome(id = "$value1$, $value0$", expect = Expect.FORBIDDEN,  desc = "y won't be observed to be updated before var is updated")
 @Outcome(id = "$value1$, $value1$", expect = Expect.ACCEPTABLE,  desc = "actor2 observe the variables after actor1 update completely")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(id = "$value0$, .*", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, when load var in actor2 before storestore Fence in actor1")
-@Outcome(id = ".*, $value1$", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec, if r1 is half-value, load var must get a full-value")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $TestClassName$ {
 

--- a/jcstress-test-gen/src/main/resources/init/X-FieldInitTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-FieldInitTest.java.template
@@ -37,12 +37,7 @@ import org.openjdk.jcstress.infra.results.*;
 @Outcome(id = "$default$", expect = Expect.ACCEPTABLE, desc = "Default value for the field. Allowed to see this: data race.")
 #end[!final]
 @Outcome(id = "$set$", expect = Expect.ACCEPTABLE, desc = "Seeing the set value.")
-#if[alwaysAtomic]
 @Outcome(expect = Expect.FORBIDDEN, desc = "Other values are forbidden: atomicity violation.")
-#else[alwaysAtomic]
-@Outcome(expect = Expect.ACCEPTABLE_INTERESTING, desc = "Non-atomic access detected, allowed by spec.")
-@Ref("http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7")
-#end[alwaysAtomic]
 @State
 public class $name$ {
 


### PR DESCRIPTION
Current tests-all counts about 10K tests. Not all of them are useful: many have only ACCEPTABLE outcomes, and show nothing useful in day-to-day testing. We can eliminate them, and thus reduce the number of tests considerably.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902879](https://bugs.openjdk.java.net/browse/CODETOOLS-7902879): jcstress: Reduce the number of auto-generated tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jcstress pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/26.diff">https://git.openjdk.java.net/jcstress/pull/26.diff</a>

</details>
