### PR TITLE
CODETOOLS-7902981: jcstress: Remove trailing whitespaces in the console log

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -161,7 +161,7 @@ public class ReportUtils {
             freqLen += 2;
             expectLen += 2;
 
-            pw.printf("%" + idLen + "s%" + samplesLen + "s%" + freqLen + "s%" + expectLen + "s  %-" + descLen + "s%n",
+            pw.printf("%" + idLen + "s%" + samplesLen + "s%" + freqLen + "s%" + expectLen + "s  %s%n",
                     headResult, headSamples, headFreq, headExpect, headDesc);
 
             TestGrading grade = r.grading();
@@ -175,7 +175,7 @@ public class ReportUtils {
             }
 
             for (GradingResult gradeRes : grade.gradingResults) {
-                pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + "s%" + expectLen + "s  %-" + descLen + "s%n",
+                pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + "s%" + expectLen + "s  %s%n",
                         StringUtils.cutoff(gradeRes.id, idLen),
                         gradeRes.count,
                         StringUtils.percent(gradeRes.count, totalSamples, 2),
@@ -190,7 +190,7 @@ public class ReportUtils {
         for (String data : r.getMessages()) {
             if (skipMessage(data)) continue;
             if (!errMsgsPrinted) {
-                pw.println("  Messages: ");
+                pw.println("  Messages:");
                 errMsgsPrinted = true;
             }
             pw.println("    " + data);
@@ -203,7 +203,7 @@ public class ReportUtils {
         for (String data : r.getVmOut()) {
             if (skipMessage(data)) continue;
             if (!vmOutPrinted) {
-                pw.println("  VM output stream: ");
+                pw.println("  VM output stream:");
                 vmOutPrinted = true;
             }
             pw.println("    " + data);
@@ -216,7 +216,7 @@ public class ReportUtils {
         for (String data : r.getVmErr()) {
             if (skipMessage(data)) continue;
             if (!vmErrPrinted) {
-                pw.println("  VM error stream: ");
+                pw.println("  VM error stream:");
                 vmErrPrinted = true;
             }
             pw.println("    " + data);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -76,7 +76,7 @@ public class VMSupport {
     }
 
     public static void initFlags(Options opts) {
-        System.out.println("Initializing and probing the target VM: ");
+        System.out.println("Initializing and probing the target VM:");
         System.out.println(" (all failures are non-fatal, but may affect testing accuracy)");
         System.out.println();
 


### PR DESCRIPTION
There a couple of places where trailing whitespaces take a lot of space and induce wrapping where it is not expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902981](https://bugs.openjdk.java.net/browse/CODETOOLS-7902981): jcstress: Remove trailing whitespaces in the console log


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.java.net/jcstress pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/83.diff">https://git.openjdk.java.net/jcstress/pull/83.diff</a>

</details>
