### PR TITLE
CODETOOLS-7902903: jcstress: Optimize sanity preset mode

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -198,32 +198,33 @@ public class Options {
 
         this.spinStyle = orDefault(set.valueOf(spinStyle), SpinLoopStyle.THREAD_SPIN_WAIT);
 
+        this.time = 1000;
+        this.iters = 5;
+        this.forks = 1;
+        this.minStride = 10;
+        this.maxStride = 10000;
+        this.deoptMode = DeoptMode.ALL;
+
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {
-            this.time = 1;
+            this.time = 0;
             this.iters = 1;
             this.forks = 1;
-            this.minStride = 10;
-            this.maxStride = 10;
+            this.minStride = 1;
+            this.maxStride = 1;
             this.deoptMode = DeoptMode.NONE;
         } else
         if (this.mode.equalsIgnoreCase("quick")) {
             this.time = 200;
-            this.iters = 5;
-            this.forks = 1;
         } else
         if (this.mode.equalsIgnoreCase("default")) {
-            this.time = 1000;
-            this.iters = 5;
-            this.forks = 1;
+            // Nothing changed.
         } else
         if (this.mode.equalsIgnoreCase("tough")) {
-            this.time = 1000;
             this.iters = 10;
             this.forks = 10;
         } else
         if (this.mode.equalsIgnoreCase("stress")) {
-            this.time = 1000;
             this.iters = 50;
             this.forks = 10;
         } else {
@@ -237,10 +238,10 @@ public class Options {
         this.time = orDefault(set.valueOf(time), this.time);
         this.iters = orDefault(set.valueOf(iters), this.iters);
         this.forks = orDefault(set.valueOf(forks), this.forks);
-        this.deoptMode = orDefault(set.valueOf(deoptMode), DeoptMode.ALL);
+        this.deoptMode = orDefault(set.valueOf(deoptMode), this.deoptMode);
+        this.minStride = orDefault(set.valueOf(minStride), this.minStride);
+        this.maxStride = orDefault(set.valueOf(maxStride), this.maxStride);
 
-        this.minStride = orDefault(set.valueOf(minStride), 10);
-        this.maxStride = orDefault(set.valueOf(maxStride), 10000);
         this.heapPerFork = orDefault(set.valueOf(heapPerFork), 256);
 
         this.jvmArgs = processArgs(optJvmArgs, set);


### PR DESCRIPTION
It looks like "sanity" mode ignores the min/max stride settings, and so we enter sanityCheck_Footprints for it, producing more samples than we need. This makes "sanity" unnecessarily slow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902903](https://bugs.openjdk.java.net/browse/CODETOOLS-7902903): jcstress: Optimize sanity preset mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/jcstress pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/34.diff">https://git.openjdk.java.net/jcstress/pull/34.diff</a>

</details>
