### PR TITLE
CODETOOLS-7902952: jcstress: Disable UsePerfData to improve I/O costs

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -86,6 +86,12 @@ public class VMSupport {
                 "-XX:+UnlockDiagnosticVMOptions"
         );
 
+        detect("Disabling performance data collection",
+                SimpleTestMain.class,
+                GLOBAL_JVM_FLAGS,
+                "-XX:-UsePerfData"
+        );
+
         C1_AVAILABLE = detect("Checking for C1 availability",
                 SimpleTestMain.class,
                 null,


### PR DESCRIPTION
Sample runs shows >10 MB/s write I/O with -m sanity on large machine. Those writes seem to originate from UsePerfData subsystem. We should do -XX:-UsePerfData, since jcstress does not need it anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902952](https://bugs.openjdk.java.net/browse/CODETOOLS-7902952): jcstress: Disable UsePerfData to improve I/O costs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/jcstress pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/60.diff">https://git.openjdk.java.net/jcstress/pull/60.diff</a>

</details>
