### PR TITLE
CODETOOLS-7902957: jcstress: L-results are always equal to each other

### DIFF
--- a/jcstress-core/src/test/java/org/openjdk/jcstress/infra/results/I_Result_Test.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/infra/results/I_Result_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.results;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class I_Result_Test {
+
+    @Test
+    public void testEquals() {
+        I_Result res1 = new I_Result();
+        res1.r1 = 1;
+
+        I_Result res2 = new I_Result();
+        res2.r1 = 1;
+
+        I_Result res3 = new I_Result();
+        res3.r1 = 2;
+
+        Assert.assertEquals(res1, res2);
+        Assert.assertEquals(res1.hashCode(), res2.hashCode());
+        Assert.assertNotEquals(res3, res1);
+        Assert.assertNotEquals(res3, res2);
+    }
+
+    @Test
+    public void testCopy() {
+        I_Result res1 = new I_Result();
+        res1.r1 = 1;
+
+        Object res2 = res1.copy();
+        Assert.assertEquals(res1, res2);
+        Assert.assertEquals(res1.hashCode(), res2.hashCode());
+        res1.r1 = 2;
+        Assert.assertNotEquals(res1, res2);
+    }
+
+}

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/infra/results/L_Result_Test.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/infra/results/L_Result_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.results;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class L_Result_Test {
+
+    @Test
+    public void testEquals() {
+        Object o1 = new Object();
+        Object o2 = new Object();
+
+        L_Result res1 = new L_Result();
+        res1.r1 = o1;
+
+        L_Result res2 = new L_Result();
+        res2.r1 = o1;
+
+        L_Result res3 = new L_Result();
+        res3.r1 = o2;
+
+        Assert.assertEquals(res1, res2);
+        Assert.assertEquals(res1.hashCode(), res2.hashCode());
+        Assert.assertNotEquals(res3, res1);
+        Assert.assertNotEquals(res3, res2);
+    }
+
+}

--- a/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
+++ b/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
@@ -125,7 +125,7 @@ public class ResultGenerator {
                     pw.print("(int) (r" + n + ")");
                 } else
                 {
-                    pw.print("0");
+                    pw.print("(r" + n + " == null ? 0 : r" + n + ".hashCode())");
                 }
 
                 if (n > 1) {
@@ -151,12 +151,12 @@ public class ResultGenerator {
                 if (k == boolean.class || k == byte.class || k == short.class || k == char.class
                         || k == int.class || k == long.class) {
                     pw.println("        if (r" + n + " != that.r" + n + ") return false;");
-                }
-                if (k == double.class) {
+                } else if (k == double.class) {
                     pw.println("        if (Double.compare(r" + n + ", that.r" + n + ") != 0) return false;");
-                }
-                if (k == float.class) {
+                } else if (k == float.class) {
                     pw.println("        if (Float.compare(r" + n + ", that.r" + n + ") != 0) return false;");
+                } else {
+                    pw.println("        if (!objEquals(r" + n + ", that.r" + n + ")) return false;");
                 }
                 n++;
             }
@@ -188,6 +188,12 @@ public class ResultGenerator {
                 pw.println("        copy.r" + n + " = r" + n + ";");
             }
             pw.println("        return copy;");
+            pw.println("    }");
+        }
+
+        if (!allPrimitive) {
+            pw.println("    private static boolean objEquals(Object a, Object b) {");
+            pw.println("        return a == b || a != null && a.equals(b);");
             pw.println("    }");
         }
 


### PR DESCRIPTION
Due to a bug in ResultGenerator, all L-results are ignoring the reference in hashCode/equals computation. This means all results that have only reference results are equal to each other, and only the first result would be counted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902957](https://bugs.openjdk.java.net/browse/CODETOOLS-7902957): jcstress: L-results are always equal to each other


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.java.net/jcstress pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/63.diff">https://git.openjdk.java.net/jcstress/pull/63.diff</a>

</details>
