### PR TITLE
CODETOOLS-7902961: jcstress: Add jcstress-samples to tests-all bundle

### DIFF
--- a/tests-all/pom.xml
+++ b/tests-all/pom.xml
@@ -71,6 +71,11 @@ questions.
     <dependencies>
         <dependency>
             <groupId>org.openjdk.jcstress</groupId>
+            <artifactId>jcstress-samples</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jcstress</groupId>
             <artifactId>jcstress-tests-custom</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
It makes little sense to avoid jcstress samples from tests-all bundle. Adding samples to tests-all bundle also implicitly verifies them during the normal concurrency testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902961](https://bugs.openjdk.java.net/browse/CODETOOLS-7902961): jcstress: Add jcstress-samples to tests-all bundle


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/jcstress pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/66.diff">https://git.openjdk.java.net/jcstress/pull/66.diff</a>

</details>
