### PR TITLE
CODETOOLS-7902923: jcstress: Eliminate dependency on Executors/Futures in forked VMs

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.runners;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AbstractThread extends Thread {
+    private static final AtomicInteger ID = new AtomicInteger();
+
+    protected volatile Throwable throwable;
+
+    public AbstractThread() {
+        setDaemon(true);
+        setName("jcstress-worker-" + ID.incrementAndGet());
+    }
+
+    public Throwable throwable() { return throwable; }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/CounterThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/CounterThread.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.runners;
+
+import org.openjdk.jcstress.util.Counter;
+
+public abstract class CounterThread<R> extends AbstractThread {
+    private Counter<R> result;
+    public Counter<R> result() {
+        return result;
+    }
+
+    @Override
+    public void run() {
+        try {
+            result = internalRun();
+        } catch (Throwable e) {
+            throwable = e;
+        }
+    }
+
+    protected abstract Counter<R> internalRun();
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/LongThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/LongThread.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.runners;
+
+public abstract class LongThread extends AbstractThread {
+    private long result;
+    public long result() {
+        return result;
+    }
+
+    @Override
+    public void run() {
+        try {
+            result = internalRun();
+        } catch (Throwable e) {
+            throwable = e;
+        }
+    }
+
+    protected abstract long internalRun();
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/VoidThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/VoidThread.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.runners;
+
+public abstract class VoidThread extends AbstractThread {
+    @Override
+    public void run() {
+        try {
+            internalRun();
+        } catch (Throwable e) {
+            throwable = e;
+        }
+    }
+
+    protected abstract void internalRun();
+}


### PR DESCRIPTION
Forked VMs are executing the tests, and they are inherently using some concurrency primitives that might be under the test. Executors/Futures are the examples of such primitives. Since the jcstress uses are simple, we might as well do the hand-rolled implementations on bare Threads. This would improve test fidelity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902923](https://bugs.openjdk.java.net/browse/CODETOOLS-7902923): jcstress: Eliminate dependency on Executors/Futures in forked VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.java.net/jcstress pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/51.diff">https://git.openjdk.java.net/jcstress/pull/51.diff</a>

</details>
