### PR TITLE
CODETOOLS-7902907: jcstress: Change "FAILED" to "N/A" in probing code

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
@@ -59,7 +59,7 @@ public class OSSupport {
             System.out.printf("----- %s %s%n", "[OK]", "Trying to set per-thread affinity with syscalls");
             AFFINITY_SUPPORT_AVAILABLE = true;
         } catch (Throwable e) {
-            System.out.printf("----- %s %s%n", "[FAILED]", "Trying to set per-thread affinity with syscalls");
+            System.out.printf("----- %s %s%n", "[N/A]", "Trying to set per-thread affinity with syscalls");
             System.out.println(e.getMessage());
             AFFINITY_SUPPORT_AVAILABLE = false;
         }
@@ -73,7 +73,7 @@ public class OSSupport {
             System.out.printf("----- %s %s%n", "[OK]", label);
             return true;
         } catch (VMSupportException ex) {
-            System.out.printf("----- %s %s%n", "[FAILED]", label);
+            System.out.printf("----- %s %s%n", "[N/A]", label);
             System.out.println(ex.getMessage());
             return false;
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -258,7 +258,7 @@ public class VMSupport {
             System.out.printf("----- %s %s%n", "[OK]", label);
             return true;
         } catch (VMSupportException ex) {
-            System.out.printf("----- %s %s%n", "[FAILED]", label);
+            System.out.printf("----- %s %s%n", "[N/A]", label);
             System.out.println(ex.getMessage());
             return false;
         }


### PR DESCRIPTION
"FAILED" confuses users when received from the fairly innocuous code. "N/A" should work better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902907](https://bugs.openjdk.java.net/browse/CODETOOLS-7902907): jcstress: Change "FAILED" to "N/A" in probing code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jcstress pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/38.diff">https://git.openjdk.java.net/jcstress/pull/38.diff</a>

</details>
