### PR TITLE
CODETOOLS-7902918: jcstress: Replace the relevant uses of HashMultiset with Counter

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -30,8 +30,6 @@ import org.openjdk.jcstress.infra.grading.TestGrading;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.util.Counter;
 import org.openjdk.jcstress.util.Environment;
-import org.openjdk.jcstress.util.HashMultiset;
-import org.openjdk.jcstress.util.Multiset;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -150,5 +148,13 @@ public class TestResult implements Serializable {
 
     public boolean isEmpty() {
         return states.isEmpty();
+    }
+
+    public Counter<String> getCounter() {
+        return states;
+    }
+
+    public void addState(Counter<String> other) {
+        states.merge(other);
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -145,7 +145,7 @@ public class TestResult implements Serializable {
         return TestGrading.grade(this);
     }
 
-    public boolean hasSamples() {
-        return !states.isEmpty();
+    public boolean isEmpty() {
+        return states.isEmpty();
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -28,6 +28,7 @@ import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.grading.ReportUtils;
 import org.openjdk.jcstress.infra.grading.TestGrading;
 import org.openjdk.jcstress.infra.runners.TestConfig;
+import org.openjdk.jcstress.util.Counter;
 import org.openjdk.jcstress.util.Environment;
 import org.openjdk.jcstress.util.HashMultiset;
 import org.openjdk.jcstress.util.Multiset;
@@ -44,7 +45,7 @@ public class TestResult implements Serializable {
 
     private final TestConfig config;
     private final Status status;
-    private final Multiset<String> states;
+    private final Counter<String> states;
     private volatile Environment env;
     private final List<String> messages;
     private final List<String> vmOut;
@@ -53,14 +54,14 @@ public class TestResult implements Serializable {
     public TestResult(TestConfig config, Status status) {
         this.config = config;
         this.status = status;
-        this.states = new HashMultiset<>();
+        this.states = new Counter<>();
         this.messages = new ArrayList<>();
         this.vmOut = new ArrayList<>();
         this.vmErr = new ArrayList<>();
     }
 
     public void addState(String result, long count) {
-        states.add(result, count);
+        states.record(result, count);
     }
 
     public void addMessage(String msg) {
@@ -125,7 +126,7 @@ public class TestResult implements Serializable {
     }
 
     public long getTotalCount() {
-        return states.size();
+        return states.totalCount();
     }
 
     public long getCount(String s) {
@@ -133,7 +134,7 @@ public class TestResult implements Serializable {
     }
 
     public Collection<String> getStateKeys() {
-        return states.keys();
+        return states.elementSet();
     }
 
     public TestConfig getConfig() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -82,21 +82,18 @@ public class ReportUtils {
     }
 
     private static TestResult merged(TestConfig config, Collection<TestResult> mergeable) {
-        Multiset<String> stateCounts = new HashMultiset<>();
+        Counter<String> counter = new Counter<>();
 
         List<String> messages = new ArrayList<>();
-
         List<String> vmOuts = new ArrayList<>();
         List<String> vmErrs = new ArrayList<>();
 
         Status status = Status.NORMAL;
         Environment env = null;
         for (TestResult r : mergeable) {
-            status = status.combine(r.status());
-            for (String s : r.getStateKeys()) {
-                stateCounts.add(s, r.getCount(s));
-            }
             env = r.getEnv();
+            status = status.combine(r.status());
+            counter.merge(r.getCounter());
             messages.addAll(r.getMessages());
             vmOuts.addAll(r.getVmOut());
             vmErrs.addAll(r.getVmErr());
@@ -104,17 +101,9 @@ public class ReportUtils {
 
         TestResult root = new TestResult(status);
         root.setConfig(config);
-
-        for (String s : stateCounts.keys()) {
-            root.addState(s, stateCounts.count(s));
-        }
-
         root.setEnv(env);
-
-        for (String data : messages) {
-            root.addMessage(data);
-        }
-
+        root.addState(counter);
+        root.addMessages(messages);
         root.addVMOuts(vmOuts);
         root.addVMErrs(vmErrs);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -138,7 +138,7 @@ public class ReportUtils {
         }
         pw.println();
 
-        if (r.hasSamples()) {
+        if (!r.isEmpty()) {
             int idLen = "Observed state".length();
             int occLen = "Occurrences".length();
             int expectLen = "Expectation".length();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
@@ -212,4 +212,18 @@ public final class Counter<R> implements Serializable {
         return res;
     }
 
+    public long totalCount() {
+        long s = 0;
+        for (long c : counts) {
+            s += c;
+        }
+        return s;
+    }
+
+    public boolean isEmpty() {
+        for (long c : counts) {
+            if (c > 0) return false;
+        }
+        return true;
+    }
 }

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/util/CounterTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/util/CounterTest.java
@@ -3,6 +3,8 @@ package org.openjdk.jcstress.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.*;
+
 public class CounterTest {
 
     @Test
@@ -48,6 +50,31 @@ public class CounterTest {
         }
 
         Assert.assertEquals(1000, cnt.elementSet().size());
+    }
+
+    @Test
+    public void testSerial_1() throws IOException, ClassNotFoundException {
+        Counter<String> cnt = new Counter<>();
+        for (int c = 0; c < 1000; c++) {
+            cnt.record("Foo" + c, c);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(cnt);
+        }
+
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(baos.toByteArray());
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            @SuppressWarnings("unchecked")
+            Counter<String> desCnt = (Counter<String>) ois.readObject();
+
+            for (int c = 0; c < 1000; c++) {
+                Assert.assertEquals(c, desCnt.count("Foo" + c));
+            }
+
+            Assert.assertEquals(1000, desCnt.elementSet().size());
+        }
     }
 
 }


### PR DESCRIPTION
High-performance parts of jcstress code use open-address Counter to store state data. There is no reason why we cannot use Counter in the TestResults themselves.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902918](https://bugs.openjdk.java.net/browse/CODETOOLS-7902918): jcstress: Replace the relevant uses of HashMultiset with Counter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jcstress pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/46.diff">https://git.openjdk.java.net/jcstress/pull/46.diff</a>

</details>
