### PR TITLE
CODETOOLS-7902975: jcstress: JDK 17 cannot cleanly compile due to SecurityManager deprecation

### DIFF
--- a/jcstress-core/src/main/java/sun/misc/Unsafe.java
+++ b/jcstress-core/src/main/java/sun/misc/Unsafe.java
@@ -25,7 +25,6 @@
 package sun.misc;
 
 import java.lang.reflect.Field;
-import java.security.ProtectionDomain;
 
 /**
  * Transitional interface, allows to compile the project against old JDKs.
@@ -155,10 +154,6 @@ public abstract class Unsafe {
     public abstract int addressSize();
 
     public abstract int pageSize();
-
-    public abstract Class<?> defineClass(String name, byte[] b, int off, int len,
-                                       ClassLoader loader,
-                                       ProtectionDomain protectionDomain);
 
     public abstract Class<?> defineClass(String name, byte[] b, int off, int len);
 


### PR DESCRIPTION
Look at the bug for the build failure log.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902975](https://bugs.openjdk.java.net/browse/CODETOOLS-7902975): jcstress: JDK 17 cannot cleanly compile due to SecurityManager deprecation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/jcstress pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/78.diff">https://git.openjdk.java.net/jcstress/pull/78.diff</a>

</details>
