### PR TITLE
CODETOOLS-7902954: jcstress: Move unpacked JNA library to proper name

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
@@ -66,18 +66,25 @@ public class AffinitySupport {
         private static volatile CLibrary INSTANCE;
         private static boolean BIND_TRIED;
 
-        /*                                            q
+        /*
            Unpacks the libraries, and replies additional options for forked VMs.
          */
         public static List<String> prepare() {
             System.setProperty("jnidispatch.preserve", "true");
             Native.load("c", CLibrary.class);
 
+            File file = new File(System.getProperty("jnidispatch.path"));
+            String bootLibraryPath = file.getParent();
+
+            // Need to rename the file to the proper name, otherwise JNA would not discover it
+            File proper = new File(bootLibraryPath + '/' + System.mapLibraryName("jnidispatch"));
+            file.renameTo(proper);
+
             return Arrays.asList(
                     "-Djna.nounpack=true",    // Should not unpack itself, but use predefined path
                     "-Djna.nosys=true",       // Should load from explicit path
                     "-Djna.noclasspath=true", // Should load from explicit path
-                    "-Djna.boot.library.path=" + new File(System.getProperty("jnidispatch.path")).getParent(),
+                    "-Djna.boot.library.path=" + bootLibraryPath,
                     "-Djna.platform.library.path=" + System.getProperty("jna.platform.library.path")
             );
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupportTestMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupportTestMain.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.os;
+
+public class AffinitySupportTestMain {
+
+    public static void main(String... args) {
+        AffinitySupport.tryBind();
+    }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.os;
 
 import org.openjdk.jcstress.util.InputStreamDrainer;
+import org.openjdk.jcstress.vm.VMSupport;
 import org.openjdk.jcstress.vm.VMSupportException;
 
 import java.io.ByteArrayOutputStream;
@@ -55,8 +56,14 @@ public class OSSupport {
                 "taskset", "-c", "0");
 
         try {
+            // Prepare and dump affinity support collaterals
             AFFINITY_ADDITIONAL_OPTIONS = AffinitySupport.prepare();
-            AffinitySupport.tryBind();
+
+            // Test the unpacked mode works...
+            List<String> test = new ArrayList<>(AFFINITY_ADDITIONAL_OPTIONS);
+            test.add(AffinitySupportTestMain.class.getCanonicalName());
+            VMSupport.tryWith(test.toArray(new String[0]));
+
             System.out.printf("----- %s %s%n", "[OK]", "Trying to set per-thread affinity with syscalls");
             AFFINITY_SUPPORT_AVAILABLE = true;
         } catch (Throwable e) {


### PR DESCRIPTION
This is a regression from CODETOOLS-7902951. We need to move the unpacked library to the proper name, so that forked VM loader would discover it properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902954](https://bugs.openjdk.java.net/browse/CODETOOLS-7902954): jcstress: Move unpacked JNA library to proper name


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.java.net/jcstress pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/62.diff">https://git.openjdk.java.net/jcstress/pull/62.diff</a>

</details>
