### PR TITLE
CODETOOLS-7902911: jcstress: Fix new Sonar warnings

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -96,7 +96,7 @@ public class TestExecutor {
 
     private void notifyChanged() {
         synchronized (notifyLock) {
-            notifyLock.notify();
+            notifyLock.notifyAll();
         }
     }
 
@@ -384,6 +384,10 @@ public class TestExecutor {
                 if (ecode != 0) {
                     result = new TestResult(task, Status.VM_ERROR);
                     result.addMessage("Failed with error code " + ecode);
+                }
+                if (result == null) {
+                    result = new TestResult(task, Status.VM_ERROR);
+                    result.addMessage("Harness error, no result generated");
                 }
                 result.addVMOuts(outCollector.getOutput());
                 result.addVMErrs(errCollector.getOutput());


### PR DESCRIPTION
Recent work introduced a few new complaints from Sonar. Let us fix them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902911](https://bugs.openjdk.java.net/browse/CODETOOLS-7902911): jcstress: Fix new Sonar warnings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jcstress pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/42.diff">https://git.openjdk.java.net/jcstress/pull/42.diff</a>

</details>
