### PR TITLE
CODETOOLS-7902946: jcstress: Upgrade JNA to 5.8.0

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
@@ -60,7 +60,7 @@ public class AffinitySupport {
             if (INSTANCE == null) {
                 synchronized (Linux.class) {
                     if (INSTANCE == null) {
-                        INSTANCE = Native.loadLibrary("c", CLibrary.class);
+                        INSTANCE = Native.load("c", CLibrary.class);
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -310,12 +310,12 @@ questions.
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>4.5.2</version>
+                <version>5.8.0</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>4.5.2</version>
+                <version>5.8.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.jimfs</groupId>


### PR DESCRIPTION
jcstress still uses JNA 4.5.2. We can upgrade to 5.8.0 and thus take in bugfixes and extended platform support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902946](https://bugs.openjdk.java.net/browse/CODETOOLS-7902946): jcstress: Upgrade JNA to 5.8.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jcstress pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/54.diff">https://git.openjdk.java.net/jcstress/pull/54.diff</a>

</details>
