### PR TITLE
CODETOOLS-7902883: jcstress: Do only a few trial tests in GitHub Actions

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -34,9 +34,5 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.run-java }}
-    - name: Run all tests with "sanity" profile
-      run: java -jar tests-all/target/jcstress.jar -m sanity --jvmArgs "-XX:+UseParallelGC"
-      if: runner.os == 'Linux'
-    - name: Run custom tests with "sanity" profile
-      run: java -jar tests-custom/target/jcstress.jar -m sanity --jvmArgs "-XX:+UseParallelGC"
-      if: runner.os != 'Linux'
+    - name: Run a trial test
+      run: java -jar tests-custom/target/jcstress.jar -t UnfencedDekker

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 16-ea, 17-ea]
-        run-java: [8, 11, 16-ea, 17-ea]
+        build-java: [11, 17-ea]
+        run-java: [8, 11, 16, 17-ea]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}


### PR DESCRIPTION
The testing pipeline for jcstress is quite heavy, and it would become even more heavy-weight with upcoming affinity improvements. Instead of running sanity tests (which disables forking), we can execute a handful of trial tests in full compilation/affinity matrix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.java.net/jcstress pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/29.diff">https://git.openjdk.java.net/jcstress/pull/29.diff</a>

</details>
