### PR TITLE
CODETOOLS-7902973: jcstress: Compiler directives should include binary, not qualified class names

### DIFF
--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -60,7 +60,7 @@ public class SampleTestBench {
         String testName = SampleTest.class.getCanonicalName();
         String runnerName = SampleTest_jcstress.class.getCanonicalName();
 
-        TestInfo ti = new TestInfo(testName, runnerName, "", 2, Arrays.asList("a1", "a2"), false);
+        TestInfo ti = new TestInfo(testName, testName, runnerName, "", 2, Arrays.asList("a1", "a2"), false);
         TestConfig cfg = new TestConfig(opts, ti, 1, Collections.emptyList(), CompileMode.UNIFIED, new SchedulingClass(AffinityMode.NONE, 2));
         int[] map = new int[2];
         map[0] = -1;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -28,9 +28,7 @@ import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.infra.processors.JCStressTestProcessor;
-import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
-import org.openjdk.jcstress.infra.runners.WorkerSync;
+import org.openjdk.jcstress.infra.runners.*;
 import org.openjdk.jcstress.link.BinaryLinkServer;
 import org.openjdk.jcstress.link.ServerListener;
 import org.openjdk.jcstress.os.*;
@@ -250,6 +248,39 @@ public class TestExecutor {
 
             PrintWriter pw = new PrintWriter(compilerDirectives);
             pw.println("[");
+
+            // The auxiliary thread roots are not compiled at all, so that calling
+            // actor methods there directly does not enter the compilers at all.
+            pw.println("  {");
+            pw.println("    match: \"" + VoidThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("    c1: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("    c2: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("  },");
+            pw.println("  {");
+            pw.println("    match: \"" + LongThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("    c1: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("    c2: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("  },");
+            pw.println("  {");
+            pw.println("    match: \"" + CounterThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("    c1: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("    c2: {");
+            pw.println("      Exclude: true,");
+            pw.println("    },");
+            pw.println("  },");
 
             // The task loop:
             pw.println("  {");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/TestInfo.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/TestInfo.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 
 public class TestInfo {
     private final String name;
+    private final String binaryName;
     private final String description;
     private final String runner;
     private final int threads;
@@ -42,8 +43,9 @@ public class TestInfo {
     private final Collection<String> refs;
     private final List<String> actorNames;
 
-    public TestInfo(String name, String runner, String description, int threads, List<String> actorNames, boolean requiresFork) {
+    public TestInfo(String name, String binaryName, String runner, String description, int threads, List<String> actorNames, boolean requiresFork) {
         this.name = name;
+        this.binaryName = binaryName;
         this.runner = runner;
         this.description = description;
         this.threads = threads;
@@ -77,6 +79,10 @@ public class TestInfo {
 
     public String name() {
         return name;
+    }
+
+    public String binaryName() {
+        return binaryName;
     }
 
     public String description() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -38,6 +38,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
@@ -95,12 +96,14 @@ public class JCStressTestProcessor extends AbstractProcessor {
             }
         } else {
             try {
+                Elements elements = processingEnv.getElementUtils();
                 FileObject file = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", TestList.LIST.substring(1));
                 PrintWriter writer = new PrintWriter(file.openWriter());
                 for (TestInfo test : tests) {
                     TestLineWriter wl = new TestLineWriter();
 
                     wl.put(test.getTest().getQualifiedName().toString());
+                    wl.put(elements.getBinaryName(test.getTest()).toString());
                     wl.put(test.getGeneratedName());
                     wl.put(test.getDescription());
                     List<ExecutableElement> actors = test.getActors();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -38,6 +38,7 @@ public class TestConfig implements Serializable {
     public final int iters;
     public final int threads;
     public final String name;
+    public final String binaryName;
     public final String generatedRunnerName;
     public final List<String> jvmArgs;
     public final int forkId;
@@ -64,6 +65,7 @@ public class TestConfig implements Serializable {
         maxFootprintMB = opts.getMaxFootprintMb();
         threads = info.threads();
         name = info.name();
+        binaryName = info.binaryName();
         generatedRunnerName = info.generatedRunner();
         actorNames = info.actorNames();
         this.compileMode = compileMode;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestList.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestList.java
@@ -57,6 +57,7 @@ public class TestList {
 
                     if (read.isCorrect()) {
                         String name = read.nextString();
+                        String binaryName = read.nextString();
                         String runner = read.nextString();
                         String description = read.nextString();
 
@@ -69,7 +70,7 @@ public class TestList {
                         boolean requiresFork = read.nextBoolean();
                         int caseCount = read.nextInt();
 
-                        TestInfo testInfo = new TestInfo(name, runner, description, actorCount, actorNames, requiresFork);
+                        TestInfo testInfo = new TestInfo(name, binaryName, runner, description, actorCount, actorNames, requiresFork);
                         m.put(name, testInfo);
 
                         for (int c = 0; c < caseCount; c++) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -106,9 +106,6 @@ public class VMSupport {
 
         COMPILERS_AVAILABLE = C1_AVAILABLE || C2_AVAILABLE;
 
-        C1_AVAILABLE = false;
-        C2_AVAILABLE = false;
-
         // Tests are supposed to run in a very tight memory constraints:
         // the test objects are small and reused where possible. The footprint
         // testing machinery would select appropriate stride sizes to fit the heap.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -106,6 +106,9 @@ public class VMSupport {
 
         COMPILERS_AVAILABLE = C1_AVAILABLE || C2_AVAILABLE;
 
+        C1_AVAILABLE = false;
+        C2_AVAILABLE = false;
+
         // Tests are supposed to run in a very tight memory constraints:
         // the test objects are small and reused where possible. The footprint
         // testing machinery would select appropriate stride sizes to fit the heap.


### PR DESCRIPTION
This seems to cause issues for nested classes. Annotation processor normally answers the "qualified name", which concatenates the nested class name with ".". Compiler directives expect nested class names to be concatenated with "$", that is, expect the binary class name.

Currently, requested-to-run-in-interpreter nested class methods would mismatch and be compiled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902973](https://bugs.openjdk.java.net/browse/CODETOOLS-7902973): jcstress: Compiler directives should include binary, not qualified class names


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.java.net/jcstress pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/75.diff">https://git.openjdk.java.net/jcstress/pull/75.diff</a>

</details>
