### PR TITLE
CODETOOLS-7902948: jcstress: Shortcut counter copy path for copyable results

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/Copyable.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/Copyable.java
@@ -24,8 +24,15 @@
  */
 package org.openjdk.jcstress.infra;
 
+/**
+ * Marks the class as directly copyable.
+ */
 public interface Copyable {
 
+    /**
+     * Produce the distinct copy of the object and all of its references.
+     * @return object copy
+     */
     Object copy();
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/Copyable.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/Copyable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra;
+
+public interface Copyable {
+
+    Object copy();
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jcstress.util;
 
+import org.openjdk.jcstress.infra.Copyable;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -136,7 +138,7 @@ public final class Counter<R> implements Serializable {
 
         // completely new key, insert, and exit
         keyCount++;
-        keys[idx] = decouple(result);
+        keys[idx] = copyOf(result);
         counts[idx] = count;
     }
 
@@ -194,7 +196,21 @@ public final class Counter<R> implements Serializable {
         return 0L;
     }
 
-    private static <T> T decouple(T result) {
+    private static <T> T copyOf(T result) {
+        // Known immutable
+        if (result instanceof String) {
+            return result;
+        }
+
+        // Special class that knows how to copy itself
+        if (result instanceof Copyable) {
+            Object copy = ((Copyable) result).copy();
+            @SuppressWarnings("unchecked")
+            final T tCopy = (T) copy;
+            return tCopy;
+        }
+
+        // Generic copying...
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(bos);

--- a/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
+++ b/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
@@ -41,6 +41,7 @@ public class ResultGenerator {
     }
 
     public String generateResult(Class<?>... args) {
+        boolean allPrimitive = true;
         String name = "";
         for (Class k : args) {
             if (k.isPrimitive()) {
@@ -54,6 +55,7 @@ public class ResultGenerator {
                 if (k == double.class)  name += "D";
             } else {
                 name += "L";
+                allPrimitive = false;
             }
         }
         name += "_Result";
@@ -74,11 +76,15 @@ public class ResultGenerator {
 
         pw.println("package org.openjdk.jcstress.infra.results;");
         pw.println("");
-        pw.println("import java.io.Serializable;");
+        if (allPrimitive) {
+            pw.println("import org.openjdk.jcstress.infra.Copyable;");
+        } else {
+            pw.println("import java.io.Serializable;");
+        }
         pw.println("import org.openjdk.jcstress.annotations.Result;");
         pw.println("");
         pw.println("@Result");
-        pw.println("public final class " + name + " implements Serializable {");
+        pw.println("public final class " + name + " implements " + (allPrimitive ? "Copyable" : "Serializable" ) + " {");
 
         {
             int n = 1;
@@ -158,10 +164,10 @@ public class ResultGenerator {
 
         pw.println("        return true;");
         pw.println("    }");
+        pw.println();
 
         pw.println("    public String toString() {");
         pw.print("        return \"\" + ");
-
         {
             int n = 1;
             for (Class k : args) {
@@ -172,8 +178,18 @@ public class ResultGenerator {
             }
             pw.println(";");
         }
-
         pw.println("    }");
+        pw.println();
+
+        if (allPrimitive) {
+            pw.println("    public Object copy() {");
+            pw.println("        " + name + " copy = new " + name + "();");
+            for (int n = 1; n <= args.length; n++) {
+                pw.println("        copy.r" + n + " = r" + n + ";");
+            }
+            pw.println("        return copy;");
+            pw.println("    }");
+        }
 
         pw.println("}");
         pw.close();


### PR DESCRIPTION
In jcstress, @Result instances can be reset in place. Which means that Counter has to do defensive copies before inserting results as keys. It now does it with serialization-deserialization stub. This takes about 10 ms to initialize on first key insertion. Fortunately, we can do better: if results are implicitly copyable (i.e. have only primitive fields), we can copy them directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902948](https://bugs.openjdk.java.net/browse/CODETOOLS-7902948): jcstress: Shortcut counter copy path for copyable results


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.java.net/jcstress pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/56.diff">https://git.openjdk.java.net/jcstress/pull/56.diff</a>

</details>
