### PR TITLE
CODETOOLS-7902979: jcstress: Another round of samples updates

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_01_Simple.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_01_Simple.java
@@ -43,10 +43,14 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     and instance, and record what results are coming from there.
 
     Done enough times, we will get the history of observed results, and that
-    would tell us something about the concurrent behavior. For example, running
-    this test would yield:
+    would tell us something about the concurrent behavior.
 
-        .......... [OK] org.openjdk.jcstress.samples.api.APISample_01_Simple
+    How to run this test:
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_01_Simple
+
+       ...
+
+        .......... [OK] org.openjdk.jcstress.samples.api.API_01_Simple
 
           Scheduling class:
             actor1: package group 0, core group 0
@@ -66,9 +70,6 @@ import static org.openjdk.jcstress.annotations.Expect.*;
             1, 1   46,946,789   10.1%  Interesting  Both actors came up with the same value: atomicity failure.
             1, 2  110,240,149   23.8%   Acceptable  actor1 incremented, then actor2.
             2, 1  306,529,420   66.1%   Acceptable  actor2 incremented, then actor1.
-
-     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_01
  */
 
 // Mark the class as JCStress test.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_02_Arbiters.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_02_Arbiters.java
@@ -37,7 +37,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     finished.
 
     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_02_Arbiters
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_02_Arbiters
 
         ...
 

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_03_Termination.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_03_Termination.java
@@ -39,13 +39,13 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     record "STALE".
 
     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_03
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_03_Termination
 
         ...
 
           RESULT  SAMPLES     FREQ       EXPECT  DESCRIPTION
-           STALE        4   30.77%  Interesting  Test hung up.
-      TERMINATED        9   69.23%   Acceptable  Gracefully finished.
+           STALE        1   <0.01%  Interesting  Test hung up.
+      TERMINATED   13,168   99.99%   Acceptable  Gracefully finished.
 
       Messages:
         Have stale threads, forcing VM to exit for proper cleanup.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_04_Nesting.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_04_Nesting.java
@@ -37,7 +37,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     better comparison. JCStress allows to nest tests like this:
 
     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_04
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_04_Nesting
 
         ...
 

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_05_SharedMetadata.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_05_SharedMetadata.java
@@ -35,7 +35,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     at another class.
 
     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_05
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_05_SharedMetadata
 
         ...
 

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_06_Descriptions.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_06_Descriptions.java
@@ -35,7 +35,7 @@ import static org.openjdk.jcstress.annotations.Expect.*;
     the behavior in question.
 
     How to run this test:
