### PR TITLE
CODETOOLS-7902959: jcstress: Update progress line to ANSI multi-line for better presentation

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -103,8 +103,6 @@ public class JCStress {
 
         out.println();
         out.println();
-        out.println("RUN COMPLETE.");
-        out.println();
 
         parseResults();
     }
@@ -138,16 +136,8 @@ public class JCStress {
         drc.close();
 
         new TextReportPrinter(opts, collector).work();
-        new HTMLReportPrinter(opts, collector).work();
-
-        out.println();
-        out.println("HTML report was generated. Look at " + opts.getResultDest() + "index.html for the complete run results.");
-        out.println();
-
-        out.println("Will throw any pending exceptions at this point.");
+        new HTMLReportPrinter(opts, collector, out).work();
         new ExceptionReportPrinter(collector).work();
-
-        out.println("Done.");
     }
 
     private SortedSet<Integer> computeActorCounts(Set<String> tests) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -29,8 +29,16 @@ import org.openjdk.jcstress.TestExecutor;
 import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
+import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,8 +63,12 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private final long printIntervalMs;
     private long lastPrint;
 
+    private static final int PROGRESS_COMPONENTS = 5;
     private final boolean progressInteractive;
-    private int progressLen;
+    private final boolean progressAnsi;
+    private boolean progressFirstLine;
+    private final int[] progressLen;
+    private final DateTimeFormatter fmt;
 
     private long passed;
     private long failed;
