### PR TITLE
CODETOOLS-7902962: jcstress: Print merged results at the end of the run

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -149,7 +149,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
             if (!progressInteractive) {
                 output.println();
             }
-            ReportUtils.printResult(output, r, true);
+            ReportUtils.printResult(output, r, false);
         }
 
         if (shouldPrintStatusLine) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -110,20 +110,22 @@ public class ReportUtils {
         return root;
     }
 
-    public static void printResult(PrintWriter pw, TestResult r, boolean inProgress) {
+    public static void printResult(PrintWriter pw, TestResult r, boolean finalResults) {
         TestConfig config = r.getConfig();
 
         String label = StringUtils.leftPadDash("[" + ReportUtils.statusToLabel(r) + "]", 15);
         String testName = StringUtils.chunkName(r.getName());
         pw.printf("%15s %s%n", label, testName);
         pw.println();
-        pw.format("  Scheduling class:%n");
-        pw.println(SchedulingClass.description(config.getSchedulingClass(), config.actorNames));
-        pw.format("  CPU allocation:%n");
-        pw.println(CPUMap.description(config.cpuMap, config.actorNames));
-        pw.format("  Compilation: %s%n", CompileMode.description(config.getCompileMode(), config.actorNames));
-        pw.format("  JVM args: %s%n", config.jvmArgs);
-        if (inProgress) {
+        if (finalResults) {
+            pw.println("  Results across all configurations:");
+        } else {
+            pw.format("  Scheduling class:%n");
+            pw.println(SchedulingClass.description(config.getSchedulingClass(), config.actorNames));
+            pw.format("  CPU allocation:%n");
+            pw.println(CPUMap.description(config.cpuMap, config.actorNames));
+            pw.format("  Compilation: %s%n", CompileMode.description(config.getCompileMode(), config.actorNames));
+            pw.format("  JVM args: %s%n", config.jvmArgs);
             pw.format("  Fork: #%d%n", config.forkId + 1);
         }
         pw.println();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -58,32 +58,30 @@ public class TextReportPrinter {
     public void work() {
         emittedTests.clear();
 
-        List<TestResult> byConfig = ReportUtils.mergedByName(collector.getTestResults());
-        Collections.sort(byConfig, Comparator
-                .comparing(TestResult::getName)
-                .thenComparing(t -> t.getConfig().jvmArgs.toString()));
+        List<TestResult> byName = ReportUtils.mergedByName(collector.getTestResults());
+        Collections.sort(byName, Comparator.comparing(TestResult::getName));
 
         pw.println("RUN RESULTS:");
 
-        printXTests(byConfig,
+        printXTests(byName,
                 "Interesting tests",
                 r -> r.status() == Status.NORMAL && r.grading().hasInteresting,
                 true
         );
 
-        printXTests(byConfig,
+        printXTests(byName,
                 "Failed tests",
                 r -> r.status() == Status.NORMAL && !r.grading().isPassed,
                 true
         );
 
-        printXTests(byConfig,
+        printXTests(byName,
                 "Error tests",
                 r -> r.status() != Status.NORMAL && r.status() != Status.API_MISMATCH,
                 true
         );
 
-        printXTests(byConfig,
+        printXTests(byName,
                 "All remaining tests",
                 r -> !emittedTests.contains(r),
                 verbosity.printAllTests());

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -58,7 +58,7 @@ public class TextReportPrinter {
     public void work() {
         emittedTests.clear();
 
-        List<TestResult> byConfig = ReportUtils.mergedByConfig(collector.getTestResults());
+        List<TestResult> byConfig = ReportUtils.mergedByName(collector.getTestResults());
         Collections.sort(byConfig, Comparator
                 .comparing(TestResult::getName)
                 .thenComparing(t -> t.getConfig().jvmArgs.toString()));
@@ -68,19 +68,19 @@ public class TextReportPrinter {
         printXTests(byConfig,
                 "Interesting tests",
                 r -> r.status() == Status.NORMAL && r.grading().hasInteresting,
-                verbosity.printAllTests()
+                true
         );
 
         printXTests(byConfig,
                 "Failed tests",
                 r -> r.status() == Status.NORMAL && !r.grading().isPassed,
-                verbosity.printAllTests()
+                true
         );
 
         printXTests(byConfig,
                 "Error tests",
                 r -> r.status() != Status.NORMAL && r.status() != Status.API_MISMATCH,
-                verbosity.printAllTests()
+                true
         );
 
         printXTests(byConfig,
@@ -116,7 +116,7 @@ public class TextReportPrinter {
 
     public void emitTest(TestResult result) {
         emittedTests.add(result);
-        ReportUtils.printResult(pw, result, false);
+        ReportUtils.printResult(pw, result, true);
     }
 
 }


### PR DESCRIPTION
It makes little sense to print the per-configuration results at the end of the run, when the run itself prints it. We are better off printing the merged results across all configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902962](https://bugs.openjdk.java.net/browse/CODETOOLS-7902962): jcstress: Print merged results at the end of the run


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jcstress pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/67.diff">https://git.openjdk.java.net/jcstress/pull/67.diff</a>

</details>
