### PR TITLE
CODETOOLS-7902922: jcstress: Tune up generated code once more

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/FootprintEstimator.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/FootprintEstimator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.runners;
+
+public interface FootprintEstimator {
+    void runWith(int size, long[] counters);
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -27,7 +27,6 @@ package org.openjdk.jcstress.infra.runners;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
 public class ForkedTestConfig {
@@ -102,10 +101,6 @@ public class ForkedTestConfig {
 
         maxStride = Math.min(maxStride, succCount);
         minStride = Math.min(minStride, succCount);
-    }
-
-    public interface FootprintEstimator {
-        void runWith(int size, long[] counters);
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {


### PR DESCRIPTION
There are more tune ups in generated code in sight:
 - reduce the use of lambdas
 - reduce the use of collections
 - avoid some unnecessary loops
 - avoid excessive message handling

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902922](https://bugs.openjdk.java.net/browse/CODETOOLS-7902922): jcstress: Tune up generated code once more


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/jcstress pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/50.diff">https://git.openjdk.java.net/jcstress/pull/50.diff</a>

</details>
