### PR TITLE
CODETOOLS-7902965: jcstress: Enhance FREQ precision to 0.01%

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -139,7 +139,7 @@ public class ReportUtils {
 
             int idLen = headResult.length();
             int samplesLen = headSamples.length();
-            int freqLen = Math.max(6, headFreq.length());
+            int freqLen = Math.max(7, headFreq.length());
             int expectLen = headExpect.length();
             int descLen = 60;
 
@@ -178,7 +178,7 @@ public class ReportUtils {
                 pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + "s%" + expectLen + "s  %-" + descLen + "s%n",
                         StringUtils.cutoff(gradeRes.id, idLen),
                         gradeRes.count,
-                        StringUtils.percent(gradeRes.count, totalSamples, 1),
+                        StringUtils.percent(gradeRes.count, totalSamples, 2),
                         gradeRes.expect,
                         StringUtils.cutoff(gradeRes.description, descLen));
             }


### PR DESCRIPTION
Most of the time, small number of samples yields "<0.1%". It would be better to produce the more precise frequency stats, one order of magnitude more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902965](https://bugs.openjdk.java.net/browse/CODETOOLS-7902965): jcstress: Enhance FREQ precision to 0.01%


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/jcstress pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/70.diff">https://git.openjdk.java.net/jcstress/pull/70.diff</a>

</details>
