### PR TITLE
CODETOOLS-7902943: jcstress: Update console UX again

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -92,6 +92,8 @@ public class JCStress {
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
         TestExecutor executor = new TestExecutor(opts.verbosity(), sink, scheduler);
+        printer.setExecutor(executor);
+
         executor.runAll(configs);
 
         sink.close();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -63,7 +63,7 @@ public class TestExecutor {
     private final Map<Integer, VM> vmByToken;
     private final Object notifyLock;
 
-    private final AtomicInteger cntRunning;
+    private final AtomicInteger jvmsRunning;
 
     public TestExecutor(Verbosity verbosity, TestResultCollector sink, Scheduler scheduler) throws IOException {
         this.verbosity = verbosity;
@@ -85,11 +85,7 @@ public class TestExecutor {
             }
         });
 
-        this.cntRunning = new AtomicInteger();
-    }
-
-    public int getJVMsRunning() {
-        return cntRunning.get();
+        this.jvmsRunning = new AtomicInteger();
     }
 
     private void awaitNotification() {
@@ -183,6 +179,10 @@ public class TestExecutor {
 
     public int getSystemCpus() {
         return scheduler.getSystemCpus();
+    }
+
+    public int getJVMsRunning() {
+        return jvmsRunning.get();
     }
 
     private class VM {
@@ -351,7 +351,7 @@ public class TestExecutor {
                 ProcessBuilder pb = new ProcessBuilder(command);
                 process = pb.start();
 
-                cntRunning.incrementAndGet();
+                jvmsRunning.incrementAndGet();
 
                 // start the stream drainers and read the streams into memory;
                 // makes little sense to write them to files, since we would be
@@ -394,7 +394,7 @@ public class TestExecutor {
             try {
                 int ecode = process.waitFor();
 
-                cntRunning.decrementAndGet();
+                jvmsRunning.decrementAndGet();
 
                 outCollector.join();
                 errCollector.join();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Expect.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Expect.java
@@ -32,20 +32,32 @@ public enum Expect {
     /**
      * Acceptable result. Acceptable results are not required to be present.
      */
-    ACCEPTABLE,
+    ACCEPTABLE("Acceptable"),
 
     /**
      * Same as {@link #ACCEPTABLE}, but this result will be highlighted in reports.
      */
-    ACCEPTABLE_INTERESTING,
+    ACCEPTABLE_INTERESTING("Interesting"),
 
     /**
      * Forbidden result. Should never be present.
      */
-    FORBIDDEN,
+    FORBIDDEN("Forbidden"),
 
     /**
      * Internal expectation: no grading. Do not use.
      */
-    UNKNOWN,
+    UNKNOWN("Unknown"),
+    ;
+
+    private final String desc;
+
+    Expect(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String toString() {
+        return desc;
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -182,19 +182,19 @@ public class ConsoleReportPrinter implements TestResultCollector {
         final long G = 1000*M;
         final long T = 1000*G;
 
-        if (v > 10*T) {
+        if (v > T) {
             return String.format("%3.2f T/sec", v / T);
         }
 
-        if (v > 10*G) {
+        if (v > G) {
             return String.format("%3.2f G/sec", v / G);
         }
 
-        if (v > 10*M) {
+        if (v > M) {
             return String.format("%3.2f M/sec", v / M);
         }
 
-        if (v > 10*K) {
+        if (v > K) {
             return String.format("%3.2f K/sec", v / K);
         }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.infra.grading;
 
 import org.openjdk.jcstress.Options;
+import org.openjdk.jcstress.TestExecutor;
 import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
@@ -61,6 +62,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private long failed;
     private long softErrors;
     private long hardErrors;
+    private TestExecutor executor;
 
     public ConsoleReportPrinter(Options opts, PrintWriter pw, long expectedForks) {
         this.output = pw;
@@ -143,9 +145,13 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
     private void printStatusLine() {
         long currentTime = System.nanoTime();
-        String line = String.format("(ETA: %10s) (Sample Rate: %s) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs) ",
+        final int actorCpus = executor.getActorCpus();
+        final int systemCpus = executor.getSystemCpus();
+        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d running) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
                 computeETA(),
                 computeSpeed(),
+                executor.getJVMsRunning(),
+                actorCpus, systemCpus, actorCpus + systemCpus,
                 expectedResults, passed, failed, softErrors, hardErrors
         );
         progressLen = line.length();
@@ -231,4 +237,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         }
     }
 
+    public void setExecutor(TestExecutor executor) {
+        this.executor = executor;
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -159,7 +159,7 @@ public class ReportUtils {
             freqLen += 2;
             expectLen += 2;
 
-            pw.printf("%" + idLen + "s%" + samplesLen + "s%" + (freqLen+1) + "s%" + expectLen + "s  %-" + descLen + "s%n",
+            pw.printf("%" + idLen + "s%" + samplesLen + "s%" + freqLen + "s%" + expectLen + "s  %-" + descLen + "s%n",
                     headResult, headSamples, headFreq, headExpect, headDesc);
 
             TestGrading grade = r.grading();
@@ -173,10 +173,10 @@ public class ReportUtils {
             }
 
             for (GradingResult gradeRes : grade.gradingResults) {
-                pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + ".2f%%%" + expectLen + "s  %-" + descLen + "s%n",
+                pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + "s%" + expectLen + "s  %-" + descLen + "s%n",
                         StringUtils.cutoff(gradeRes.id, idLen),
                         gradeRes.count,
-                        gradeRes.count * 100.0 / totalSamples,
+                        StringUtils.percent(gradeRes.count, totalSamples, 1),
                         gradeRes.expect,
                         StringUtils.cutoff(gradeRes.description, descLen));
             }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -129,9 +129,14 @@ public class ReportUtils {
         pw.println();
 
         if (!r.isEmpty()) {
-            int idLen = "Observed state".length();
-            int occLen = "Occurrences".length();
-            int expectLen = "Expectation".length();
+            final String headResult = "RESULT";
+            final String headSamples = "SAMPLES";
+            final String headExpect = "EXPECT";
+            final String headDesc = "DESCRIPTION";
+
+            int idLen = headResult.length();
+            int occLen = headSamples.length();
+            int expectLen = headExpect.length();
             int descLen = 60;
 
             for (String s : r.getStateKeys()) {
@@ -151,10 +156,11 @@ public class ReportUtils {
             occLen += 2;
             expectLen += 2;
 
-            pw.printf("%" + idLen + "s %" + occLen + "s %" + expectLen + "s  %-" + descLen + "s%n", "Observed state", "Occurrences", "Expectation", "Interpretation");
+            pw.printf("  %" + idLen + "s  %" + occLen + "s  %" + expectLen + "s  %-" + descLen + "s%n",
+                    headResult, headSamples, headExpect, headDesc);
 
             for (GradingResult gradeRes : r.grading().gradingResults) {
-                pw.printf("%" + idLen + "s %," + occLen + "d %" + expectLen + "s  %-" + descLen + "s%n",
+                pw.printf("  %" + idLen + "s  %," + occLen + "d  %" + expectLen + "s  %-" + descLen + "s%n",
                         StringUtils.cutoff(gradeRes.id, idLen),
                         gradeRes.count,
                         gradeRes.expect,

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -100,20 +100,20 @@ public class JCStressTestProcessor extends AbstractProcessor {
                 for (TestInfo test : tests) {
                     TestLineWriter wl = new TestLineWriter();
 
-                    wl.put(test.getTest().getQualifiedName());
+                    wl.put(test.getTest().getQualifiedName().toString());
                     wl.put(test.getGeneratedName());
                     wl.put(test.getDescription());
                     List<ExecutableElement> actors = test.getActors();
                     wl.put(actors.size());
                     for (ExecutableElement actor : actors) {
-                        wl.put(actor.getSimpleName());
+                        wl.put(actor.getSimpleName().toString());
                     }
                     wl.put(test.isRequiresFork());
 
                     wl.put(test.cases().size());
 
                     for (Outcome c : test.cases()) {
-                        wl.put(c.expect());
+                        wl.put(c.expect().ordinal());
                         wl.put(c.desc());
                         wl.put(c.id().length);
                         for (String id : c.id()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestList.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestList.java
@@ -44,11 +44,12 @@ public class TestList {
 
     private static Map<String, TestInfo> getTests() {
         if (tests == null) {
+            Expect[] expectValues = Expect.values();
             Map<String, TestInfo> m = new HashMap<>();
-            InputStream stream = null;
-            try {
-                stream = TestList.class.getResourceAsStream(LIST);
-                BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+
+            try (InputStream stream = TestList.class.getResourceAsStream(LIST);
+                 InputStreamReader isr = new InputStreamReader(stream);
+                 BufferedReader reader = new BufferedReader(isr)) {
 
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -72,8 +73,8 @@ public class TestList {
                         m.put(name, testInfo);
 
                         for (int c = 0; c < caseCount; c++) {
-                            Expect expect  = Expect.valueOf(read.nextString());
-                            String desc    = read.nextString();
+                            Expect expect = expectValues[read.nextInt()];
+                            String desc = read.nextString();
                             int stateCount = read.nextInt();
                             for (int s = 0; s < stateCount; s++) {
                                 String regex = read.nextString();
@@ -90,15 +91,8 @@ public class TestList {
                 }
             } catch (IOException e) {
                 throw new IllegalStateException("Fatal error", e);
-            } finally {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (IOException e) {
-                        // swallow
-                    }
-                }
             }
+            // swallow
             tests = m;
         }
         return tests;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
@@ -36,7 +36,8 @@ public class Scheduler {
     private final int maxUse;
     private final Topology topology;
     private final BitSet availableCores;
-    private int currentUse;
+    private int currentActorUse;
+    private int currentSystemUse;
     private final PackageRecord[] freeMapPackage;
 
     public Scheduler(Topology t, int max) {
@@ -54,7 +55,7 @@ public class Scheduler {
     }
 
     public synchronized CPUMap tryAcquire(SchedulingClass scl) {
-        if (currentUse + scl.numActors() > maxUse) {
+        if (currentActorUse + scl.numActors() > maxUse) {
             // Over the limit, break out.
             return null;
         }
@@ -153,7 +154,7 @@ public class Scheduler {
                 if (availableCPUs.get(thread)) {
                     availableCPUs.set(thread, false);
                     actorMap[aIdx] = thread;
-                    currentUse++;
+                    currentActorUse++;
                     break;
                 }
             }
@@ -167,7 +168,7 @@ public class Scheduler {
                 if (availableCPUs.get(thread)) {
                     availableCPUs.set(thread, false);
                     system[systemCnt++] = thread;
-                    currentUse++;
+                    currentSystemUse++;
                 }
             }
         }
@@ -230,7 +231,7 @@ public class Scheduler {
                 }
                 availableCPUs.set(thread, false);
                 system[systemCnt++] = thread;
-                currentUse++;
+                currentSystemUse++;
             }
         }
 
@@ -279,8 +280,8 @@ public class Scheduler {
             }
         }
 
-        if (use != currentUse) {
-            throw new IllegalStateException(when + ": CPU use counts are inconsistent, counter = " + currentUse + ", actually taken = " + use);
+        if (use != currentActorUse) {
+            throw new IllegalStateException(when + ": CPU use counts are inconsistent, counter = " + currentActorUse + ", actually taken = " + use);
         }
 
         for (int p = 0; p < topology.packagesPerSystem(); p++) {
@@ -305,13 +306,13 @@ public class Scheduler {
             if (c != -1) {
                 availableCPUs.set(c, true);
                 availableCores.set(topology.threadToCore(c), true);
-                currentUse--;
+                currentActorUse--;
             }
         }
         for (int c : cpuMap.systemMap()) {
             availableCPUs.set(c, true);
             availableCores.set(topology.threadToCore(c), true);
-            currentUse--;
+            currentSystemUse--;
         }
 
         recomputeFreeMaps();
@@ -332,6 +333,14 @@ public class Scheduler {
         }
 
         Arrays.sort(freeMapPackage);
+    }
+
+    public int getActorCpus() {
+        return currentActorUse;
+    }
+
+    public int getSystemCpus() {
+        return currentSystemUse;
     }
 
     private static class PackageRecord implements Comparable<PackageRecord> {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
@@ -280,8 +280,9 @@ public class Scheduler {
             }
         }
 
-        if (use != currentActorUse) {
-            throw new IllegalStateException(when + ": CPU use counts are inconsistent, counter = " + currentActorUse + ", actually taken = " + use);
+        final int expected = currentActorUse + currentSystemUse;
+        if (use != expected) {
+            throw new IllegalStateException(when + ": CPU use counts are inconsistent, counter = " + expected + ", actually taken = " + use);
         }
 
         for (int p = 0; p < topology.packagesPerSystem(); p++) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -168,14 +168,6 @@ public class StringUtils {
         return r;
     }
 
-    public static String repeat(String s, int count) {
-        StringBuilder sb = new StringBuilder();
-        for (int c = 0; c < count; c++) {
-            sb.append(s);
-        }
-        return sb.toString();
-    }
-
     public static String percent(long v, long total, int prec) {
         double p = v * 100.0 / total;
         double limit = Math.pow(0.1, prec);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -167,4 +167,12 @@ public class StringUtils {
         }
         return r;
     }
+
+    public static String repeat(String s, int count) {
+        StringBuilder sb = new StringBuilder();
+        for (int c = 0; c < count; c++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -175,4 +175,14 @@ public class StringUtils {
         }
         return sb.toString();
     }
+
+    public static String percent(long v, long total, int prec) {
+        double p = v * 100.0 / total;
+        double limit = Math.pow(0.1, prec);
+        if (p < limit) {
+            return String.format("<%." + prec + "f%%", limit);
+        } else {
+            return String.format("%." + prec + "f%%", p);
+        }
+    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/TestLineWriter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/TestLineWriter.java
@@ -33,7 +33,7 @@ public class TestLineWriter {
         line.append("JCTEST");
     }
 
-    public void put(Object value) {
+    public void put(String value) {
         String s = String.valueOf(value);
         line.append(s.length());
         line.append("S");


### PR DESCRIPTION
We can make the console UX even better: print JVM/CPU in use counts, print sample frequencies, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902943](https://bugs.openjdk.java.net/browse/CODETOOLS-7902943): jcstress: Update console UX again


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jcstress pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/53.diff">https://git.openjdk.java.net/jcstress/pull/53.diff</a>

</details>
