### PR TITLE
CODETOOLS-7902977: jcstress: Minor touchups for jcstress-samples

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_01_SynchronizedBarriers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_01_SynchronizedBarriers.java
@@ -44,7 +44,7 @@ public class AdvancedJMM_01_SynchronizedBarriers {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_01
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_01_SynchronizedBarriers
      */
 
     /*

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
@@ -36,11 +36,11 @@ import java.lang.invoke.VarHandle;
 import static org.openjdk.jcstress.annotations.Expect.*;
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
-public class AdvancedJMM_02_MemorySynchronicity {
+public class AdvancedJMM_02_MultiCopyAtomic {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_02_MemorySynchronicity[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_02_MultiCopyAtomic[.SubTestName]
      */
 
     /*
@@ -81,23 +81,23 @@ public class AdvancedJMM_02_MemorySynchronicity {
 
         But on PPC64 -- that is not a multi-copy atomic architecture -- this test yields:
 
-              RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
-          0, 0, 0, 0    8,000,004    0.78%   Acceptable  Boring
-          0, 0, 0, 1    1,464,110    0.14%   Acceptable  Boring
-          0, 0, 1, 0    1,179,814    0.12%   Acceptable  Boring
-          0, 0, 1, 1   41,275,652    4.03%   Acceptable  Boring
-          0, 1, 0, 0    1,038,437    0.10%   Acceptable  Boring
-          0, 1, 0, 1       60,198   <0.01%   Acceptable  Boring
-          0, 1, 1, 0    5,957,811    0.58%   Acceptable  Boring
-          0, 1, 1, 1   19,326,879    1.88%   Acceptable  Boring
-          1, 0, 0, 0      999,321    0.10%   Acceptable  Boring
-          1, 0, 0, 1    6,711,610    0.65%   Acceptable  Boring
-          1, 0, 1, 0       28,752   <0.01%  Interesting  Whoa
-          1, 0, 1, 1   19,428,477    1.89%   Acceptable  Boring
-          1, 1, 0, 0   21,080,890    2.06%   Acceptable  Boring
-          1, 1, 0, 1   17,442,987    1.70%   Acceptable  Boring
-          1, 1, 1, 0   15,403,205    1.50%   Acceptable  Boring
-          1, 1, 1, 1  865,916,157   84.45%   Acceptable  Boring
+              RESULT        SAMPLES     FREQ       EXPECT  DESCRIPTION
+          0, 0, 0, 0     37,176,296    0.64%   Acceptable  Boring
+          0, 0, 0, 1      9,400,698    0.16%   Acceptable  Boring
+          0, 0, 1, 0      7,820,972    0.13%   Acceptable  Boring
+          0, 0, 1, 1    264,268,403    4.54%   Acceptable  Boring
+          0, 1, 0, 0      6,000,722    0.10%   Acceptable  Boring
+          0, 1, 0, 1        285,037   <0.01%   Acceptable  Boring
+          0, 1, 1, 0     33,201,729    0.57%   Acceptable  Boring
+          0, 1, 1, 1    119,718,218    2.05%   Acceptable  Boring
+          1, 0, 0, 0      5,952,891    0.10%   Acceptable  Boring
+          1, 0, 0, 1     42,960,279    0.74%   Acceptable  Boring
+          1, 0, 1, 0        144,597   <0.01%  Interesting  Whoa
+          1, 0, 1, 1    111,705,898    1.92%   Acceptable  Boring
+          1, 1, 0, 0    149,136,163    2.56%   Acceptable  Boring
+          1, 1, 0, 1    108,356,855    1.86%   Acceptable  Boring
+          1, 1, 1, 0    100,533,303    1.73%   Acceptable  Boring
+          1, 1, 1, 1  4,829,074,643   82.89%   Acceptable  Boring
      */
 
     @JCStressTest
@@ -147,27 +147,28 @@ public class AdvancedJMM_02_MemorySynchronicity {
       ----------------------------------------------------------------------------------------------------------
 
         To see why this is not a vanilla memory reordering, we can put fences around the critical accesses.
-        If we follow the "usual" fencing around the seqc
+        If we follow the "usual" fencing around the accesses, it would not help on non-multi-copy-atomic
+        platforms. Even though we stick all accesses in their places, and prevent reads going one over the
+        other, the asynchronous nature of memory updates would manifest on some platforms.
 
-
-PPC64:
-      RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
-  0, 0, 0, 0  116,646,109   22.21%   Acceptable  Boring
-  0, 0, 0, 1   19,589,207    3.73%   Acceptable  Boring
-  0, 0, 1, 0   13,989,162    2.66%   Acceptable  Boring
-  0, 0, 1, 1   22,118,188    4.21%   Acceptable  Boring
-  0, 1, 0, 0   16,780,917    3.20%   Acceptable  Boring
-  0, 1, 0, 1       44,960   <0.01%   Acceptable  Boring
-  0, 1, 1, 0   54,578,089   10.39%   Acceptable  Boring
-  0, 1, 1, 1    3,448,588    0.66%   Acceptable  Boring
-  1, 0, 0, 0   15,474,140    2.95%   Acceptable  Boring
-  1, 0, 0, 1   63,265,053   12.05%   Acceptable  Boring
-  1, 0, 1, 0        2,151   <0.01%  Interesting  Whoa
-  1, 0, 1, 1    2,820,992    0.54%   Acceptable  Boring
-  1, 1, 0, 0   33,421,547    6.36%   Acceptable  Boring
-  1, 1, 0, 1   10,101,731    1.92%   Acceptable  Boring
-  1, 1, 1, 0    9,358,080    1.78%   Acceptable  Boring
-  1, 1, 1, 1  143,471,870   27.32%   Acceptable  Boring
+        PPC64:
+              RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
+          0, 0, 0, 0  626,124,064   22.51%   Acceptable  Boring
+          0, 0, 0, 1  100,592,056    3.62%   Acceptable  Boring
+          0, 0, 1, 0   86,443,974    3.11%   Acceptable  Boring
+          0, 0, 1, 1  117,149,197    4.21%   Acceptable  Boring
+          0, 1, 0, 0  102,075,205    3.67%   Acceptable  Boring
+          0, 1, 0, 1      270,587   <0.01%   Acceptable  Boring
+          0, 1, 1, 0  278,452,698   10.01%   Acceptable  Boring
+          0, 1, 1, 1   18,548,574    0.67%   Acceptable  Boring
+          1, 0, 0, 0   96,280,543    3.46%   Acceptable  Boring
+          1, 0, 0, 1  311,153,395   11.19%   Acceptable  Boring
+          1, 0, 1, 0        7,599   <0.01%  Interesting  Whoa
+          1, 0, 1, 1   14,614,329    0.53%   Acceptable  Boring
+          1, 1, 0, 0  195,921,897    7.04%   Acceptable  Boring
+          1, 1, 0, 1   52,391,418    1.88%   Acceptable  Boring
+          1, 1, 1, 0   42,992,478    1.55%   Acceptable  Boring
+          1, 1, 1, 1  738,325,730   26.55%   Acceptable  Boring
      */
 
     @JCStressTest
@@ -212,27 +213,28 @@ PPC64:
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        To see why this is not a vanilla memory reordering, we can put fences around the critical accesses.
-        If we follow the "usual" fencing around the seqc
+        Depending on the hardware, a more thorough fencing might be required. For example, on PPC64,
+        we would need to emit a full fence before the sequentially consistent read, if we want to stop
+        seeing non-MCA behaviors. Indeed, in this test, the interesting cases are gone.
 
-PPC64:
-      RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
-  0, 0, 0, 0    3,162,682    0.63%   Acceptable  Boring
-  0, 0, 0, 1      420,692    0.08%   Acceptable  Boring
-  0, 0, 1, 0       49,183   <0.01%   Acceptable  Boring
-  0, 0, 1, 1   17,923,289    3.55%   Acceptable  Boring
-  0, 1, 0, 0      344,895    0.07%   Acceptable  Boring
-  0, 1, 0, 1       58,153    0.01%   Acceptable  Boring
-  0, 1, 1, 0      703,765    0.14%   Acceptable  Boring
-  0, 1, 1, 1   17,055,833    3.38%   Acceptable  Boring
-  1, 0, 0, 0       55,722    0.01%   Acceptable  Boring
-  1, 0, 0, 1      926,450    0.18%   Acceptable  Boring
-  1, 0, 1, 0            0    0.00%  Interesting  Whoa
-  1, 0, 1, 1   15,951,198    3.16%   Acceptable  Boring
-  1, 1, 0, 0   15,055,385    2.98%   Acceptable  Boring
-  1, 1, 0, 1   23,580,682    4.67%   Acceptable  Boring
-  1, 1, 1, 0   20,358,942    4.03%   Acceptable  Boring
-  1, 1, 1, 1  389,383,273   77.10%   Acceptable  Boring
+        PPC64:
+              RESULT        SAMPLES     FREQ       EXPECT  DESCRIPTION
+          0, 0, 0, 0     16,428,729    0.62%   Acceptable  Boring
+          0, 0, 0, 1      1,054,058    0.04%   Acceptable  Boring
+          0, 0, 1, 0        219,026   <0.01%   Acceptable  Boring
+          0, 0, 1, 1     82,801,314    3.11%   Acceptable  Boring
+          0, 1, 0, 0      2,250,558    0.08%   Acceptable  Boring
+          0, 1, 0, 1        248,656   <0.01%   Acceptable  Boring
+          0, 1, 1, 0      3,318,302    0.12%   Acceptable  Boring
+          0, 1, 1, 1     89,272,976    3.36%   Acceptable  Boring
+          1, 0, 0, 0        375,410    0.01%   Acceptable  Boring
+          1, 0, 0, 1      3,598,655    0.14%   Acceptable  Boring
+          1, 0, 1, 0              0    0.00%  Interesting  Whoa
+          1, 0, 1, 1     81,560,207    3.07%   Acceptable  Boring
+          1, 1, 0, 0     94,117,189    3.54%   Acceptable  Boring
+          1, 1, 0, 1    124,773,490    4.69%   Acceptable  Boring
+          1, 1, 1, 0    107,590,486    4.05%   Acceptable  Boring
+          1, 1, 1, 1  2,051,591,968   77.15%   Acceptable  Boring
      */
 
     @JCStressTest

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_04_MisplacedVolatile.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_04_MisplacedVolatile.java
@@ -37,7 +37,7 @@ public class AdvancedJMM_04_MisplacedVolatile {
 
      /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_03_LosingUpdates[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_04_MisplacedVolatile[.SubTestName]
      */
 
     static class Composite {

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_08_WrongListReleaseOrder.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_08_WrongListReleaseOrder.java
@@ -44,7 +44,7 @@ public class AdvancedJMM_08_WrongListReleaseOrder {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_08_WrongListReleaseOrder[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_08_WrongListReleaseOrder
      */
 
     /*

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_VolatilesAreNotFences.java
@@ -38,7 +38,7 @@ public class AdvancedJMM_12_VolatilesAreNotFences {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_12_SynchronizedAreNotFences[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_12_VolatilesAreNotFences[.SubTestName]
      */
 
     /*

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_01_DataRaces.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_01_DataRaces.java
@@ -61,7 +61,6 @@ public class BasicJMM_01_DataRaces {
                       RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
       class java.lang.Object  3,619,439,149   51.74%  Acceptable  Seeing the object, valid class
                         null  3,376,358,355   48.26%  Acceptable  Not seeing the object yet
-
     */
 
     Object o;

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
@@ -121,7 +121,7 @@ public class BasicJMM_02_AccessAtomicity {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        Recovering the access atomicity is possible with making the field "volatile":
+        Recovering the access atomicity is possible by making the field "volatile":
 
         x86_32:
           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
@@ -194,18 +194,15 @@ public class BasicJMM_02_AccessAtomicity {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        While the spec requirements for field and array element accesses are
-        strict, the implementations of concrete classes may have a relaxed
-        semantics. Take ByteBuffer where we can read the 4-byte integer from
-        an arbitrary offset.
+        While the spec requirements for field and array element accesses are strict, the implementations of
+        concrete classes may have a relaxed semantics. Take ByteBuffer where we can read the 4-byte integer
+        from an arbitrary offset.
 
-        Older ByteBuffer implementations accessed one byte at a time, and that
-        required merging/splitting anything larger than a byte into the individual
-        operations. Of course, there is no access atomicity there by construction.
-        In newer ByteBuffer implementations, the _aligned_ accesses are done with
-        larger instructions that gives back atomicity. Misaligned accesses would
-        still have to do several narrower accesses on machines that don't support
-        misalignments.
+        Older ByteBuffer implementations accessed one byte at a time, and that required merging/splitting
+        anything larger than a byte into the individual operations. Of course, there is no access atomicity
+        there by construction. In newer ByteBuffer implementations, the _aligned_ accesses are done with
+        larger instructions that gives back atomicity. Misaligned accesses would still have to do several
+        narrower accesses on machines that don't support misalignments.
 
         x86_64:
              RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
@@ -247,9 +244,9 @@ public class BasicJMM_02_AccessAtomicity {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        However, even if the misaligned accesses is supported by hardware, it would never
-        be guaranteed atomic. For example, reading the value that spans two cache-lines would
-        not be atomic, even if we manage to issue a single instruction for access.
+        However, even if the misaligned accesses is supported by hardware, it would never be guaranteed atomic.
+        For example, reading the value that spans two cache-lines would not be atomic, even if we manage to issue
+        a single instruction for access.
 
         x86_64:
              RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_04_Progress.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_04_Progress.java
@@ -105,9 +105,9 @@ public class BasicJMM_04_Progress {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        In fact, the overwhelming majority of hardware makes writes eventually visible, so what
-        we minimally want is to make the accesses opaque to the optimizing compilers. Luckily,
-        that is simple to do with VarHandles.{set|get}Opaque.
+        In fact, the overwhelming majority of hardware makes writes eventually visible, so what we minimally
+        want is to make the accesses opaque to the optimizing compilers. Luckily, that is simple to do with
+        VarHandles.{set|get}Opaque.
 
         Indeed, this is guaranteed to happen on all platforms:
 

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_05_Coherence.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_05_Coherence.java
@@ -45,10 +45,9 @@ public class BasicJMM_05_Coherence {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        Yet another subtle and intuitive property comes from the naive understanding
-        of how programs work. Under Java Memory Model, in absence of synchronization,
-        the order of independent reads is undefined. That includes reads of the *same*
-        variable!
+        Yet another subtle and intuitive property comes from the naive understanding of how programs work.
+        Under Java Memory Model, in absence of synchronization, the order of independent reads is undefined.
+        That includes reads of the *same* variable!
 
           RESULT      SAMPLES     FREQ       EXPECT  DESCRIPTION
             0, 0   14,577,607    6.96%   Acceptable  Doing both reads early.
@@ -101,9 +100,8 @@ public class BasicJMM_05_Coherence {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        The stronger property -- coherence -- mandates that the writes to the same
-        variable to be observed in a total order (that implies that _observers_ are
-        also ordered). Java "volatile" assumes this property.
+        The stronger property -- coherence -- mandates that the writes to the same variable to be observed in
+        a total order (that implies that _observers_ are also ordered). Java "volatile" assumes this property.
 
           RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
             0, 0  114,696,597   30.95%  Acceptable  Doing both reads early.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_06_Causality.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_06_Causality.java
@@ -45,10 +45,9 @@ public class BasicJMM_06_Causality {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        The next property helps some inter-thread semantics. In JMM, happens-before mandates
-        what results are plausible and what are not, when non-synchronized reads are involved.
-        That order is partial, so there are pairs of reads/writes we can tell nothing about
-        order-wise.
+        The next property helps some inter-thread semantics. In JMM, happens-before mandates what results are
+        plausible and what are not, when non-synchronized reads are involved. That order is partial, so there
+        are pairs of reads/writes we can tell nothing about order-wise.
 
         For example, in the case of two non-volatile variables, JMM allows observing
         "1, 0".
@@ -143,11 +142,11 @@ public class BasicJMM_06_Causality {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-         The easiest way to solve this is to mark $y as "volatile". In this case, JMM would
-         disallow seeing (1, 0). Volatile write would now be "release"-ing write and volatile
-         read would now be "acquiring" read. That means all writes that precede releasing store
-         would be visible to readers of acquiring read. Note this effect is only guaranteed
-         if the acquiring read sees the value written by releasing write.
+         The easiest way to solve this is to mark $y as "volatile". In this case, JMM would disallow seeing
+         (1, 0). Volatile write would now be "release"-ing write and volatile read would now be "acquiring"
+         read. That means all writes that precede releasing store would be visible to readers of acquiring
+         read. Note this effect is only guaranteed if the acquiring read sees the value written by releasing
+         write.
 
          Indeed, in all configurations, we shall see zero samples for the now forbidden
          test case.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_09_BenignRaces.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_09_BenignRaces.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.jcstress.samples.jmm.advanced;
+package org.openjdk.jcstress.samples.jmm.basic;
 
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressTest;
@@ -32,10 +32,10 @@ import org.openjdk.jcstress.infra.results.II_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
 
-public class AdvancedJMM_14_BenignRaces {
+public class BasicJMM_09_BenignRaces {
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_14_BenignRaces[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t BasicJMM_09_BenignRaces[.SubTestName]
      */
 
     /*

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_10_OOTA.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_10_OOTA.java
@@ -33,11 +33,11 @@ import static org.openjdk.jcstress.annotations.Expect.*;
 @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "The only valid result")
 @Outcome(             expect = FORBIDDEN,  desc = "Every other result is forbidden")
 @State
-public class BasicJMM_09_OOTA {
+public class BasicJMM_10_OOTA {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t BasicJMM_09_OOTA
+            $ java -jar jcstress-samples/target/jcstress.jar -t BasicJMM_10_OOTA
      */
 
     /*


### PR DESCRIPTION
Some post-review comments emerged for jcstress-samples, this should make them cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902977](https://bugs.openjdk.java.net/browse/CODETOOLS-7902977): jcstress: Minor touchups for jcstress-samples


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/jcstress pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/80.diff">https://git.openjdk.java.net/jcstress/pull/80.diff</a>

</details>
