### PR TITLE
CODETOOLS-7902969: jcstress: Fix AdvancedJMM_08_WrongListReleaseOrder test

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_08_WrongListReleaseOrder.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_08_WrongListReleaseOrder.java
@@ -39,7 +39,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
 @State
 @Outcome(id = {"-1", "42"}, expect = ACCEPTABLE,             desc = "Boring")
 @Outcome(id = "0",          expect = ACCEPTABLE_INTERESTING, desc = "Whoa")
-@Outcome(id = "-2",         expect = ACCEPTABLE_INTERESTING, desc = "Whoa-whoa")
+@Outcome(id = {"-2", "-3"}, expect = ACCEPTABLE_INTERESTING, desc = "Whoa-whoa")
 public class AdvancedJMM_08_WrongListReleaseOrder {
 
     /*
@@ -86,9 +86,14 @@ public class AdvancedJMM_08_WrongListReleaseOrder {
                 r.r1 = 0;
             } else {
                 try {
-                    r.r1 = l.get(0);
+                    Integer li = l.get(0);
+                    if (li != null) {
+                        r.r1 = li;
+                    } else {
+                        r.r1 = -2;
+                    }
                 } catch (ArrayIndexOutOfBoundsException e) {
-                    r.r1 = -2;
+                    r.r1 = -3;
                 }
             }
         } else {


### PR DESCRIPTION
There is apparently a missing outcome when the backing array is already resized, but the store did not happen yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902969](https://bugs.openjdk.java.net/browse/CODETOOLS-7902969): jcstress: Fix AdvancedJMM_08_WrongListReleaseOrder test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.java.net/jcstress pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/73.diff">https://git.openjdk.java.net/jcstress/pull/73.diff</a>

</details>
