### PR TITLE
CODETOOLS-7902967: jcstress: Rehash Unsafe usages in infrastructure and tests

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/UnsafeHolder.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/UnsafeHolder.java
@@ -27,11 +27,11 @@ package org.openjdk.jcstress.util;
 public class UnsafeHolder {
 
     // Unsafe mechanics
-    public static final sun.misc.Unsafe U;
+    public static final sun.misc.Unsafe UNSAFE;
 
     static {
         try {
-            U = getUnsafe();
+            UNSAFE = getUnsafe();
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/ContendedTestMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/ContendedTestMain.java
@@ -26,12 +26,13 @@ package org.openjdk.jcstress.vm;
 
 import org.openjdk.jcstress.annotations.Result;
 import org.openjdk.jcstress.util.Reflections;
-import org.openjdk.jcstress.util.UnsafeHolder;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.*;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class ContendedTestMain {
 
@@ -86,7 +87,7 @@ public class ContendedTestMain {
 
         FieldDef(Field f) {
             field = f;
-            offset = UnsafeHolder.U.objectFieldOffset(f);
+            offset = UNSAFE.objectFieldOffset(f);
         }
 
         @Override

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/JMMSample_01_AccessAtomicity.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/JMMSample_01_AccessAtomicity.java
@@ -27,12 +27,13 @@ package org.openjdk.jcstress.samples;
 import org.openjdk.jcstress.annotations.*;
 import org.openjdk.jcstress.infra.results.I_Result;
 import org.openjdk.jcstress.infra.results.J_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class JMMSample_01_AccessAtomicity {
 
@@ -261,20 +262,20 @@ public class JMMSample_01_AccessAtomicity {
     public static class UnsafeCrossCacheLine {
 
         public static final int SIZE = 256;
-        public static final long ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-        public static final long ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+        public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+        public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
 
         byte[] ss = new byte[SIZE];
         long off = ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE * ThreadLocalRandom.current().nextInt(SIZE - 4);
 
         @Actor
         public void writer() {
-            UnsafeHolder.U.putInt(ss, off, 0xFFFFFFFF);
+            UNSAFE.putInt(ss, off, 0xFFFFFFFF);
         }
 
         @Actor
         public void reader(I_Result r) {
-            r.r1 = UnsafeHolder.U.getInt(ss, off);
+            r.r1 = UNSAFE.getInt(ss, off);
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
@@ -31,9 +31,10 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.BBBB_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
 
 import java.util.Random;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests if Unsafe breaks the atomicity while doing cross cache-line reads/writes.")
@@ -51,8 +52,8 @@ public class UnsafeIntAtomicityTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
-    public static final long ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-    public static final long ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+    public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
     /** Alignment constraint: 4-bytes is default, for integers */
@@ -69,12 +70,12 @@ public class UnsafeIntAtomicityTest {
 
     @Actor
     public void actor1() {
-        UnsafeHolder.U.putInt(bytes, offset, 0xFFFFFFFF);
+        UNSAFE.putInt(bytes, offset, 0xFFFFFFFF);
     }
 
     @Actor
     public void actor2(BBBB_Result r) {
-        int t = UnsafeHolder.U.getInt(bytes, offset);
+        int t = UNSAFE.getInt(bytes, offset);
         r.r1 = (byte) ((t >> 0) & 0xFF);
         r.r2 = (byte) ((t >> 8) & 0xFF);
         r.r3 = (byte) ((t >> 16) & 0xFF);

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if acquire-release fences induce proper happens-before.
@@ -56,7 +57,7 @@ public class FencedAcquireReleaseTest {
     public void actor1() {
         x = 1;
         x = 2;
-        UnsafeHolder.U.storeFence();
+        UNSAFE.storeFence();
         y = 1;
         x = 3;
     }
@@ -64,7 +65,7 @@ public class FencedAcquireReleaseTest {
     @Actor
     public void actor2(II_Result r) {
         int sy = y;
-        UnsafeHolder.U.loadFence();
+        UNSAFE.loadFence();
         int sx = x;
         r.r1 = sy;
         r.r2 = sx;

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
@@ -31,7 +31,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if read-after-write using fences preserves SC
@@ -51,14 +52,14 @@ public class FencedDekkerTest {
     @Actor
     public void actor1(II_Result r) {
         a = 1;
-        UnsafeHolder.U.fullFence();
+        UNSAFE.fullFence();
         r.r1 = b;
     }
 
     @Actor
     public void actor2(II_Result r) {
         b = 1;
-        UnsafeHolder.U.fullFence();
+        UNSAFE.fullFence();
         r.r2 = a;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if release fence before publication ensures non-default read
@@ -55,7 +56,7 @@ public class FencedPublicationTest {
     public void actor1() {
         Data d = new Data();
         d.x = 1;
-        UnsafeHolder.U.storeFence();
+        UNSAFE.storeFence();
         data = d;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.III_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Test if acquire/release forces re-read
@@ -55,7 +56,7 @@ public class FencedReadTwiceTest {
     @Actor
     public void actor1() {
         x = 1;
-        UnsafeHolder.U.storeFence();
+        UNSAFE.storeFence();
         y = 1;
     }
 
@@ -63,7 +64,7 @@ public class FencedReadTwiceTest {
     public void actor2(III_Result r) {
         r.r1 = x;
         r.r2 = y;
-        UnsafeHolder.U.loadFence();
+        UNSAFE.loadFence();
         r.r3 = x;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.I_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class BooleanFencedTest {
 
         public Shell() {
             this.x = true;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ByteFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ByteFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.B_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class ByteFencedTest {
 
         public Shell() {
             this.x = (byte) 0xFF;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.C_Result;
 import org.openjdk.jcstress.tests.init.Grading_CharShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_CharShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class CharFencedTest {
 
         public Shell() {
             this.x = 1;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.D_Result;
 import org.openjdk.jcstress.tests.init.Grading_DoubleShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_DoubleShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class DoubleFencedTest {
 
         public Shell() {
             this.x = Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL);
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.F_Result;
 import org.openjdk.jcstress.tests.init.Grading_FloatShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_FloatShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class FloatFencedTest {
 
         public Shell() {
             this.x = Float.intBitsToFloat(0xFFFFFFFF);
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/IntFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/IntFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.I_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class IntFencedTest {
 
         public Shell() {
             this.x = 0xFFFFFFFF;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.J_Result;
 import org.openjdk.jcstress.tests.init.Grading_LongShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_LongShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class LongFencedTest {
 
         public Shell() {
             this.x = 0xFFFFFFFFFFFFFFFFL;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.S_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -44,7 +45,7 @@ public class ShortFencedTest {
 
         public Shell() {
             this.x = (short) 0xFFFF;
-            UnsafeHolder.U.storeFence();
+            UNSAFE.storeFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/UnsafeBusyLoopTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/UnsafeBusyLoopTest.java
@@ -31,7 +31,8 @@ import org.openjdk.jcstress.annotations.Mode;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.Signal;
 import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest(Mode.Termination)
 @Outcome(id = "TERMINATED", expect = Expect.ACCEPTABLE, desc = "The thread had sucessfully terminated.")
@@ -44,7 +45,7 @@ public class UnsafeBusyLoopTest {
 
     static {
         try {
-            offset = UnsafeHolder.U.objectFieldOffset(UnsafeBusyLoopTest.class.getDeclaredField("isStopped"));
+            offset = UNSAFE.objectFieldOffset(UnsafeBusyLoopTest.class.getDeclaredField("isStopped"));
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
         }
@@ -52,7 +53,7 @@ public class UnsafeBusyLoopTest {
 
     @Actor
     public void actor1() {
-        while (!UnsafeHolder.U.getBoolean(this, offset)) {
+        while (!UNSAFE.getBoolean(this, offset)) {
             // burn!
         }
     }

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeArrayInterleaveTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeArrayInterleaveTest.java
@@ -32,7 +32,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.III_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests the word-tearing guarantees for byte[] via Unsafe.")
@@ -43,22 +44,22 @@ public class UnsafeArrayInterleaveTest {
     /** Array size: 256 bytes inevitably crosses the cache line on most implementations */
     public static final int SIZE = 256;
 
-    public static final int ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-    public static final int ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+    public static final int ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    public static final int ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
 
     byte[] ss = new byte[SIZE];
 
     @Actor
     public void actor1() {
         for (int i = 0; i < ss.length; i += 2) {
-            UnsafeHolder.U.putByte(ss, (long)(ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE*i), (byte)1);
+            UNSAFE.putByte(ss, (long)(ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE*i), (byte)1);
         }
     }
 
     @Actor
     public void actor2() {
         for (int i = 1; i < ss.length; i += 2) {
-            UnsafeHolder.U.putByte(ss, (long)(ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE*i), (byte)2);
+            UNSAFE.putByte(ss, (long)(ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE*i), (byte)2);
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
@@ -32,9 +32,10 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
 
 import java.util.Random;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests the word-tearing guarantees for byte[] via Unsafe.")
@@ -51,8 +52,8 @@ public class UnsafeIntTearingTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
-    public static final long ARRAY_BASE_OFFSET = UnsafeHolder.U.arrayBaseOffset(byte[].class);
-    public static final long ARRAY_BASE_SCALE = UnsafeHolder.U.arrayIndexScale(byte[].class);
+    public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
     /** Alignment constraint: 4-bytes is default, for integers */
@@ -71,18 +72,18 @@ public class UnsafeIntTearingTest {
 
     @Actor
     public void actor1() {
-        UnsafeHolder.U.putInt(bytes, offset1, 0xAAAAAAAA);
+        UNSAFE.putInt(bytes, offset1, 0xAAAAAAAA);
     }
 
     @Actor
     public void actor2() {
-        UnsafeHolder.U.putInt(bytes, offset2, 0x55555555);
+        UNSAFE.putInt(bytes, offset2, 0x55555555);
     }
 
     @Arbiter
     public void arbiter1(II_Result r) {
-        r.r1 = UnsafeHolder.U.getInt(bytes, offset1);
-        r.r2 = UnsafeHolder.U.getInt(bytes, offset2);
+        r.r1 = UNSAFE.getInt(bytes, offset1);
+        r.r2 = UNSAFE.getInt(bytes, offset2);
     }
 
 }

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong1.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong1.java
@@ -31,7 +31,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.JJ_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests if Unsafe.getAndAddLong is racy")
@@ -41,11 +42,11 @@ import org.openjdk.jcstress.util.UnsafeHolder;
 @State
 public class UnsafeAddLong1 {
 
-    public static long OFFSET;
+    public static final long OFFSET;
 
     static {
         try {
-            OFFSET = UnsafeHolder.U.objectFieldOffset(UnsafeAddLong1.class.getDeclaredField("x"));
+            OFFSET = UNSAFE.objectFieldOffset(UnsafeAddLong1.class.getDeclaredField("x"));
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
         }
@@ -56,7 +57,7 @@ public class UnsafeAddLong1 {
 
     @Actor
     public void actor1() {
-        UnsafeHolder.U.getAndAddLong(this, OFFSET, 1L << 1);
+        UNSAFE.getAndAddLong(this, OFFSET, 1L << 1);
         written = 1;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong42.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong42.java
@@ -31,7 +31,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.JJ_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests if Unsafe.getAndAddLong is racy")
@@ -41,11 +42,11 @@ import org.openjdk.jcstress.util.UnsafeHolder;
 @State
 public class UnsafeAddLong42 {
 
-    public static long OFFSET;
+    public static final long OFFSET;
 
     static {
         try {
-            OFFSET = UnsafeHolder.U.objectFieldOffset(UnsafeAddLong42.class.getDeclaredField("x"));
+            OFFSET = UNSAFE.objectFieldOffset(UnsafeAddLong42.class.getDeclaredField("x"));
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
         }
@@ -56,7 +57,7 @@ public class UnsafeAddLong42 {
 
     @Actor
     public void actor1() {
-        UnsafeHolder.U.getAndAddLong(this, OFFSET, 1L << 42);
+        UNSAFE.getAndAddLong(this, OFFSET, 1L << 42);
         written = 1;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafePutOrderedTwice.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafePutOrderedTwice.java
@@ -26,7 +26,8 @@ package org.openjdk.jcstress.tests.unsafe;
 
 import org.openjdk.jcstress.annotations.*;
 import org.openjdk.jcstress.infra.results.II_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests if Unsafe.putOrderedInt is in-order")
@@ -40,8 +41,8 @@ public class UnsafePutOrderedTwice {
 
     static {
         try {
-            OFFSET_LOCK = UnsafeHolder.U.objectFieldOffset(UnsafePutOrderedTwice.class.getDeclaredField("lock"));
-            OFFSET_TOP = UnsafeHolder.U.objectFieldOffset(UnsafePutOrderedTwice.class.getDeclaredField("top"));
+            OFFSET_LOCK = UNSAFE.objectFieldOffset(UnsafePutOrderedTwice.class.getDeclaredField("lock"));
+            OFFSET_TOP = UNSAFE.objectFieldOffset(UnsafePutOrderedTwice.class.getDeclaredField("top"));
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
         }
@@ -52,8 +53,8 @@ public class UnsafePutOrderedTwice {
 
     @Actor
     public void actor1() {
-        UnsafeHolder.U.putOrderedInt(this, OFFSET_TOP, 1);
-        UnsafeHolder.U.putOrderedInt(this, OFFSET_LOCK, 1);
+        UNSAFE.putOrderedInt(this, OFFSET_TOP, 1);
+        UNSAFE.putOrderedInt(this, OFFSET_LOCK, 1);
     }
 
     @Actor

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeReadTwiceOverVolatileReadTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeReadTwiceOverVolatileReadTest.java
@@ -26,7 +26,8 @@ package org.openjdk.jcstress.tests.unsafe;
 
 import org.openjdk.jcstress.annotations.*;
 import org.openjdk.jcstress.infra.results.III_Result;
-import org.openjdk.jcstress.util.UnsafeHolder;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Test if volatile write-read induces happens-before if in between two non-volatile reads.
@@ -46,11 +47,11 @@ import org.openjdk.jcstress.util.UnsafeHolder;
 @State
 public class UnsafeReadTwiceOverVolatileReadTest {
 
-    public static long OFFSET;
+    public static final long OFFSET;
 
     static {
         try {
-            OFFSET = UnsafeHolder.U.objectFieldOffset(UnsafeReadTwiceOverVolatileReadTest.class.getDeclaredField("y"));
+            OFFSET = UNSAFE.objectFieldOffset(UnsafeReadTwiceOverVolatileReadTest.class.getDeclaredField("y"));
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
         }
@@ -62,13 +63,13 @@ public class UnsafeReadTwiceOverVolatileReadTest {
     @Actor
     public void actor1() {
         x = 1;
-        UnsafeHolder.U.putIntVolatile(this, OFFSET, 1);
+        UNSAFE.putIntVolatile(this, OFFSET, 1);
     }
 
     @Actor
     public void actor2(III_Result r) {
         r.r1 = x;
-        r.r2 = UnsafeHolder.U.getIntVolatile(this, OFFSET);
+        r.r2 = UNSAFE.getIntVolatile(this, OFFSET);
         r.r3 = x;
     }
 


### PR DESCRIPTION
Currently we use `UnsafeHolder` in test infra and tests, and we can make those usages more straightforward.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902967](https://bugs.openjdk.java.net/browse/CODETOOLS-7902967): jcstress: Rehash Unsafe usages in infrastructure and tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.java.net/jcstress pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/71.diff">https://git.openjdk.java.net/jcstress/pull/71.diff</a>

</details>
