### PR TITLE
CODETOOLS-7902971: jcstress: Interepreted mode match is incorrect

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -333,7 +333,7 @@ public class TestExecutor {
                 // Allow run loop to be compiled with the best compiler available.
                 if (CompileMode.isInt(cm, a)) {
                     pw.println("  {");
-                    pw.println("    match: \"+" + task.name + "::" + an + "\",");
+                    pw.println("    match: \"" + task.name + "::" + an + "\",");
                     pw.println("    c1: {");
                     pw.println("      Exclude: true,");
                     pw.println("    },");


### PR DESCRIPTION
Look here:

```
                // If this actor runs in interpreted mode, then actor method should not be compiled.
                // Allow run loop to be compiled with the best compiler available.
                if (CompileMode.isInt(cm, a)) {
                    pw.println(" {");
                    pw.println(" match: \"+" + task.name + "::" + an + "\",");
```

The "+" sign there is a copy-paste error from a relevant "inline" block. But "+" makes no sense in "match", and it would always mismatch. That means the "interpreter" split configuration are actually compiling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902971](https://bugs.openjdk.java.net/browse/CODETOOLS-7902971): jcstress: Interepreted mode match is incorrect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/jcstress pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/74.diff">https://git.openjdk.java.net/jcstress/pull/74.diff</a>

</details>
