### PR TITLE
CODETOOLS-7902950: jcstress: Offload VM start/finish/output tasks to separate workers

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -147,10 +147,10 @@ public class ConsoleReportPrinter implements TestResultCollector {
         long currentTime = System.nanoTime();
         final int actorCpus = executor.getActorCpus();
         final int systemCpus = executor.getSystemCpus();
-        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d running) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
+        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d start, %d run, %d finish) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
                 computeETA(),
                 computeSpeed(),
-                executor.getJVMsRunning(),
+                executor.getJVMsStarting(), executor.getJVMsRunning(), executor.getJVMsFinishing(),
                 actorCpus, systemCpus, actorCpus + systemCpus,
                 expectedResults, passed, failed, softErrors, hardErrors
         );

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/InputStreamCollector.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/InputStreamCollector.java
@@ -25,13 +25,11 @@
 package org.openjdk.jcstress.util;
 
 import java.io.*;
-import java.nio.Buffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.Callable;
 
-public class InputStreamCollector extends Thread {
+public class InputStreamCollector implements Callable<List<String>> {
 
     private final InputStream in;
     private final List<String> list;
@@ -41,7 +39,7 @@ public class InputStreamCollector extends Thread {
         this.list = new ArrayList<>();
     }
 
-    public void run() {
+    public List<String> call() {
         try (InputStreamReader isr = new InputStreamReader(in);
              BufferedReader br = new BufferedReader(isr)) {
             String line;
@@ -51,9 +49,6 @@ public class InputStreamCollector extends Thread {
         } catch (IOException e) {
             // Do nothing.
         }
-    }
-
-    public List<String> getOutput() {
         return list;
     }
 


### PR DESCRIPTION
The TestExecutor loop is busy driving the run, and the blocking code that starts/finishes VMs should be offloaded to separate workers. Additionally, InputStreamCollectors that currently run as separate threads, can use the threadpool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902950](https://bugs.openjdk.java.net/browse/CODETOOLS-7902950): jcstress: Offload VM start/finish/output tasks to separate workers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jcstress pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/58.diff">https://git.openjdk.java.net/jcstress/pull/58.diff</a>

</details>
