### PR TITLE
CODETOOLS-7902964: jcstress: Introduce short-stride checkpointing for more frequent collisions

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -47,7 +47,7 @@ import java.util.*;
 public class Options {
     private String resultDir;
     private String testFilter;
-    private int minStride, maxStride;
+    private int stride;
     private int time;
     private int iters;
     private final String[] args;
@@ -85,7 +85,7 @@ public class Options {
         OptionSpec<String> testFilter = parser.accepts("t", "Regexp selector for tests.")
                 .withRequiredArg().ofType(String.class).describedAs("regexp");
 
-        OptionSpec<Integer> minStride = parser.accepts("minStride", "Minimum internal stride size. Larger value decreases " +
+        OptionSpec<Integer> stride = parser.accepts("stride", "Internal stride size. Larger value decreases " +
                 "the synchronization overhead, but also reduces accuracy.")
                 .withRequiredArg().ofType(Integer.class).describedAs("N");
 
@@ -195,16 +195,14 @@ public class Options {
         this.time = 1000;
         this.iters = 5;
         this.forks = 1;
-        this.minStride = 10;
-        this.maxStride = 10000;
+        this.stride = 10000;
 
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {
             this.time = 0;
             this.iters = 1;
             this.forks = 1;
-            this.minStride = 1;
-            this.maxStride = 1;
+            this.stride = 1;
         } else
         if (this.mode.equalsIgnoreCase("quick")) {
             this.time = 200;
@@ -230,8 +228,7 @@ public class Options {
         this.time = orDefault(set.valueOf(time), this.time);
         this.iters = orDefault(set.valueOf(iters), this.iters);
         this.forks = orDefault(set.valueOf(forks), this.forks);
-        this.minStride = orDefault(set.valueOf(minStride), this.minStride);
-        this.maxStride = orDefault(set.valueOf(maxStride), this.maxStride);
+        this.stride = orDefault(set.valueOf(stride), this.stride);
 
         this.heapPerFork = orDefault(set.valueOf(heapPerFork), 256);
 
@@ -275,17 +272,13 @@ public class Options {
         out.printf("  Writing the test results to \"%s\"%n", resultFile);
         out.printf("  Parsing results to \"%s\"%n", resultDir);
         out.printf("  Running each test matching \"%s\" for %d forks, %d iterations, %d ms each%n", getTestFilter(), getForks(), getIterations(), getTime());
-        out.printf("  Solo stride size will be autobalanced within [%d, %d] elements, but taking no more than %d Mb.%n", getMinStride(), getMaxStride(), getMaxFootprintMb());
+        out.printf("  Stride size: %d elements, but taking no more than %d Mb.%n", getStride(), getMaxFootprintMb());
 
         out.println();
     }
 
-    public int getMinStride() {
-        return minStride;
-    }
-
-    public int getMaxStride() {
-        return maxStride;
+    public int getStride() {
+        return stride;
     }
 
     public String getResultDest() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -196,7 +196,7 @@ public class Options {
         this.iters = 5;
         this.forks = 1;
         this.stride = 256;
-        this.epoch = 10000;
+        this.epoch = 10240;
 
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -559,7 +559,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("                int end = Math.min(len, start + stride);");
             pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
             pw.println("                check += " + actorsCount + ";");
-            pw.println("                sync.waitCheckpoint(check);");
+            pw.println("                sync.awaitCheckpoint(check);");
             pw.println("            }");
             pw.println("            " + AUX_PREFIX + "consume(counter, " + n + ");");
             pw.println("            if (sync.tryStartUpdate()) {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -379,7 +379,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println();
 
         pw.println("    private void sanityCheck_Footprints(Counter<" + r + "> counter) throws Throwable {");
-        pw.println("        config.adjustStrides(new FootprintEstimator() {");
+        pw.println("        config.adjustEpoch(new FootprintEstimator() {");
         pw.println("          public void runWith(int size, long[] cnts) {");
         pw.println("            long time1 = System.nanoTime();");
         pw.println("            long alloc1 = AllocProfileSupport.getAllocatedBytes();");
@@ -554,10 +554,12 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("            }");
             pw.println("            int len = config.epoch;");
             pw.println("            int stride = config.stride;");
-            pw.println("            for (int start = 0, int ch = 1; start < len; start += stride, ch++) {");
+            pw.println("            int check = 0;");
+            pw.println("            for (int start = 0; start < len; start += stride) {");
             pw.println("                int end = Math.min(len, start + stride);");
             pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
-            pw.println("                sync.waitCheckpoint(ch * " + actorsCount + ");");
+            pw.println("                check += " + actorsCount + ";");
+            pw.println("                sync.waitCheckpoint(check);");
             pw.println("            }");
             pw.println("            " + AUX_PREFIX + "consume(counter, " + n + ");");
             pw.println("            if (sync.tryStartUpdate()) {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -553,13 +553,12 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("                return counter;");
             pw.println("            }");
             pw.println("            int len = config.epoch;");
-            pw.println("            for (int e = 0; e <= 128; e++) {");
-            pw.println("                int start = len * e >> 7;");
-            pw.println("                int end = Math.min(len, len * (e + 1) >> 7);");
+            pw.println("            int stride = config.stride;");
+            pw.println("            for (int start = 0, int ch = 1; start < len; start += stride, ch++) {");
+            pw.println("                int end = Math.min(len, start + stride);");
             pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
-            pw.println("                sync.waitStride((e + 1)*" + actorsCount + ");");
+            pw.println("                sync.waitCheckpoint(ch * " + actorsCount + ");");
             pw.println("            }");
-
             pw.println("            " + AUX_PREFIX + "consume(counter, " + n + ");");
             pw.println("            if (sync.tryStartUpdate()) {");
             pw.println("                workerSync = new WorkerSync(control.isStopped, " + actorsCount + ", config.spinLoopStyle);");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -576,8 +576,13 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("                return counter;");
             pw.println("            }");
             pw.println("            sync.preRun();");
-            pw.println("            " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr);");
-            pw.println("            sync.postRun();");
+            pw.println("            for (int e = 0; e < 10; e++) {");
+            pw.println("                int start = gs.length * e / 10;");
+            pw.println("                int end = gs.length * (e + 1) / 10;");
+            pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
+            pw.println("                sync.waitEpoch((e+1)*" + actorsCount + ");");
+            pw.println("            }");
+
             pw.println("            " + AUX_PREFIX + "consume(counter, " + n + ");");
             pw.println("            if (sync.tryStartUpdate()) {");
             pw.println("                " + AUX_PREFIX + "update(sync);");
@@ -586,14 +591,14 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("        }");
             pw.println("    }");
             pw.println();
-            pw.println("    private void " + RUN_LOOP_PREFIX + a.getSimpleName() + "(" + s + "[] gs, " + r + "[] gr) {");
+            pw.println("    private void " + RUN_LOOP_PREFIX + a.getSimpleName() + "(" + s + "[] gs, " + r + "[] gr, int start, int end) {");
             if (!isStateItself) {
                 pw.println("        " + t + " lt = test;");
             }
             pw.println("        " + s + "[] ls = gs;");
             pw.println("        " + r + "[] lr = gr;");
             pw.println("        int size = ls.length;");
-            pw.println("        for (int c = 0; c < size; c++) {");
+            pw.println("        for (int c = start; c < end; c++) {");
 
             // Try to access both state and result fields early. This will help
             // compiler to avoid null-pointer checks in the workload, which will

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -576,9 +576,9 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("                return counter;");
             pw.println("            }");
             pw.println("            sync.preRun();");
-            pw.println("            for (int e = 0; e < 10; e++) {");
-            pw.println("                int start = gs.length * e / 10;");
-            pw.println("                int end = gs.length * (e + 1) / 10;");
+            pw.println("            for (int e = 0; e < 256; e++) {");
+            pw.println("                int start = gs.length * e / 256;");
+            pw.println("                int end = gs.length * (e + 1) / 256;");
             pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
             pw.println("                sync.waitEpoch((e+1)*" + actorsCount + ");");
             pw.println("            }");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -447,9 +447,9 @@ public class JCStressTestProcessor extends AbstractProcessor {
         if (!isStateItself) {
             pw.println("        test = new " + t + "();");
         }
-        pw.println("        gs = new " + s + "[config.stride];");
-        pw.println("        gr = new " + r + "[config.stride];");
-        pw.println("        for (int c = 0; c < config.stride; c++) {");
+        pw.println("        gs = new " + s + "[config.epoch];");
+        pw.println("        gr = new " + r + "[config.epoch];");
+        pw.println("        for (int c = 0; c < config.epoch; c++) {");
         pw.println("            gs[c] = new " + s + "();");
         pw.println("            gr[c] = new " + r + "();");
         pw.println("        }");
@@ -496,8 +496,8 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("    private void " + AUX_PREFIX + "consume(Counter<" + r + "> cnt, int a) {");
         pw.println("        " + s + "[] ls = gs;");
         pw.println("        " + r + "[] lr = gr;");
-        pw.println("        int left = a * config.stride / " + actorsCount + ";");
-        pw.println("        int right = (a + 1) * config.stride / " + actorsCount + ";");
+        pw.println("        int left = a * config.epoch / " + actorsCount + ";");
+        pw.println("        int right = (a + 1) * config.epoch / " + actorsCount + ";");
         pw.println("        for (int c = left; c < right; c++) {");
         pw.println("            " + r + " r = lr[c];");
         pw.println("            " + s + " s = ls[c];");
@@ -552,12 +552,12 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("            if (sync.stopped) {");
             pw.println("                return counter;");
             pw.println("            }");
-            pw.println("            int len = config.stride;");
+            pw.println("            int len = config.epoch;");
             pw.println("            for (int e = 0; e <= 128; e++) {");
             pw.println("                int start = len * e >> 7;");
             pw.println("                int end = Math.min(len, len * (e + 1) >> 7);");
             pw.println("                " + RUN_LOOP_PREFIX + a.getSimpleName() + "(gs, gr, start, end);");
-            pw.println("                sync.waitEpoch((e + 1)*" + actorsCount + ");");
+            pw.println("                sync.waitStride((e + 1)*" + actorsCount + ");");
             pw.println("            }");
 
             pw.println("            " + AUX_PREFIX + "consume(counter, " + n + ");");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -38,6 +38,7 @@ public class ForkedTestConfig {
     public final String generatedRunnerName;
     public final int maxFootprintMB;
     public int stride;
+    public int epoch;
     public boolean localAffinity;
     public int[] localAffinityMap;
 
@@ -48,6 +49,7 @@ public class ForkedTestConfig {
         generatedRunnerName = cfg.generatedRunnerName;
         maxFootprintMB = cfg.maxFootprintMB;
         stride = cfg.stride;
+        epoch = cfg.epoch;
         localAffinity = cfg.shClass.mode() == AffinityMode.LOCAL;
         if (localAffinity) {
             localAffinityMap = cfg.cpuMap.actorMap();
@@ -61,6 +63,7 @@ public class ForkedTestConfig {
         generatedRunnerName = dis.readUTF();
         maxFootprintMB = dis.readInt();
         stride = dis.readInt();
+        epoch = dis.readInt();
         localAffinity = dis.readBoolean();
         if (localAffinity) {
             int len = dis.readInt();
@@ -78,6 +81,7 @@ public class ForkedTestConfig {
         dos.writeUTF(generatedRunnerName);
         dos.writeInt(maxFootprintMB);
         dos.writeInt(stride);
+        dos.writeInt(epoch);
         dos.writeBoolean(localAffinity);
         if (localAffinity) {
             dos.writeInt(localAffinityMap.length);
@@ -87,7 +91,7 @@ public class ForkedTestConfig {
         }
     }
 
-    public void adjustStrides(FootprintEstimator estimator) {
+    public void adjustEpoch(FootprintEstimator estimator) {
         int count = 1;
         int succCount = count;
         while (tryWith(estimator, count)) {
@@ -95,14 +99,14 @@ public class ForkedTestConfig {
             succCount = count;
 
             // do not go over the stride
-            if (succCount >= stride) {
+            if (succCount >= epoch) {
                 return;
             }
 
             count *= 2;
         }
 
-        stride = succCount;
+        epoch = succCount;
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -37,8 +37,7 @@ public class ForkedTestConfig {
     public final int iters;
     public final String generatedRunnerName;
     public final int maxFootprintMB;
-    public int minStride;
-    public int maxStride;
+    public int stride;
     public boolean localAffinity;
     public int[] localAffinityMap;
 
@@ -48,8 +47,7 @@ public class ForkedTestConfig {
         iters = cfg.iters;
         generatedRunnerName = cfg.generatedRunnerName;
         maxFootprintMB = cfg.maxFootprintMB;
-        minStride = cfg.minStride;
-        maxStride = cfg.maxStride;
+        stride = cfg.stride;
         localAffinity = cfg.shClass.mode() == AffinityMode.LOCAL;
         if (localAffinity) {
             localAffinityMap = cfg.cpuMap.actorMap();
@@ -62,8 +60,7 @@ public class ForkedTestConfig {
         iters = dis.readInt();
         generatedRunnerName = dis.readUTF();
         maxFootprintMB = dis.readInt();
-        minStride = dis.readInt();
-        maxStride = dis.readInt();
+        stride = dis.readInt();
         localAffinity = dis.readBoolean();
         if (localAffinity) {
             int len = dis.readInt();
@@ -80,8 +77,7 @@ public class ForkedTestConfig {
         dos.writeInt(iters);
         dos.writeUTF(generatedRunnerName);
         dos.writeInt(maxFootprintMB);
-        dos.writeInt(minStride);
-        dos.writeInt(maxStride);
+        dos.writeInt(stride);
         dos.writeBoolean(localAffinity);
         if (localAffinity) {
             dos.writeInt(localAffinityMap.length);
@@ -94,25 +90,19 @@ public class ForkedTestConfig {
     public void adjustStrides(FootprintEstimator estimator) {
         int count = 1;
         int succCount = count;
-        while (true) {
-            if (!tryWith(estimator, count)) {
-                break;
-            }
-
+        while (tryWith(estimator, count)) {
             // success!
             succCount = count;
 
-            // do not go over the maxStride
-            if (succCount >= maxStride) {
-                succCount = maxStride;
-                break;
+            // do not go over the stride
+            if (succCount >= stride) {
+                return;
             }
 
             count *= 2;
         }
 
-        maxStride = Math.min(maxStride, succCount);
-        minStride = Math.min(minStride, succCount);
+        stride = succCount;
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -37,8 +37,8 @@ public class ForkedTestConfig {
     public final int iters;
     public final String generatedRunnerName;
     public final int maxFootprintMB;
-    public int stride;
-    public int epoch;
+    public final int strideSize;
+    public int strideCount;
     public boolean localAffinity;
     public int[] localAffinityMap;
 
@@ -48,8 +48,8 @@ public class ForkedTestConfig {
         iters = cfg.iters;
         generatedRunnerName = cfg.generatedRunnerName;
         maxFootprintMB = cfg.maxFootprintMB;
-        stride = cfg.stride;
-        epoch = cfg.epoch;
+        strideSize = cfg.strideSize;
+        strideCount = cfg.strideCount;
         localAffinity = cfg.shClass.mode() == AffinityMode.LOCAL;
         if (localAffinity) {
             localAffinityMap = cfg.cpuMap.actorMap();
@@ -62,8 +62,8 @@ public class ForkedTestConfig {
         iters = dis.readInt();
         generatedRunnerName = dis.readUTF();
         maxFootprintMB = dis.readInt();
-        stride = dis.readInt();
-        epoch = dis.readInt();
+        strideSize = dis.readInt();
+        strideCount = dis.readInt();
         localAffinity = dis.readBoolean();
         if (localAffinity) {
             int len = dis.readInt();
@@ -80,8 +80,8 @@ public class ForkedTestConfig {
         dos.writeInt(iters);
         dos.writeUTF(generatedRunnerName);
         dos.writeInt(maxFootprintMB);
-        dos.writeInt(stride);
-        dos.writeInt(epoch);
+        dos.writeInt(strideSize);
+        dos.writeInt(strideCount);
         dos.writeBoolean(localAffinity);
         if (localAffinity) {
             dos.writeInt(localAffinityMap.length);
@@ -91,22 +91,22 @@ public class ForkedTestConfig {
         }
     }
 
-    public void adjustEpoch(FootprintEstimator estimator) {
+    public void adjustStrideCount(FootprintEstimator estimator) {
         int count = 1;
         int succCount = count;
         while (tryWith(estimator, count)) {
             // success!
             succCount = count;
 
-            // do not go over the stride
-            if (succCount >= epoch) {
+            // do not go over the max stride count
+            if (succCount >= strideCount) {
                 return;
             }
 
             count *= 2;
         }
 
-        epoch = succCount;
+        strideCount = succCount;
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/SpinLoopStyle.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/SpinLoopStyle.java
@@ -25,10 +25,10 @@
 package org.openjdk.jcstress.infra.runners;
 
 public enum SpinLoopStyle {
-    HARD("using plain hard busywait."),
-    THREAD_YIELD("using Thread.yield()."),
-    THREAD_SPIN_WAIT("using Thread.onSpinWait()"),
-    LOCKSUPPORT_PARK_NANOS("using LockSupport.parkNanos()."),
+    HARD("plain hard busywait"),
+    THREAD_YIELD("Thread.yield()"),
+    THREAD_SPIN_WAIT("Thread.onSpinWait()"),
+    LOCKSUPPORT_PARK_NANOS("LockSupport.parkNanos()"),
     ;
 
     private String desc;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -45,7 +45,7 @@ public class TestConfig implements Serializable {
     public final List<String> actorNames;
     public final int compileMode;
     public final SchedulingClass shClass;
-    public int minStride;
+    public int stride;
     public int maxStride;
     public CPUMap cpuMap;
 
@@ -57,8 +57,7 @@ public class TestConfig implements Serializable {
         this.forkId = forkId;
         this.jvmArgs = jvmArgs;
         time = opts.getTime();
-        minStride = opts.getMinStride();
-        maxStride = opts.getMaxStride();
+        stride = opts.getStride();
         iters = opts.getIterations();
         spinLoopStyle = opts.getSpinStyle();
         maxFootprintMB = opts.getMaxFootprintMb();
@@ -87,7 +86,7 @@ public class TestConfig implements Serializable {
 
         if (!name.equals(that.name)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
-        if (minStride != that.minStride) return false;
+        if (stride != that.stride) return false;
         if (maxStride != that.maxStride) return false;
         if (time != that.time) return false;
         if (iters != that.iters) return false;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -45,8 +45,8 @@ public class TestConfig implements Serializable {
     public final List<String> actorNames;
     public final int compileMode;
     public final SchedulingClass shClass;
-    public int stride;
-    public int epoch;
+    public final int strideSize;
+    public int strideCount;
     public CPUMap cpuMap;
 
     public void setCPUMap(CPUMap cpuMap) {
@@ -57,8 +57,8 @@ public class TestConfig implements Serializable {
         this.forkId = forkId;
         this.jvmArgs = jvmArgs;
         time = opts.getTime();
-        stride = opts.getStride();
-        epoch = opts.getEpoch();
+        strideSize = opts.getStrideSize();
+        strideCount = opts.getStrideCount();
         iters = opts.getIterations();
         spinLoopStyle = opts.getSpinStyle();
         maxFootprintMB = opts.getMaxFootprintMb();
@@ -87,8 +87,8 @@ public class TestConfig implements Serializable {
 
         if (!name.equals(that.name)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
-        if (stride != that.stride) return false;
-        if (epoch != that.epoch) return false;
+        if (strideSize != that.strideSize) return false;
+        if (strideCount != that.strideCount) return false;
         if (time != that.time) return false;
         if (iters != that.iters) return false;
         if (threads != that.threads) return false;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -46,7 +46,7 @@ public class TestConfig implements Serializable {
     public final int compileMode;
     public final SchedulingClass shClass;
     public int stride;
-    public int maxStride;
+    public int epoch;
     public CPUMap cpuMap;
 
     public void setCPUMap(CPUMap cpuMap) {
@@ -58,6 +58,7 @@ public class TestConfig implements Serializable {
         this.jvmArgs = jvmArgs;
         time = opts.getTime();
         stride = opts.getStride();
+        epoch = opts.getEpoch();
         iters = opts.getIterations();
         spinLoopStyle = opts.getSpinStyle();
         maxFootprintMB = opts.getMaxFootprintMb();
@@ -87,7 +88,7 @@ public class TestConfig implements Serializable {
         if (!name.equals(that.name)) return false;
         if (spinLoopStyle != that.spinLoopStyle) return false;
         if (stride != that.stride) return false;
-        if (maxStride != that.maxStride) return false;
+        if (epoch != that.epoch) return false;
         if (time != that.time) return false;
         if (iters != that.iters) return false;
         if (threads != that.threads) return false;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
@@ -40,20 +40,19 @@ public class WorkerSync {
 
     public volatile boolean updateStride;
     private volatile int notStarted;
-    private volatile int notFinished;
     private volatile int notConsumed;
     private volatile int notUpdated;
+    private volatile int epoch;
 
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_STARTED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notStarted");
-    static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_FINISHED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notFinished");
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_CONSUMED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notConsumed");
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_UPDATED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notUpdated");
+    static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_EPOCH = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "epoch");
 
     public WorkerSync(boolean stopped, int expectedWorkers, SpinLoopStyle spinStyle) {
         this.stopped = stopped;
         this.spinStyle = spinStyle;
         this.notStarted = expectedWorkers;
-        this.notFinished = expectedWorkers;
         this.notConsumed = expectedWorkers;
         this.notUpdated = expectedWorkers;
     }
@@ -67,27 +66,27 @@ public class WorkerSync {
         UPDATER_NOT_STARTED.decrementAndGet(this);
     }
 
-    public void postRun() {
+    public void waitEpoch(int expectedEpoch) {
         // If any thread lags behind, then we need to update our stride
         if (!updateStride && notStarted > 0) {
             updateStride = true;
         }
 
         // Notify that we are finished
-        UPDATER_NOT_FINISHED.decrementAndGet(this);
+        UPDATER_EPOCH.incrementAndGet(this);
 
         switch (spinStyle) {
             case HARD:
-                while (notFinished > 0);
+                while (epoch < expectedEpoch);
                 break;
             case THREAD_YIELD:
-                while (notFinished > 0) Thread.yield();
+                while (epoch < expectedEpoch) Thread.yield();
                 break;
             case THREAD_SPIN_WAIT:
-                while (notFinished > 0) Thread.onSpinWait();
+                while (epoch < expectedEpoch) Thread.onSpinWait();
                 break;
             case LOCKSUPPORT_PARK_NANOS:
-                while (notFinished > 0) LockSupport.parkNanos(1);
+                while (epoch < expectedEpoch) LockSupport.parkNanos(1);
                 break;
             default:
                 throw new IllegalStateException("Unhandled style: " + spinStyle);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
@@ -53,22 +53,22 @@ public class WorkerSync {
         this.notUpdated = expectedWorkers;
     }
 
-    public void waitCheckpoint(int expectedCheckpoint) {
+    public void awaitCheckpoint(int expected) {
         // Notify that we have rolled to the checkpoint
         UPDATER_CHECKPOINT.incrementAndGet(this);
 
         switch (spinStyle) {
             case HARD:
-                while (checkpoint < expectedCheckpoint);
+                while (checkpoint < expected);
                 break;
             case THREAD_YIELD:
-                while (checkpoint < expectedCheckpoint) Thread.yield();
+                while (checkpoint < expected) Thread.yield();
                 break;
             case THREAD_SPIN_WAIT:
-                while (checkpoint < expectedCheckpoint) Thread.onSpinWait();
+                while (checkpoint < expected) Thread.onSpinWait();
                 break;
             case LOCKSUPPORT_PARK_NANOS:
-                while (checkpoint < expectedCheckpoint) LockSupport.parkNanos(1);
+                while (checkpoint < expected) LockSupport.parkNanos(1);
                 break;
             default:
                 throw new IllegalStateException("Unhandled style: " + spinStyle);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
@@ -40,11 +40,11 @@ public class WorkerSync {
 
     private volatile int notConsumed;
     private volatile int notUpdated;
-    private volatile int epoch;
+    private volatile int stride;
 
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_CONSUMED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notConsumed");
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_UPDATED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notUpdated");
-    static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_EPOCH = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "epoch");
+    static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_STRIDE = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "stride");
 
     public WorkerSync(boolean stopped, int expectedWorkers, SpinLoopStyle spinStyle) {
         this.stopped = stopped;
@@ -53,22 +53,22 @@ public class WorkerSync {
         this.notUpdated = expectedWorkers;
     }
 
-    public void waitEpoch(int expectedEpoch) {
+    public void waitStride(int expectedStride) {
         // Notify that we are finished
-        UPDATER_EPOCH.incrementAndGet(this);
+        UPDATER_STRIDE.incrementAndGet(this);
 
         switch (spinStyle) {
             case HARD:
-                while (epoch < expectedEpoch);
+                while (stride < expectedStride);
                 break;
             case THREAD_YIELD:
-                while (epoch < expectedEpoch) Thread.yield();
+                while (stride < expectedStride) Thread.yield();
                 break;
             case THREAD_SPIN_WAIT:
-                while (epoch < expectedEpoch) Thread.onSpinWait();
+                while (stride < expectedStride) Thread.onSpinWait();
                 break;
             case LOCKSUPPORT_PARK_NANOS:
-                while (epoch < expectedEpoch) LockSupport.parkNanos(1);
+                while (stride < expectedStride) LockSupport.parkNanos(1);
                 break;
             default:
                 throw new IllegalStateException("Unhandled style: " + spinStyle);

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/UnfencedDekkerTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/UnfencedDekkerTest.java
@@ -32,6 +32,7 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
+import sun.misc.Contended;
 
 /**
  * Baseline for FencedDekkerTest
@@ -45,12 +46,10 @@ import org.openjdk.jcstress.infra.results.II_Result;
 @State
 public class UnfencedDekkerTest {
 
-    @sun.misc.Contended
-    @jdk.internal.vm.annotation.Contended
+    @Contended
     int a;
 
-    @sun.misc.Contended
-    @jdk.internal.vm.annotation.Contended
+    @Contended
     int b;
 
     @Actor

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/UnfencedDekkerTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/UnfencedDekkerTest.java
@@ -32,7 +32,6 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-import sun.misc.Contended;
 
 /**
  * Baseline for FencedDekkerTest
@@ -46,10 +45,12 @@ import sun.misc.Contended;
 @State
 public class UnfencedDekkerTest {
 
-    @Contended
+    @sun.misc.Contended
+    @jdk.internal.vm.annotation.Contended
     int a;
 
-    @Contended
+    @sun.misc.Contended
+    @jdk.internal.vm.annotation.Contended
     int b;
 
     @Actor


### PR DESCRIPTION
Currently, the harness uses larger strides to run and consume the results of the test. Unfortunately, when actor threads are unbalanced (e.g. run asymmetric workloads), there is a single collision per entire stride. Having shorter strides would increase collision ratios, but would create much more overhead for creating/consuming benchmark results and state.

We can do long "epoch" with several shorter "strides" and spin-loop checkpointing between strides, so that threads can catch up more often.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902964](https://bugs.openjdk.java.net/browse/CODETOOLS-7902964): jcstress: Introduce short-stride checkpointing for more frequent collisions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jcstress pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/69.diff">https://git.openjdk.java.net/jcstress/pull/69.diff</a>

</details>
