### PR TITLE
CODETOOLS-7902972: jcstress: Worker thread methods should not inline further calls

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -28,9 +28,7 @@ import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.collectors.TestResult;
 import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.infra.processors.JCStressTestProcessor;
-import org.openjdk.jcstress.infra.runners.ForkedTestConfig;
-import org.openjdk.jcstress.infra.runners.TestConfig;
-import org.openjdk.jcstress.infra.runners.WorkerSync;
+import org.openjdk.jcstress.infra.runners.*;
 import org.openjdk.jcstress.link.BinaryLinkServer;
 import org.openjdk.jcstress.link.ServerListener;
 import org.openjdk.jcstress.os.*;
@@ -250,6 +248,23 @@ public class TestExecutor {
 
             PrintWriter pw = new PrintWriter(compilerDirectives);
             pw.println("[");
+
+            // The worker threads:
+            // Avoid any inlining for worker threads: either wait for task loop
+            // compilation and pick up from there, or avoid inlining the actor method
+            // that might be interpreted.
+            pw.println("  {");
+            pw.println("    match: \"" + VoidThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("  },");
+            pw.println("  {");
+            pw.println("    match: \"" + LongThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("  },");
+            pw.println("  {");
+            pw.println("    match: \"" + CounterThread.class.getName() + "::*\",");
+            pw.println("    inline: \"-*::*\",");
+            pw.println("  },");
 
             // The task loop:
             pw.println("  {");


### PR DESCRIPTION
Currently, actor methods can be called from the sanity checks, thus bypassing the non-inlineablitity directives for run loops. A similar issue is with worker thread and task loop: task loop configuration should take precedence over (default) worker thread config.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902972](https://bugs.openjdk.java.net/browse/CODETOOLS-7902972): jcstress: Worker thread methods should not inline further calls


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/jcstress pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/76.diff">https://git.openjdk.java.net/jcstress/pull/76.diff</a>

</details>