@@ -68,9 +80,14 @@ public class ConsoleReportPrinter implements TestResultCollector {
         this.output = pw;
         this.expectedResults = expectedForks;
         verbosity = opts.verbosity();
-        progressLen = 1;
+        progressLen = new int[PROGRESS_COMPONENTS];
+        Arrays.fill(progressLen, 1);
 
+        progressFirstLine = true;
         progressInteractive = (System.console() != null);
+        progressAnsi = VMSupport.isLinux();
+        fmt = DateTimeFormatter.ofPattern("E, yyyy-MM-dd HH:mm:ss");
+
         output.println("  Attached the " + (progressInteractive ? "interactive console" : "non-interactive output stream") + ".");
 
         printIntervalMs = (PRINT_INTERVAL_MS != null) ?
@@ -147,15 +164,35 @@ public class ConsoleReportPrinter implements TestResultCollector {
         long currentTime = System.nanoTime();
         final int actorCpus = executor.getActorCpus();
         final int systemCpus = executor.getSystemCpus();
-        String line = String.format("(ETA: %10s) (Sample Rate: %s) (JVMs: %d start, %d active, %d finish) (CPUs: %d actor, %d system, %d total) (Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
-                computeETA(),
-                computeSpeed(),
-                executor.getJVMsStarting(), executor.getJVMsRunning(), executor.getJVMsFinishing(),
-                actorCpus, systemCpus, actorCpus + systemCpus,
-                expectedResults, passed, failed, softErrors, hardErrors
-        );
-        progressLen = line.length();
-        output.print(line);
+
+        String l0 = String.format("(ETA: %s)",
+                computeETA());
+        String l1 = String.format("(Sampling Rate: %s)",
+                computeSpeed());
+        String l2 = String.format("(JVMs: %d starting, %d running, %d finishing)",
+                executor.getJVMsStarting(), executor.getJVMsRunning(), executor.getJVMsFinishing());
+        String l3 = String.format("(CPUs: %d actor, %d system, %d total)",
+                actorCpus, systemCpus, actorCpus + systemCpus);
+        String l4 = String.format("(Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
+                expectedResults, passed, failed, softErrors, hardErrors);
+
+        if (progressAnsi) {
+            progressLen[0] = l0.length();
+            progressLen[1] = l1.length();
+            progressLen[2] = l2.length();
+            progressLen[3] = l3.length();
+            progressLen[4] = l4.length();
+
+            output.println(l0);
+            output.println(l1);
+            output.println(l2);
+            output.println(l3);
+            output.println(l4);
+        } else {
+            output.printf("%s %s %s %s %s", l0, l1, l2, l3, l4);
+            progressLen[0] = l0.length() + l1.length() + l2.length() + l3.length() + l4.length() + 4;
+        }
+
         if (!progressInteractive) {
             output.println();
         }
@@ -165,8 +202,19 @@ public class ConsoleReportPrinter implements TestResultCollector {
     }
 
     private void clearStatusLine() {
+        if (progressFirstLine) {
+            progressFirstLine = false;
+            return;
+        }
         if (progressInteractive) {
-            output.printf("\r%" + progressLen + "s\r", "");
+            if (progressAnsi) {
+                for (int i = progressLen.length - 1; i >= 0; i--) {
+                    output.printf("\033[F%" + progressLen[i] + "s\r", "");
+                }
+            } else {
+                output.printf("\r%" + progressLen[0] + "s\r", "");
+            }
+
         }
     }
 
@@ -216,7 +264,9 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
         long nsToGo = (long)(timeSpent * (1.0 * (expectedResults - 1) / resultsGot - 1));
         if (nsToGo > 0) {
-            String result = "";
+            LocalDateTime ldt = LocalDateTime.now().plus(nsToGo, ChronoUnit.NANOS);
+
+            String result = "in ";
             long days = TimeUnit.NANOSECONDS.toDays(nsToGo);
             if (days > 0) {
                 result += days + "d+";
@@ -231,6 +281,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
             long seconds = TimeUnit.NANOSECONDS.toSeconds(nsToGo);
 
             result += String.format("%02d:%02d:%02d", hours, minutes, seconds);
+            result += "; at " + ldt.format(fmt);
             return result;
         } else {
             return "now";

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -173,7 +173,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
         String l4 = String.format("(Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
                 expectedResults, passed, failed, softErrors, hardErrors);
 
-        if (progressAnsi) {
+        if (!progressInteractive || progressAnsi) {
             progressLen[0] = l0.length();
             progressLen[1] = l1.length();
             progressLen[2] = l2.length();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -32,13 +32,10 @@ import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -214,7 +211,6 @@ public class ConsoleReportPrinter implements TestResultCollector {
             } else {
                 output.printf("\r%" + progressLen[0] + "s\r", "");
             }
-
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -37,6 +37,7 @@ import org.openjdk.jcstress.util.*;
 import java.awt.*;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.List;
@@ -53,10 +54,12 @@ public class HTMLReportPrinter {
     private final InProcessCollector collector;
     private int cellStyle = 1;
 
-    public HTMLReportPrinter(Options opts, InProcessCollector collector) {
+    public HTMLReportPrinter(Options opts, InProcessCollector collector, PrintStream out) {
         this.collector = collector;
         this.resultDir = opts.getResultDest();
-        new File(resultDir).mkdirs();
+        File dir = new File(resultDir);
+        dir.mkdirs();
+        out.println("  HTML report generated at " + dir.getAbsolutePath() + File.separator + "index.html");
     }
 
     public void work() throws FileNotFoundException {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -64,52 +64,43 @@ public class TextReportPrinter {
                 .thenComparing(t -> t.getConfig().jvmArgs.toString()));
 
         pw.println("RUN RESULTS:");
-        pw.println("------------------------------------------------------------------------------------------------------------------------");
-        pw.println();
 
         printXTests(byConfig,
-                "INTERESTING tests",
-                "Some interesting behaviors observed. This is for the plain curiosity.",
+                "Interesting tests",
                 r -> r.status() == Status.NORMAL && r.grading().hasInteresting,
-                true
+                verbosity.printAllTests()
         );
 
         printXTests(byConfig,
-                "FAILED tests",
-                "Strong asserts were violated. Correct implementations should have no assert failures here.",
+                "Failed tests",
                 r -> r.status() == Status.NORMAL && !r.grading().isPassed,
-                true
+                verbosity.printAllTests()
         );
 
         printXTests(byConfig,
-                "ERROR tests",
-                "Tests break for some reason, other than failing the assert. Correct implementations should have none.",
+                "Error tests",
                 r -> r.status() != Status.NORMAL && r.status() != Status.API_MISMATCH,
-                true
+                verbosity.printAllTests()
         );
 
         printXTests(byConfig,
                 "All remaining tests",
-                "Tests that do not fall into any of the previous categories.",
                 r -> !emittedTests.contains(r),
                 verbosity.printAllTests());
 
-        pw.println("------------------------------------------------------------------------------------------------------------------------");
+        pw.println();
     }
 
     private void printXTests(List<TestResult> list,
                              String header,
-                             String subHeader,
                              Predicate<TestResult> predicate,
                              boolean emitDetails) {
 
-        pw.println("*** " + header);
-        pw.println("  " + subHeader);
-        pw.println();
-        pw.println("  " + list.stream().filter(predicate).count() + " matching test results. " + (!emitDetails ? " Use -v to print them." : ""));
-        pw.println();
+        final long count = list.stream().filter(predicate).count();
+        pw.println("  " + header + ": " + (count > 0 ? count + " matching test results." + (!emitDetails ? " Use -v to print them." : "") : "No matches."));
 
         if (emitDetails) {
+            pw.println();
             boolean emitted = false;
             for (TestResult result : list) {
                 if (predicate.test(result)) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
@@ -97,7 +97,7 @@ public class CompileMode {
 
     public static String description(int mode, List<String> actorNames) {
         if (mode == UNIFIED) {
-            return "unified across all actors";
+            return "unified across all actors" + System.lineSeparator();
         }
 
         StringBuilder sb = new StringBuilder();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -394,11 +394,11 @@ public class VMSupport {
     }
 
     public static boolean isWindows() {
-        return System.getProperty("os.name").contains("indows");
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     public static boolean isLinux() {
-        return System.getProperty("os.name").contains("Linux");
+        return System.getProperty("os.name").toLowerCase().contains("linux");
     }
 
     public static List<Config> getAvailableVMConfigs() {


### PR DESCRIPTION
When jcstress is presented with large font, the status line is too long to be useful. We can use multi-line ANSI codes to break it into pieces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902959](https://bugs.openjdk.java.net/browse/CODETOOLS-7902959): jcstress: Update progress line to ANSI multi-line for better presentation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.java.net/jcstress pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/65.diff">https://git.openjdk.java.net/jcstress/pull/65.diff</a>

</details>
