### PR TITLE
CODETOOLS-7902910: jcstress: Avoid creating lots of temporary files

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/InputStreamCollector.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/InputStreamCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.util;
+
+import java.io.*;
+import java.nio.Buffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class InputStreamCollector extends Thread {
+
+    private final InputStream in;
+    private final List<String> list;
+
+    public InputStreamCollector(InputStream in) {
+        this.in = in;
+        this.list = new ArrayList<>();
+    }
+
+    public void run() {
+        try (InputStreamReader isr = new InputStreamReader(in);
+             BufferedReader br = new BufferedReader(isr)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                list.add(line);
+            }
+        } catch (IOException e) {
+            // Do nothing.
+        }
+    }
+
+    public List<String> getOutput() {
+        return list;
+    }
+
+}


### PR DESCRIPTION
jcstress puts stdin and stdout into separate temporary files. It makes little sense, as the host VM would read those files into memory anyway. We can just buffer those to memory.

Additionally, we can stop creating compiler directives file when it is not needed.
Options

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902910](https://bugs.openjdk.java.net/browse/CODETOOLS-7902910): jcstress: Avoid creating lots of temporary files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/jcstress pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/41.diff">https://git.openjdk.java.net/jcstress/pull/41.diff</a>

</details>
