### PR TITLE
CODETOOLS-7902904: jcstress: Explicit waits for VM shutdowns

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -26,6 +26,7 @@ package org.openjdk.jcstress;
 
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.link.BinaryLinkClient;
+import org.openjdk.jcstress.os.AffinitySupport;
 import org.openjdk.jcstress.vm.WhiteBoxSupport;
 
 /**
@@ -47,7 +48,7 @@ public class ForkedMain {
         }
 
         String host = args[0];
-        int port = Integer.valueOf(args[1]);
+        int port = Integer.parseInt(args[1]);
         String token = args[2];
 
         BinaryLinkClient link = new BinaryLinkClient(host, port);
@@ -57,6 +58,8 @@ public class ForkedMain {
         while ((config = link.nextJob(token)) != null) {
             executor.run(config);
         }
+
+        link.done(token);
     }
 
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
@@ -82,4 +82,12 @@ public final class BinaryLinkClient {
             throw new IllegalStateException(e);
         }
     }
+
+    public void done(String token) {
+        try {
+            requestResponse(new DoneFrame(token));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
@@ -128,6 +128,10 @@ public final class BinaryLinkServer {
                             ResultsFrame rf = (ResultsFrame) obj;
                             listener.onResult(rf.getToken(), rf.getRes());
                             oos.writeObject(new OkResponseFrame());
+                        } else if (obj instanceof DoneFrame) {
+                            String tkn = ((DoneFrame) obj).getToken();
+                            listener.onDone(tkn);
+                            oos.writeObject(new OkResponseFrame());
                         } else {
                             // should always reply something
                             oos.writeObject(new WTFWasThatFrame());

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/DoneFrame.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/DoneFrame.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.link;
+
+import java.io.Serializable;
+
+class DoneFrame implements Serializable {
+    private static final long serialVersionUID = -4528163874292325861L;
+
+    private final String token;
+
+    public DoneFrame(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
@@ -33,4 +33,6 @@ public interface ServerListener {
 
     void onResult(String token, TestResult result);
 
+    void onDone(String token);
+
 }


### PR DESCRIPTION
Current TestExecutor code spins in the 100ms-wait loop for re-starting the next epoch of scheduling. This is way too large a wait for -m sanity. Reducing it to 10ms throws the non-sanity runs under the bus. We should instead do explicit waits for VM shutdown, and restart the scheduling then.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902904](https://bugs.openjdk.java.net/browse/CODETOOLS-7902904): jcstress: Explicit waits for VM shutdowns


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jcstress pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/35.diff">https://git.openjdk.java.net/jcstress/pull/35.diff</a>

</details>
