### PR TITLE
CODETOOLS-7902974: jcstress: Footprint estimator should balance both stride count and stride size

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -37,7 +37,7 @@ public class ForkedTestConfig {
     public final int iters;
     public final String generatedRunnerName;
     public final int maxFootprintMB;
-    public final int strideSize;
+    public int strideSize;
     public int strideCount;
     public boolean localAffinity;
     public int[] localAffinityMap;
@@ -92,21 +92,38 @@ public class ForkedTestConfig {
     }
 
     public void adjustStrideCount(FootprintEstimator estimator) {
+        int size = 1;
+        int succSize = size;
+        while (tryWith(estimator, size)) {
+            // success!
+            succSize = size;
+
+            // do not go over the max stride size
+            if (succSize >= strideSize) {
+                succSize = strideSize;
+                break;
+            }
+
+            size *= 2;
+        }
+
         int count = 1;
         int succCount = count;
-        while (tryWith(estimator, count)) {
+        while (tryWith(estimator, succSize*count)) {
             // success!
             succCount = count;
 
             // do not go over the max stride count
             if (succCount >= strideCount) {
-                return;
+                succCount = strideCount;
+                break;
             }
 
             count *= 2;
         }
 
         strideCount = succCount;
+        strideSize = succSize;
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -92,38 +92,23 @@ public class ForkedTestConfig {
     }
 
     public void adjustStrideCount(FootprintEstimator estimator) {
-        int size = 1;
-        int succSize = size;
-        while (tryWith(estimator, size)) {
-            // success!
-            succSize = size;
-
-            // do not go over the max stride size
-            if (succSize >= strideSize) {
-                succSize = strideSize;
-                break;
-            }
-
-            size *= 2;
-        }
-
         int count = 1;
         int succCount = count;
-        while (tryWith(estimator, succSize*count)) {
+        while (tryWith(estimator, count)) {
             // success!
             succCount = count;
 
-            // do not go over the max stride count
-            if (succCount >= strideCount) {
-                succCount = strideCount;
+            // do not go over the the limit
+            if (succCount >= strideSize * strideCount) {
+                succCount = strideSize * strideCount;
                 break;
             }
 
             count *= 2;
         }
 
-        strideCount = succCount;
-        strideSize = succSize;
+        strideSize = Math.min(succCount, strideSize);
+        strideCount = succCount / strideSize;
     }
 
     private boolean tryWith(FootprintEstimator estimator, int count) {


### PR DESCRIPTION
Current "arrays.large" are failing with OOM because estimator only balances the stride count, while leaving stride size at 256. This is a recent regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902974](https://bugs.openjdk.java.net/browse/CODETOOLS-7902974): jcstress: Footprint estimator should balance both stride count and stride size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/jcstress pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/77.diff">https://git.openjdk.java.net/jcstress/pull/77.diff</a>

</details>