-       $ java -jar jcstress-samples/target/jcstress.jar -t APISample_06
+       $ java -jar jcstress-samples/target/jcstress.jar -t API_06_Descriptions
  */
 
 @JCStressTest

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_01_SynchronizedBarriers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_01_SynchronizedBarriers.java
@@ -72,9 +72,9 @@ public class AdvancedJMM_01_SynchronizedBarriers {
                 1, 1    278,646,578    6.79%   Acceptable  Boring
 
          Technically, this is due to "lock coarsening" that merged the synchronized blocks, and then was able
-         to order the writes to "x" and "y" differently. JMM as stated allows
-         this optimization: we are only required to see these stores in order if we are
-         synchronizing on the same "this". Side observers can see the writes in whatever order.
+         to order the writes to "x" and "y" differently. JMM as stated allows this optimization: we are only
+         required to see these stores in order if we are synchronizing on the same "this". Side observers can
+         see the writes in whatever order.
     */
 
     static final VarHandle VH_X, VH_Y;

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
@@ -59,7 +59,7 @@ public class AdvancedJMM_02_MultiCopyAtomic {
         IRIW detects whether the independent writes to "x" and "y" are seen in different orders by two
         other workers.
 
-        On x86_64 -- that is multi-copy atomic architecture -- this test yields:
+        On x86_64 -- that is total store order and multi-copy atomic architecture -- this test yields:
 
               RESULT         SAMPLES     FREQ       EXPECT  DESCRIPTION
           0, 0, 0, 0   1,018,009,462    3.39%   Acceptable  Boring
@@ -79,7 +79,8 @@ public class AdvancedJMM_02_MultiCopyAtomic {
           1, 1, 1, 0   1,248,633,288    4.15%   Acceptable  Boring
           1, 1, 1, 1  16,117,960,946   53.63%   Acceptable  Boring
 
-        But on PPC64 -- that is not a multi-copy atomic architecture -- this test yields:
+        But on PPC64 or ARM64 -- that are not the total store order architectures
+        -- this test yields:
 
               RESULT        SAMPLES     FREQ       EXPECT  DESCRIPTION
           0, 0, 0, 0     37,176,296    0.64%   Acceptable  Boring

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_11_VolatileVsFinal.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_11_VolatileVsFinal.java
@@ -34,10 +34,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
 
-public class AdvancedJMM_13_VolatileVsFinal {
+public class AdvancedJMM_11_VolatileVsFinal {
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_13_VolatileVsFinal[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_11_VolatileVsFinal[.SubTestName]
      */
 
     /*
@@ -46,7 +46,7 @@ public class AdvancedJMM_13_VolatileVsFinal {
         Perhaps, one of the most surprising JMM behaviors is that volatile fields do not include
         the final field semantics. That is, if we publish the reference to the object racily,
         then we can see the default value for the "volatile" field! This is mostly because the
-        volatile itself is in the wrong place. This is similar to AdvancedJMM_10_WrongAcquireReleaseOrder
+        volatile itself is in the wrong place. This is similar to previous AdvancedJMM_10_WrongAcquireReleaseOrder
         example.
 
         It can be seen on some platforms with this synthetic test.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_SynchronizedAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_SynchronizedAreNotFences.java
@@ -33,11 +33,11 @@ import org.openjdk.jcstress.infra.results.II_Result;
 import static org.openjdk.jcstress.annotations.Expect.*;
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
-public class AdvancedJMM_11_SynchronizedAreNotFences {
+public class AdvancedJMM_12_SynchronizedAreNotFences {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_11_SynchronizedAreNotFences
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_12_SynchronizedAreNotFences
      */
 
     /*

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_13_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_13_VolatilesAreNotFences.java
@@ -34,17 +34,17 @@ import org.openjdk.jcstress.infra.results.II_Result;
 import static org.openjdk.jcstress.annotations.Expect.*;
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
-public class AdvancedJMM_12_VolatilesAreNotFences {
+public class AdvancedJMM_13_VolatilesAreNotFences {
 
     /*
         How to run this test:
-            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_12_VolatilesAreNotFences[.SubTestName]
+            $ java -jar jcstress-samples/target/jcstress.jar -t AdvancedJMM_13_VolatilesAreNotFences[.SubTestName]
      */
 
     /*
        ----------------------------------------------------------------------------------------------------------
 
-        Similarly to AdvancedJMM_11_SynchronizedAreNotFences example, the volatile accesses cannot be reliably
+        Similarly to AdvancedJMM_12_SynchronizedAreNotFences example, the volatile accesses cannot be reliably
         used for their auxiliary memory effects. In this example, if we do not observe the write of the "b", then
         we can see the old "x", even though volatile accesses _might_ be implemented with barriers.
 

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_03_WordTearing.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_03_WordTearing.java
@@ -43,15 +43,13 @@ public class BasicJMM_03_WordTearing {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        Java Memory Model prohibits word tearing. That is, it requires that
-        every field and array element as distinct, and the operations for one
-        element should not disturb others.
+        Java Memory Model prohibits word tearing. That is, it requires that every field and array element
+        as distinct, and the operations for one element should not disturb others.
 
-        Note this is a bit different from access atomicity. Access atomicity says
-        that the accesses to a _wide_ logical field should be atomic, even if it
-        requires several _narrower_ physical accesses. Prohibited word tearing
-        means the accesses to a _narrow_ logical field should not disturb the
-        adjacent fields, even if done with a _wider_ physical access.
+        Note this is a bit different from access atomicity. Access atomicity says that the accesses to
+        a _wide_ logical field should be atomic, even if it requires several _narrower_ physical accesses.
+        Prohibited word tearing means the accesses to a _narrow_ logical field should not disturb the adjacent
+        fields, even if done with a _wider_ physical access.
 
         Indeed, the test on plain boolean arrays shows this rule holds:
 
@@ -86,10 +84,9 @@ public class BasicJMM_03_WordTearing {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        However, while that requirement is enforced for fields and array elements, the
-        Java classes implementations may still violate this requirement, if, say, they
-        pack elements densely, and read/write adjacent elements routinely. The usual
-        example of this is java.util.BitSet.
+        However, while that requirement is enforced for fields and array elements, the Java classes
+        implementations may still violate this requirement, if, say, they pack elements densely, and
+        read/write adjacent elements routinely. The usual example of this is java.util.BitSet.
 
         Indeed, this is simple to reproduce:
 
@@ -139,7 +136,7 @@ public class BasicJMM_03_WordTearing {
         on platforms that do not have direct sub-word accesses, CASes should still work _as if_
         the boolean fields are distinct.
 
-        For example, this test passes on ARM32 (that does not have byte-wide CASes). The test verifies
+        For example, this test passes on ARM32, that does not have byte-wide CASes. The test verifies
         that CAS over each of the fields do not conflict, and both are able to succeed.
 
               RESULT     SAMPLES     FREQ      EXPECT  DESCRIPTION

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_06_Causality.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_06_Causality.java
@@ -148,8 +148,7 @@ public class BasicJMM_06_Causality {
          read. Note this effect is only guaranteed if the acquiring read sees the value written by releasing
          write.
 
-         Indeed, in all configurations, we shall see zero samples for the now forbidden
-         test case.
+         Indeed, in all configurations, we shall see zero samples for the now forbidden test case.
 
          AArch64:
             RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_07_Consensus.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_07_Consensus.java
@@ -45,13 +45,12 @@ public class BasicJMM_07_Consensus {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        Another property comes for the inter-thread semantics deals not with
-        partial, but total order. In JMM, synchronization order mandates that
-        special "synchronization" actions always form a total order, consistent
-        with program order.
+        Another property comes for the inter-thread semantics deals not with partial, but total order.
+        In JMM, synchronization order mandates that special "synchronization" actions always form a total
+        order, consistent with program order.
 
-        The most famous example that needs total order of operation is Dekker
-        idiom, the building block of Dekker lock.
+        The most famous example that needs total order of operation is Dekker idiom, the building block
+        of Dekker lock.
 
         x86_64:
           RESULT        SAMPLES     FREQ       EXPECT  DESCRIPTION
@@ -85,9 +84,8 @@ public class BasicJMM_07_Consensus {
     /*
       ----------------------------------------------------------------------------------------------------------
 
-        Adding volatile to both $x and $y bring them together into synchronization order,
-        and thus require the results to be consistent with the case when reads/writes
-        form a total order.
+        Adding volatile to both $x and $y bring them together into synchronization order, and thus require
+        the results to be consistent with the case when reads/writes form a total order.
 
           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
             0, 0              0    0.00%   Forbidden  Violates sequential consistency


### PR DESCRIPTION
These updates follow the recent JCStress Workshop and fix issues discovered there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902979](https://bugs.openjdk.java.net/browse/CODETOOLS-7902979): jcstress: Another round of samples updates


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.java.net/jcstress pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/81.diff">https://git.openjdk.java.net/jcstress/pull/81.diff</a>

</details>
