### PR TITLE
CODETOOLS-7902951: jcstress: Optimize JNA loading paths

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -371,6 +371,9 @@ public class TestExecutor {
                 // basic Java line
                 command.addAll(VMSupport.getJavaInvokeLine());
 
+                // additional flags from OS support
+                command.addAll(OSSupport.getJavaInvokeArguments());
+
                 // jvm args
                 command.addAll(task.jvmArgs);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
@@ -29,14 +29,14 @@ import org.openjdk.jcstress.vm.VMSupportException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class OSSupport {
 
     private static volatile boolean TASKSET_AVAILABLE;
+    private static List<String> AFFINITY_ADDITIONAL_OPTIONS;
+
     public static boolean taskSetAvailable() {
         return TASKSET_AVAILABLE;
     }
@@ -55,6 +55,7 @@ public class OSSupport {
                 "taskset", "-c", "0");
 
         try {
+            AFFINITY_ADDITIONAL_OPTIONS = AffinitySupport.prepare();
             AffinitySupport.tryBind();
             System.out.printf("----- %s %s%n", "[OK]", "Trying to set per-thread affinity with syscalls");
             AFFINITY_SUPPORT_AVAILABLE = true;
@@ -65,6 +66,14 @@ public class OSSupport {
         }
 
         System.out.println();
+    }
+
+    public static Collection<? extends String> getJavaInvokeArguments() {
+        if (AFFINITY_SUPPORT_AVAILABLE) {
+            return AFFINITY_ADDITIONAL_OPTIONS;
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     private static boolean detectCommand(String label, String... opts) {

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/os/AffinitySupportTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/os/AffinitySupportTest.java
@@ -13,6 +13,11 @@ public class AffinitySupportTest {
     }
 
     @Test
+    public void prepare() {
+        AffinitySupport.prepare();
+    }
+
+    @Test
     public void tryBind() {
         AffinitySupport.tryBind();
     }


### PR DESCRIPTION
Forked VMs unpack JNA libraries on every invocation. Those should actually be unpacked once by host VM, and then reused by forked VMs.

This saves about 30 ms per forked VM invocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902951](https://bugs.openjdk.java.net/browse/CODETOOLS-7902951): jcstress: Optimize JNA loading paths


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/jcstress pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/59.diff">https://git.openjdk.java.net/jcstress/pull/59.diff</a>

</details>
