### PR TITLE
CODETOOLS-7902905: jcstress: Improve scheduling performance

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/SerializedBufferCollector.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/SerializedBufferCollector.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jcstress.infra.collectors;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +45,7 @@ public class SerializedBufferCollector implements TestResultCollector {
 
     public SerializedBufferCollector(TestResultCollector dst) {
         sink = dst;
-        results = new LinkedBlockingQueue<>();
+        results = new ArrayBlockingQueue<>(1024);
         processor = new Thread(this::work);
         processor.setName(SerializedBufferCollector.class.getName() + " processor thread");
         processor.setDaemon(true);
@@ -78,6 +79,10 @@ public class SerializedBufferCollector implements TestResultCollector {
 
     @Override
     public void add(TestResult result) {
-        results.add(result);
+        try {
+            results.put(result);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/HashMultimap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/HashMultimap.java
@@ -49,11 +49,7 @@
 package org.openjdk.jcstress.util;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class HashMultimap<K, V> implements Multimap<K, V>, Serializable {
 
@@ -85,6 +81,11 @@ public class HashMultimap<K, V> implements Multimap<K, V>, Serializable {
     }
 
     @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
+    }
+
+    @Override
     public void clear() {
         map.clear();
     }
@@ -111,5 +112,20 @@ public class HashMultimap<K, V> implements Multimap<K, V>, Serializable {
     @Override
     public void remove(K key) {
         map.remove(key);
+    }
+
+    @Override
+    public V removeLast(K key) {
+        Collection<V> vs = map.get(key);
+        if (!vs.isEmpty()) {
+            List<V> list = (List<V>) vs;
+            V v = list.remove(list.size() - 1);
+            if (list.isEmpty()) {
+                map.remove(key);
+            }
+            return v;
+        } else {
+            return null;
+        }
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/Multimap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/Multimap.java
@@ -97,4 +97,7 @@ public interface Multimap<K, V> {
 
     void remove(K key);
 
+    V removeLast(K key);
+
+    boolean containsKey(K key);
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/TreeMultimap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/TreeMultimap.java
@@ -49,11 +49,7 @@
 package org.openjdk.jcstress.util;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 public class TreeMultimap<K, V> implements Multimap<K, V>, Serializable {
 
@@ -111,5 +107,15 @@ public class TreeMultimap<K, V> implements Multimap<K, V>, Serializable {
     @Override
     public void remove(K key) {
         map.remove(key);
+    }
+
+    @Override
+    public V removeLast(K key) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/TreesetMultimap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/TreesetMultimap.java
@@ -49,12 +49,7 @@
 package org.openjdk.jcstress.util;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeSet;
+import java.util.*;
 
 public class TreesetMultimap<K, V> implements Multimap<K, V>, Serializable {
 
@@ -112,5 +107,15 @@ public class TreesetMultimap<K, V> implements Multimap<K, V>, Serializable {
     @Override
     public void remove(K key) {
         map.remove(key);
+    }
+
+    @Override
+    public V removeLast(K key) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
     }
 }


### PR DESCRIPTION
Current scheduler walks the entire TestConfig list on every scheduling epoch. This was observed to be a bottleneck on large machines: the scheduler is unable to feed the entire machine with jobs. We can do much better by trying each scheduling class exactly once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902905](https://bugs.openjdk.java.net/browse/CODETOOLS-7902905): jcstress: Improve scheduling performance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jcstress pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/36.diff">https://git.openjdk.java.net/jcstress/pull/36.diff</a>

</details>
