### PR TITLE
CODETOOLS-7902916: jcstress: Pass a limited subset of TestConfig to the forked VMs

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -26,6 +26,7 @@ package org.openjdk.jcstress;
 
 import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.Runner;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.link.BinaryLinkClient;
@@ -67,20 +68,20 @@ public class ForkedMain {
             }
         });
 
-        TestConfig config = link.nextJob(token);
+        ForkedTestConfig config = link.nextJob(token);
 
         TestResult result;
 
         try {
             Class<?> aClass = Class.forName(config.generatedRunnerName);
-            Constructor<?> cnstr = aClass.getConstructor(TestConfig.class, ExecutorService.class);
+            Constructor<?> cnstr = aClass.getConstructor(ForkedTestConfig.class, ExecutorService.class);
             Runner<?> o = (Runner<?>) cnstr.newInstance(config, pool);
             result = o.run();
         } catch (ClassFormatError | NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
-            result = new TestResult(config, Status.API_MISMATCH);
+            result = new TestResult(Status.API_MISMATCH);
             result.addMessage(StringUtils.getStacktrace(e));
         } catch (Throwable ex) {
-            result = new TestResult(config, Status.TEST_ERROR);
+            result = new TestResult(Status.TEST_ERROR);
             result.addMessage(StringUtils.getStacktrace(ex));
         }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -28,7 +28,6 @@ import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.Runner;
