### PR TITLE
CODETOOLS-7902947: jcstress: Skip affinity initialization when non-local affinity mode is requested

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -47,14 +47,18 @@ public class ForkedMain {
             throw new IllegalStateException("Expected three arguments");
         }
 
-        // Pre-initialize the affinity support and threads, so that workers
-        // do not have to do this on critical paths during the execution.
-        // This also runs when the rest of the infrastructure starts up.
-        new WarmupAffinityTask().start();
+        boolean initLocalAffinity = Boolean.parseBoolean(args[0]);
 
-        String host = args[0];
-        int port = Integer.parseInt(args[1]);
-        int token = Integer.parseInt(args[2]);
+        if (initLocalAffinity) {
+            // Pre-initialize the affinity support and threads, so that workers
+            // do not have to do this on critical paths during the execution.
+            // This also runs when the rest of the infrastructure starts up.
+            new WarmupAffinityTask().start();
+        }
+
+        String host = args[1];
+        int port = Integer.parseInt(args[2]);
+        int token = Integer.parseInt(args[3]);
 
         BinaryLinkClient link = new BinaryLinkClient(host, port);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -342,6 +342,9 @@ public class TestExecutor {
 
                 command.add(ForkedMain.class.getName());
 
+                // notify the forked VM whether we want the local affinity initialized
+                command.add(Boolean.toString(task.shClass.mode() == AffinityMode.LOCAL));
+
                 command.add(host);
                 command.add(String.valueOf(port));
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -569,7 +569,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println();
             pw.println("    private Counter<" + r + "> " + TASK_LOOP_PREFIX + a.getSimpleName() + "() {");
             pw.println("        Counter<" + r + "> counter = new Counter<>();");
-            pw.println("        if (config.localAffinity) AffinitySupport.bind(config.actorMap[" + n + "]);");
+            pw.println("        if (config.localAffinity) AffinitySupport.bind(config.localAffinityMap[" + n + "]);");
             pw.println("        while (true) {");
             pw.println("            WorkerSync sync = workerSync;");
             pw.println("            if (sync.stopped) {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -457,6 +457,18 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println();
         pw.println("        control.isStopped = false;");
         pw.println();
+
+        // Initialize affinity before starting the timing measurement, so that init time
+        // does not eat up into the test run time.
+        pw.println("        if (config.localAffinity) {");
+        pw.println("            try {");
+        pw.println("                AffinitySupport.tryBind();");
+        pw.println("            } catch (Exception e) {");
+        pw.println("                // Do not care");
+        pw.println("            }");
+        pw.println("        }");
+        pw.println();
+
         pw.println("        ArrayList<CounterThread<" + r + ">> threads = new ArrayList<>(" + actorsCount + ");");
         for (ExecutableElement a : info.getActors()) {
             pw.println("        threads.add(new CounterThread<" + r + ">() { public Counter<" + r + "> internalRun() {");
@@ -557,7 +569,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println();
             pw.println("    private Counter<" + r + "> " + TASK_LOOP_PREFIX + a.getSimpleName() + "() {");
             pw.println("        Counter<" + r + "> counter = new Counter<>();");
-            pw.println("        AffinitySupport.bind(config.actorMap[" + n + "]);");
+            pw.println("        if (config.localAffinity) AffinitySupport.bind(config.actorMap[" + n + "]);");
             pw.println("        while (true) {");
             pw.println("            WorkerSync sync = workerSync;");
             pw.println("            if (sync.stopped) {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -40,7 +40,7 @@ public class ForkedTestConfig {
     public int minStride;
     public int maxStride;
     public boolean localAffinity;
-    public int[] actorMap;
+    public int[] localAffinityMap;
 
     public ForkedTestConfig(TestConfig cfg) {
         spinLoopStyle = cfg.spinLoopStyle;
@@ -51,7 +51,9 @@ public class ForkedTestConfig {
         minStride = cfg.minStride;
         maxStride = cfg.maxStride;
         localAffinity = cfg.shClass.mode() == AffinityMode.LOCAL;
-        actorMap = cfg.cpuMap.actorMap();
+        if (localAffinity) {
+            localAffinityMap = cfg.cpuMap.actorMap();
+        }
     }
 
     public ForkedTestConfig(DataInputStream dis) throws IOException {
@@ -63,10 +65,12 @@ public class ForkedTestConfig {
         minStride = dis.readInt();
         maxStride = dis.readInt();
         localAffinity = dis.readBoolean();
-        int len = dis.readInt();
-        actorMap = new int[len];
-        for (int c = 0; c < len; c++) {
-            actorMap[c] = dis.readInt();
+        if (localAffinity) {
+            int len = dis.readInt();
+            localAffinityMap = new int[len];
+            for (int c = 0; c < len; c++) {
+                localAffinityMap[c] = dis.readInt();
+            }
         }
     }
 
@@ -79,9 +83,11 @@ public class ForkedTestConfig {
         dos.writeInt(minStride);
         dos.writeInt(maxStride);
         dos.writeBoolean(localAffinity);
-        dos.writeInt(actorMap.length);
-        for (int am : actorMap) {
-            dos.writeInt(am);
+        if (localAffinity) {
+            dos.writeInt(localAffinityMap.length);
+            for (int am : localAffinityMap) {
+                dos.writeInt(am);
+            }
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
+import org.openjdk.jcstress.os.AffinityMode;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -37,6 +39,7 @@ public class ForkedTestConfig {
     public final int maxFootprintMB;
     public int minStride;
     public int maxStride;
+    public boolean localAffinity;
     public int[] actorMap;
 
     public ForkedTestConfig(TestConfig cfg) {
@@ -47,6 +50,7 @@ public class ForkedTestConfig {
         maxFootprintMB = cfg.maxFootprintMB;
         minStride = cfg.minStride;
         maxStride = cfg.maxStride;
+        localAffinity = cfg.shClass.mode() == AffinityMode.LOCAL;
         actorMap = cfg.cpuMap.actorMap();
     }
 
@@ -58,6 +62,7 @@ public class ForkedTestConfig {
         maxFootprintMB = dis.readInt();
         minStride = dis.readInt();
         maxStride = dis.readInt();
+        localAffinity = dis.readBoolean();
         int len = dis.readInt();
         actorMap = new int[len];
         for (int c = 0; c < len; c++) {
@@ -73,6 +78,7 @@ public class ForkedTestConfig {
         dos.writeInt(maxFootprintMB);
         dos.writeInt(minStride);
         dos.writeInt(maxStride);
+        dos.writeBoolean(localAffinity);
         dos.writeInt(actorMap.length);
         for (int am : actorMap) {
             dos.writeInt(am);


### PR DESCRIPTION
Currently, we eagerly initialize affinity support in ForkedMain, even when local affinity mode is not enabled. This eats precious time that we spend on doing unnecessary work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902947](https://bugs.openjdk.java.net/browse/CODETOOLS-7902947): jcstress: Skip affinity initialization when non-local affinity mode is requested


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jcstress pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/55.diff">https://git.openjdk.java.net/jcstress/pull/55.diff</a>

</details>
