### PR TITLE
CODETOOLS-7902953: jcstress: Minor touchups for status line and percent reporting

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -147,7 +147,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         long currentTime = System.nanoTime();
         final int actorCpus = executor.getActorCpus();
         final int systemCpus = executor.getSystemCpus();
-        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d start, %d run, %d finish) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
+        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d start, %d active, %d finish) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
                 computeETA(),
                 computeSpeed(),
                 executor.getJVMsStarting(), executor.getJVMsRunning(), executor.getJVMsFinishing(),

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -169,6 +169,9 @@ public class StringUtils {
     }
 
     public static String percent(long v, long total, int prec) {
+        if (v == 0) {
+            return String.format("%." + prec + "f%%", 0D);
+        }
         double p = v * 100.0 / total;
         double limit = Math.pow(0.1, prec);
         if (p < limit) {


### PR DESCRIPTION
See the changeset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902953](https://bugs.openjdk.java.net/browse/CODETOOLS-7902953): jcstress: Minor touchups for status line and percent reporting


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jcstress pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/61.diff">https://git.openjdk.java.net/jcstress/pull/61.diff</a>

</details>