-import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.link.BinaryLinkClient;
 import org.openjdk.jcstress.util.StringUtils;
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class TestResult implements Serializable {
 
-    private final TestConfig config;
+    private TestConfig config;
     private final Status status;
     private final Multiset<String> states;
     private volatile Environment env;
@@ -50,13 +50,16 @@ public class TestResult implements Serializable {
     private final List<String> vmOut;
     private final List<String> vmErr;
 
-    public TestResult(TestConfig config, Status status) {
-        this.config = config;
+    public TestResult(Status status) {
         this.status = status;
         this.states = new HashMultiset<>();
         this.messages = new ArrayList<>();
         this.vmOut = new ArrayList<>();
         this.vmErr = new ArrayList<>();
+    }
+
+    public void setConfig(TestConfig config) {
+        this.config = config;
     }
 
     public void addState(String result, long count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -102,7 +102,8 @@ public class ReportUtils {
             vmErrs.addAll(r.getVmErr());
         }
 
-        TestResult root = new TestResult(config, status);
+        TestResult root = new TestResult(status);
+        root.setConfig(config);
 
         for (String s : stateCounts.keys()) {
             root.addState(s, stateCounts.count(s));

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -330,7 +330,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("    " + r + "[] gr;");
         pw.println();
 
-        pw.println("    public " + className + "(TestConfig config, ExecutorService pool) {");
+        pw.println("    public " + className + "(ForkedTestConfig config, ExecutorService pool) {");
         pw.println("        super(config, pool, \"" + getQualifiedName(info.getTest()) + "\");");
         pw.println("    }");
         pw.println();
@@ -567,7 +567,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println();
             pw.println("    private Counter<" + r + "> " + TASK_LOOP_PREFIX + a.getSimpleName() + "() {");
             pw.println("        Counter<" + r + "> counter = new Counter<>();");
-            pw.println("        AffinitySupport.bind(config.cpuMap.actorMap()[" + n + "]);");
+            pw.println("        AffinitySupport.bind(config.actorMap[" + n + "]);");
             pw.println("        while (true) {");
             pw.println("            WorkerSync sync = workerSync;");
             pw.println("            if (sync.stopped) {");
@@ -774,7 +774,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("public class " + generatedName + " extends Runner<" + generatedName + ".Outcome> {");
         pw.println();
 
-        pw.println("    public " + generatedName + "(TestConfig config, ExecutorService pool) {");
+        pw.println("    public " + generatedName + "(ForkedTestConfig config, ExecutorService pool) {");
         pw.println("        super(config, pool, \"" + getQualifiedName(info.getTest()) + "\");");
         pw.println("    }");
         pw.println();
@@ -953,7 +953,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
         Class<?>[] imports = new Class<?>[] {
                 ArrayList.class, Arrays.class, Collection.class,
                 ExecutorService.class, Future.class, TimeUnit.class,
-                TestConfig.class, TestResult.class,
+                ForkedTestConfig.class, TestResult.class,
                 Runner.class, WorkerSync.class, Counter.class,
                 ExecutionException.class,
                 Callable.class, Collections.class, List.class,

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -24,38 +24,54 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
-import org.openjdk.jcstress.os.SchedulingClass;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.os.CPUMap;
+import org.openjdk.jcstress.os.SchedulingClass;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-public class TestConfig implements Serializable {
+public class ForkedTestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
     public final int time;
     public final int iters;
     public final int threads;
     public final String name;
     public final String generatedRunnerName;
-    public final List<String> jvmArgs;
-    public final int forkId;
     public final int maxFootprintMB;
-    public final List<String> actorNames;
     public final int compileMode;
-    public final SchedulingClass shClass;
     public int minStride;
     public int maxStride;
+    public StrideCap strideCap;
     public CPUMap cpuMap;
 
     public void setCPUMap(CPUMap cpuMap) {
         this.cpuMap = cpuMap;
     }
 
-    public TestConfig(Options opts, TestInfo info, int forkId, List<String> jvmArgs, int compileMode, SchedulingClass scl) {
-        this.forkId = forkId;
-        this.jvmArgs = jvmArgs;
+    public enum StrideCap {
+        NONE,
+        FOOTPRINT,
+        TIME,
+    }
+
+    public ForkedTestConfig(TestConfig cfg) {
+        spinLoopStyle = cfg.spinLoopStyle;
+        time = cfg.time;
+        iters = cfg.iters;
+        threads = cfg.threads;
+        name = cfg.name;
+        generatedRunnerName = cfg.generatedRunnerName;
+        maxFootprintMB = cfg.maxFootprintMB;
+        compileMode = cfg.compileMode;
+        minStride = cfg.minStride;
+        maxStride = cfg.minStride;
+        cpuMap = cfg.cpuMap;
+    }
+
+    public ForkedTestConfig(Options opts, TestInfo info, int compileMode) {
         time = opts.getTime();
         minStride = opts.getMinStride();
         maxStride = opts.getMaxStride();
@@ -65,17 +81,66 @@ public class TestConfig implements Serializable {
         threads = info.threads();
         name = info.name();
         generatedRunnerName = info.generatedRunner();
-        actorNames = info.actorNames();
         this.compileMode = compileMode;
-        shClass = scl;
+        strideCap = StrideCap.NONE;
+    }
+
+    public void adjustStrides(FootprintEstimator estimator) {
+        int count = 1;
+        int succCount = count;
+        while (true) {
+            StrideCap cap = tryWith(estimator, count);
+            if (cap != StrideCap.NONE) {
+                strideCap = cap;
+                break;
+            }
+
+            // success!
+            succCount = count;
+
+            // do not go over the maxStride
+            if (succCount >= maxStride) {
+                succCount = maxStride;
+                break;
+            }
+
+            count *= 2;
+        }
+
+        maxStride = Math.min(maxStride, succCount);
+        minStride = Math.min(minStride, succCount);
+    }
+
+    public interface FootprintEstimator {
+        void runWith(int size, long[] counters);
+    }
+
+    private StrideCap tryWith(FootprintEstimator estimator, int count) {
+        try {
+            long[] cnts = new long[2];
+            estimator.runWith(count, cnts);
+            long footprint = cnts[0];
+            long usedTime = cnts[1];
+
+            if (footprint > maxFootprintMB * 1024 * 1024) {
+                // blown the footprint estimate
+                return StrideCap.FOOTPRINT;
+            }
+
+            if (TimeUnit.NANOSECONDS.toMillis(usedTime) > time) {
+                // blown the time estimate
+                return StrideCap.TIME;
+            }
+
+        } catch (OutOfMemoryError err) {
+            // blown the heap size
+            return StrideCap.FOOTPRINT;
+        }
+        return StrideCap.NONE;
     }
 
     public int getCompileMode() {
         return compileMode;
-    }
-
-    public SchedulingClass getSchedulingClass() {
-        return shClass;
     }
 
     @Override
@@ -83,7 +148,7 @@ public class TestConfig implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        TestConfig that = (TestConfig) o;
+        ForkedTestConfig that = (ForkedTestConfig) o;
 
         if (!name.equals(that.name)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
@@ -93,8 +158,6 @@ public class TestConfig implements Serializable {
         if (iters != that.iters) return false;
         if (threads != that.threads) return false;
         if (compileMode != that.compileMode) return false;
-        if (!jvmArgs.equals(that.jvmArgs)) return false;
-        if (!shClass.equals(that.shClass)) return false;
         return true;
     }
 
@@ -103,8 +166,4 @@ public class TestConfig implements Serializable {
         return name.hashCode();
     }
 
-    @Override
-    public String toString() {
-        return "JVM options: " + jvmArgs +"; Compile mode: " + getCompileMode();
-    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -109,25 +109,4 @@ public class ForkedTestConfig implements Serializable {
         return StrideCap.NONE;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ForkedTestConfig that = (ForkedTestConfig) o;
-
-        if (!generatedRunnerName.equals(that.generatedRunnerName)) return false;
-        if (spinLoopStyle != that.spinLoopStyle) return false;
-        if (minStride != that.minStride) return false;
-        if (maxStride != that.maxStride) return false;
-        if (time != that.time) return false;
-        if (iters != that.iters) return false;
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return generatedRunnerName.hashCode();
-    }
-
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -24,32 +24,19 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
-import org.openjdk.jcstress.Options;
-import org.openjdk.jcstress.infra.TestInfo;
-import org.openjdk.jcstress.os.CPUMap;
-import org.openjdk.jcstress.os.SchedulingClass;
-
 import java.io.Serializable;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class ForkedTestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
     public final int time;
     public final int iters;
-    public final int threads;
-    public final String name;
     public final String generatedRunnerName;
     public final int maxFootprintMB;
-    public final int compileMode;
     public int minStride;
     public int maxStride;
-    public StrideCap strideCap;
-    public CPUMap cpuMap;
-
-    public void setCPUMap(CPUMap cpuMap) {
-        this.cpuMap = cpuMap;
-    }
+    public transient StrideCap strideCap;
+    public int[] actorMap;
 
     public enum StrideCap {
         NONE,
@@ -61,28 +48,11 @@ public class ForkedTestConfig implements Serializable {
         spinLoopStyle = cfg.spinLoopStyle;
         time = cfg.time;
         iters = cfg.iters;
-        threads = cfg.threads;
-        name = cfg.name;
         generatedRunnerName = cfg.generatedRunnerName;
         maxFootprintMB = cfg.maxFootprintMB;
-        compileMode = cfg.compileMode;
         minStride = cfg.minStride;
         maxStride = cfg.minStride;
-        cpuMap = cfg.cpuMap;
-    }
-
-    public ForkedTestConfig(Options opts, TestInfo info, int compileMode) {
-        time = opts.getTime();
-        minStride = opts.getMinStride();
-        maxStride = opts.getMaxStride();
-        iters = opts.getIterations();
-        spinLoopStyle = opts.getSpinStyle();
-        maxFootprintMB = opts.getMaxFootprintMb();
-        threads = info.threads();
-        name = info.name();
-        generatedRunnerName = info.generatedRunner();
-        this.compileMode = compileMode;
-        strideCap = StrideCap.NONE;
+        actorMap = cfg.cpuMap.actorMap();
     }
 
     public void adjustStrides(FootprintEstimator estimator) {
@@ -139,10 +109,6 @@ public class ForkedTestConfig implements Serializable {
         return StrideCap.NONE;
     }
 
-    public int getCompileMode() {
-        return compileMode;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -150,20 +116,18 @@ public class ForkedTestConfig implements Serializable {
 
         ForkedTestConfig that = (ForkedTestConfig) o;
 
-        if (!name.equals(that.name)) return false;
+        if (!generatedRunnerName.equals(that.generatedRunnerName)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
         if (minStride != that.minStride) return false;
         if (maxStride != that.maxStride) return false;
         if (time != that.time) return false;
         if (iters != that.iters) return false;
-        if (threads != that.threads) return false;
-        if (compileMode != that.compileMode) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return generatedRunnerName.hashCode();
     }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -26,7 +26,6 @@ package org.openjdk.jcstress.infra.runners;
 
 import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.TestResult;
-import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.util.Counter;
 import org.openjdk.jcstress.util.StringUtils;
 
@@ -50,10 +49,10 @@ public abstract class Runner<R> {
     protected final Control control;
     protected final ExecutorService pool;
     protected final String testName;
-    protected final TestConfig config;
+    protected final ForkedTestConfig config;
     protected final List<String> messages;
 
-    public Runner(TestConfig config, ExecutorService pool, String testName) {
+    public Runner(ForkedTestConfig config, ExecutorService pool, String testName) {
         this.pool = pool;
         this.testName = testName;
         this.control = new Control();
@@ -113,7 +112,7 @@ public abstract class Runner<R> {
     }
 
     private TestResult prepareResult(Status status) {
-        TestResult result = new TestResult(config, status);
+        TestResult result = new TestResult(status);
         for (String msg : messages) {
             result.addMessage(msg);
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
@@ -26,7 +26,6 @@ package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.*;
 import java.net.Socket;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkClient.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.*;
@@ -66,7 +67,7 @@ public final class BinaryLinkClient {
         }
     }
 
-    public TestConfig nextJob(String token) throws IOException {
+    public ForkedTestConfig nextJob(String token) throws IOException {
         Object reply = requestResponse(new JobRequestFrame(token));
         if (reply instanceof JobResponseFrame) {
             return ((JobResponseFrame) reply).getConfig();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jcstress.link;
 
+import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.*;
@@ -122,7 +123,7 @@ public final class BinaryLinkServer {
                          ObjectOutputStream oos = new ObjectOutputStream(bos)) {
                         if (obj instanceof JobRequestFrame) {
                             String tkn = ((JobRequestFrame) obj).getToken();
-                            TestConfig cfg = listener.onJobRequest(tkn);
+                            ForkedTestConfig cfg = listener.onJobRequest(tkn);
                             oos.writeObject(new JobResponseFrame(cfg));
                         } else if (obj instanceof ResultsFrame) {
                             ResultsFrame rf = (ResultsFrame) obj;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/BinaryLinkServer.java
@@ -25,7 +25,6 @@
 package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.*;
 import java.net.*;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/JobResponseFrame.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/JobResponseFrame.java
@@ -25,7 +25,6 @@
 package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.Serializable;
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/JobResponseFrame.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/JobResponseFrame.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jcstress.link;
 
+import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.Serializable;
@@ -31,13 +32,13 @@ import java.io.Serializable;
 class JobResponseFrame implements Serializable {
     private static final long serialVersionUID = 2082214387637725282L;
 
-    private final TestConfig config;
+    private final ForkedTestConfig config;
 
-    public JobResponseFrame(TestConfig config) {
+    public JobResponseFrame(ForkedTestConfig config) {
         this.config = config;
     }
 
-    public TestConfig getConfig() {
+    public ForkedTestConfig getConfig() {
         return config;
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
@@ -25,11 +25,12 @@
 package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 
 public interface ServerListener {
 
-    TestConfig onJobRequest(String token);
+    ForkedTestConfig onJobRequest(String token);
 
     void onResult(String token, TestResult result);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/link/ServerListener.java
@@ -26,7 +26,6 @@ package org.openjdk.jcstress.link;
 
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
 
 public interface ServerListener {
 


### PR DESCRIPTION
Current TestConfig is serialized and passed in full to the forked VMs. It carries a lot of baggage that forked VM does not really care about. We can instead pass a very limited subset of it. It also opens the way to use the small non-Java-Serialization format later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902916](https://bugs.openjdk.java.net/browse/CODETOOLS-7902916): jcstress: Pass a limited subset of TestConfig to the forked VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jcstress pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/44.diff">https://git.openjdk.java.net/jcstress/pull/44.diff</a>

</details>
