### PR TITLE
CODETOOLS-7902917: jcstress: Errors during interruption tests

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -787,11 +787,11 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("            run(results);");
         pw.println();
         pw.println("            if (results.count(Outcome.STALE) > 0) {");
-        pw.println("                messages.add(\"Have stale threads, forcing VM to exit for proper cleanup.\");");
-        pw.println("                dump(results);");
-        pw.println("                System.exit(0);");
+        pw.println("                forceExit = true;");
+        pw.println("                break;");
         pw.println("            }");
         pw.println("        }");
+        pw.println();
         pw.println("        return dump(results);");
         pw.println("    }");
         pw.println();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -51,6 +51,7 @@ public abstract class Runner<R> {
     protected final String testName;
     protected final ForkedTestConfig config;
     protected final List<String> messages;
+    protected volatile boolean forceExit;
 
     public Runner(ForkedTestConfig config, ExecutorService pool, String testName) {
         this.pool = pool;
@@ -138,6 +139,10 @@ public abstract class Runner<R> {
              result.addState(String.valueOf(e), cnt.count(e));
         }
         return result;
+    }
+
+    public boolean forceExit() {
+        return forceExit;
     }
 
     public abstract Counter<R> sanityCheck() throws Throwable;


### PR DESCRIPTION
This is a regression since CODETOOLS-7902906. The interruption tests would never reply the result, because they call System.exit(0) before binary link is able to push the result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902917](https://bugs.openjdk.java.net/browse/CODETOOLS-7902917): jcstress: Errors during interruption tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jcstress pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/45.diff">https://git.openjdk.java.net/jcstress/pull/45.diff</a>

</details>
