### PR TITLE
CODETOOLS-7902925: jcstress: Fix new Sonar warnings

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
@@ -26,7 +26,7 @@ package org.openjdk.jcstress.infra.runners;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class AbstractThread extends Thread {
+public abstract class AbstractThread extends Thread {
     private static final AtomicInteger ID = new AtomicInteger();
 
     protected volatile Throwable throwable;
@@ -35,6 +35,9 @@ public class AbstractThread extends Thread {
         setDaemon(true);
         setName("jcstress-worker-" + ID.incrementAndGet());
     }
+
+    @Override
+    public abstract void run();
 
     public Throwable throwable() { return throwable; }
 


### PR DESCRIPTION
After recent work, Sonar complains about AbstractThread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902925](https://bugs.openjdk.java.net/browse/CODETOOLS-7902925): jcstress: Fix new Sonar warnings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/jcstress pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/52.diff">https://git.openjdk.java.net/jcstress/pull/52.diff</a>

</details>
