### PR TITLE
CODETOOLS-7902983: jcstress: Improve performance for tests with many results

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -51,6 +51,7 @@ public class TestResult implements Serializable {
     private final List<String> messages;
     private final List<String> vmOut;
     private final List<String> vmErr;
+    private transient TestGrading grading;
 
     public TestResult(Status status) {
         this.status = status;
@@ -189,7 +190,12 @@ public class TestResult implements Serializable {
     }
 
     public TestGrading grading() {
-        return TestGrading.grade(this);
+        TestGrading g = grading;
+        if (g == null) {
+            g = TestGrading.grade(this);
+            grading = g;
+        }
+        return g;
     }
 
     public boolean isEmpty() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -400,12 +400,19 @@ public class HTMLReportPrinter {
             Expect expect = null;
 
             for (TestResult r : sorted) {
+                boolean found = false;
                 for (GradingResult c : r.grading().gradingResults) {
                     if (c.id.equals(key)) {
                         o.println("<td align='right' width='" + 30D/configs + "%' bgColor=" + selectHTMLColor(c.expect, c.count == 0) + ">" + c.count + "</td>");
                         description = c.description;
                         expect = c.expect;
+                        found = true;
+                        break;
                     }
+                }
+
+                if (!found) {
+                    o.println("<td align='right' width='" + 30D/configs + "%' bgColor=" + selectHTMLColor(Expect.ACCEPTABLE, true) + ">0</td>");
                 }
             }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -400,18 +400,12 @@ public class HTMLReportPrinter {
             Expect expect = null;
 
             for (TestResult r : sorted) {
-                boolean found = false;
-                for (GradingResult c : r.grading().gradingResults) {
-                    if (c.id.equals(key)) {
-                        o.println("<td align='right' width='" + 30D/configs + "%' bgColor=" + selectHTMLColor(c.expect, c.count == 0) + ">" + c.count + "</td>");
-                        description = c.description;
-                        expect = c.expect;
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found) {
+                GradingResult c = r.grading().gradingResults.get(key);
+                if (c != null) {
+                    o.println("<td align='right' width='" + 30D/configs + "%' bgColor=" + selectHTMLColor(c.expect, c.count == 0) + ">" + c.count + "</td>");
+                    description = c.description;
+                    expect = c.expect;
+                } else {
                     o.println("<td align='right' width='" + 30D/configs + "%' bgColor=" + selectHTMLColor(Expect.ACCEPTABLE, true) + ">0</td>");
                 }
             }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -166,7 +166,7 @@ public class ReportUtils {
 
             TestGrading grade = r.grading();
             long totalSamples = 0;
-            for (GradingResult gradeRes : grade.gradingResults) {
+            for (GradingResult gradeRes : grade.gradingResults.values()) {
                 totalSamples += gradeRes.count;
             }
 
@@ -174,7 +174,7 @@ public class ReportUtils {
                 totalSamples = 1;
             }
 
-            for (GradingResult gradeRes : grade.gradingResults) {
+            for (GradingResult gradeRes : grade.gradingResults.values()) {
                 pw.printf("%" + idLen + "s%," + samplesLen + "d%" + freqLen + "s%" + expectLen + "s  %s%n",
                         StringUtils.cutoff(gradeRes.id, idLen),
                         gradeRes.count,

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TestGrading.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TestGrading.java
@@ -39,7 +39,7 @@ import java.util.*;
 public class TestGrading {
     public boolean isPassed;
     public boolean hasInteresting;
-    public final List<GradingResult> gradingResults;
+    public final TreeMap<String, GradingResult> gradingResults;
     public final List<String> failureMessages;
 
     public static TestGrading grade(TestResult r) {
@@ -48,7 +48,7 @@ public class TestGrading {
 
     private TestGrading(TestResult r) {
         TestInfo test = TestList.getInfo(r.getName());
-        gradingResults = new ArrayList<>();
+        gradingResults = new TreeMap<>();
         failureMessages = new NonNullArrayList<>();
 
         isPassed = true;
@@ -92,12 +92,13 @@ public class TestGrading {
             hasInteresting |= hasInteresting(ex, count);
             failureMessages.add(failureMessage(s, ex, count, matched.description()));
 
-            gradingResults.add(new GradingResult(
-                    s,
-                    matched.expect(),
-                    count,
-                    matched.description()
-            ));
+            gradingResults.put(s,
+                    new GradingResult(
+                            s,
+                            matched.expect(),
+                            count,
+                            matched.description()
+                    ));
         }
 
         // Record unmatched cases from the test description itself
@@ -107,16 +108,14 @@ public class TestGrading {
             hasInteresting |= hasInteresting(ex, 0);
             failureMessages.add(failureMessage("N/A", ex, 0, c.description()));
 
-            gradingResults.add(new GradingResult(
-                    c.matchPattern(),
-                    ex,
-                    0,
-                    c.description()
-            ));
+            gradingResults.put(c.matchPattern(),
+                    new GradingResult(
+                            c.matchPattern(),
+                            ex,
+                            0,
+                            c.description()
+                    ));
         }
-
-        Collections.sort(gradingResults,
-                Comparator.comparing(c -> c.id));
     }
 
     public static String failureMessage(String id, Expect expect, long count, String description) {


### PR DESCRIPTION
As reported here:
  https://mail.openjdk.java.net/pipermail/jcstress-dev/2021-June/000702.html

Cache the grading, optimize HTML table generation a little.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902983](https://bugs.openjdk.java.net/browse/CODETOOLS-7902983): jcstress: Improve performance for tests with many results


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.java.net/jcstress pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/86.diff">https://git.openjdk.java.net/jcstress/pull/86.diff</a>

</details>
