### PR TITLE
CODETOOLS-7902884: jcstress: Fix new Sonar warnings

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
@@ -54,7 +54,7 @@ public class AffinitySupport {
     }
 
     static class Linux {
-        private static CLibrary INSTANCE;
+        private static volatile CLibrary INSTANCE;
 
         public static void tryInit() {
             if (INSTANCE == null) {


### PR DESCRIPTION
After recent commits, Sonar reports a few warnings. These should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902884](https://bugs.openjdk.java.net/browse/CODETOOLS-7902884): jcstress: Fix new Sonar warnings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.java.net/jcstress pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/31.diff">https://git.openjdk.java.net/jcstress/pull/31.diff</a>

</details>
