### PR TITLE
CODETOOLS-7902984: jcstress: Fix lint warnings in generated code and utilities

### DIFF
--- a/jcstress-core/pom.xml
+++ b/jcstress-core/pom.xml
@@ -51,7 +51,7 @@ questions.
                 <configuration>
                     <proc>none</proc>
                     <compilerArgs>
-                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:all,-options,-serial</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -62,7 +62,7 @@ public class Main {
     }
 
     static void printVersion(PrintStream out) {
-        Class clazz = Main.class;
+        Class<?> clazz = Main.class;
         String className = clazz.getSimpleName() + ".class";
         String classPath = clazz.getResource(className).toString();
         if (!classPath.startsWith("jar")) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/JCStressMeta.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/JCStressMeta.java
@@ -40,6 +40,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JCStressMeta {
 
-    Class value();
+    Class<?> value();
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -65,7 +65,26 @@ public class JCStressTestProcessor extends AbstractProcessor {
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(JCStressTest.class.getName());
+        List<Class<?>> classes = Arrays.asList(
+                JCStressTest.class,
+                JCStressMeta.class,
+                State.class,
+                Result.class,
+                Actor.class,
+                Arbiter.class,
+                Signal.class,
+                Outcome.class,
+                Outcome.Outcomes.class,
+                Ref.class,
+                Ref.Refs.class,
+                Description.class
+        );
+
+        HashSet<String> set = new HashSet<>();
+        for (Class<?> cl : classes) {
+            set.add(cl.getCanonicalName());
+        }
+        return set;
     }
 
     @Override
@@ -480,7 +499,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("        }});");
         }
         pw.println();
-        pw.println("        for (CounterThread t : threads) {");
+        pw.println("        for (CounterThread<" + r + "> t : threads) {");
         pw.println("            t.start();");
         pw.println("        }");
         pw.println();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
@@ -524,6 +524,7 @@ public class Scheduler {
         return Collections.singletonList(scl);
     }
 
+    @SuppressWarnings("fallthrough")
     public List<SchedulingClass> scheduleClasses(int actorThreads, int threadLimit, AffinityMode mode) {
         switch (mode) {
             case LOCAL:

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/ResultUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/ResultUtils.java
@@ -28,7 +28,7 @@ public class ResultUtils {
 
     public static String resultName(Class<?>... args) {
         String name = "";
-        for (Class k : args) {
+        for (Class<?> k : args) {
             if (k.isPrimitive()) {
                 if (k == boolean.class) name += "Z";
                 if (k == byte.class)    name += "B";

--- a/jcstress-core/src/main/java/sun/misc/Unsafe.java
+++ b/jcstress-core/src/main/java/sun/misc/Unsafe.java
@@ -246,9 +246,9 @@ public abstract class Unsafe {
 
     public abstract void putByte(java.lang.Object o, long l, byte l1);
 
-    public abstract int arrayBaseOffset(java.lang.Class aClass);
+    public abstract int arrayBaseOffset(java.lang.Class<?> aClass);
 
-    public abstract int arrayIndexScale(java.lang.Class aClass);
+    public abstract int arrayIndexScale(java.lang.Class<?> aClass);
 
     public abstract int getAndAddInt(Object o, long offset, int delta);
 

--- a/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
+++ b/jcstress-result-gen/src/main/java/org/openjdk/jcstress/ResultGenerator.java
@@ -43,7 +43,7 @@ public class ResultGenerator {
     public String generateResult(Class<?>... args) {
         boolean allPrimitive = true;
         String name = "";
-        for (Class k : args) {
+        for (Class<?> k : args) {
             if (k.isPrimitive()) {
                 if (k == boolean.class) name += "Z";
                 if (k == byte.class)    name += "B";
@@ -88,7 +88,7 @@ public class ResultGenerator {
 
         {
             int n = 1;
-            for (Class k : args) {
+            for (Class<?> k : args) {
                 pw.println("    @sun.misc.Contended");
                 pw.println("    @jdk.internal.vm.annotation.Contended");
                 pw.println("    public " + k.getSimpleName() + " r" + n + ";");
@@ -108,7 +108,7 @@ public class ResultGenerator {
         pw.println("        return ");
         {
             int n = 1;
-            for (Class k : args) {
+            for (Class<?> k : args) {
                 pw.print("        ");
                 if (n != 1) {
                     pw.print(" + ");
@@ -147,7 +147,7 @@ public class ResultGenerator {
 
         {
             int n = 1;
-            for (Class k : args) {
+            for (Class<?> k : args) {
                 if (k == boolean.class || k == byte.class || k == short.class || k == char.class
                         || k == int.class || k == long.class) {
                     pw.println("        if (r" + n + " != that.r" + n + ") return false;");
@@ -170,7 +170,7 @@ public class ResultGenerator {
         pw.print("        return \"\" + ");
         {
             int n = 1;
-            for (Class k : args) {
+            for (Class<?> k : args) {
                 if (n != 1)
                     pw.print(" + \", \" + ");
                 pw.print("r" + n);

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
@@ -227,7 +227,7 @@ public class TestGenerator {
             return types[index];
         }
 
-        public Class[] all() {
+        public Class<?>[] all() {
             return types;
         }
 

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
@@ -185,10 +185,8 @@ public class SeqCstTraceGenerator {
     private void emit(MultiThread mt, Collection<TraceResult> scResults) {
         String klass = mt.canonicalId() + "_Test";
 
-        Class[] klasses = new Class[mt.loadCount() + mt.allVariables().size()];
-        for (int c = 0; c < klasses.length; c++) {
-            klasses[c] = int.class;
-        }
+        Class<?>[] klasses = new Class<?>[mt.loadCount() + mt.allVariables().size()];
+        Arrays.fill(klasses, int.class);
 
         String resultName = ResultUtils.resultName(klasses);
 

--- a/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest1.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest1.java.template
@@ -52,7 +52,8 @@ public class $TestClassName$ {
 
     @Actor
     public void actor2($T$$T$_Result r) {
-        r.r1 = field;
-        x = ($type$) r.r1;
+        $type$ t = field;
+        x = t;
+        r.r1 = t;
     }
 }

--- a/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest2.java.template
+++ b/jcstress-test-gen/src/main/resources/fences/X-LoadStoreFenceTest2.java.template
@@ -52,7 +52,8 @@ public class $TestClassName$ {
 
     @Actor
     public void actor2($T$$T$_Result r) {
-        r.r1 = y;
-        field = ($type$) r.r1;
+        $type$ t = y;
+        field = t;
+        r.r1 = t;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,15 @@ questions.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <compilerArgs>
+                            <arg>-Xlint:all,-deprecation,-options,-serial,-processing</arg>
+                            <arg>-Werror</arg>
+                        </compilerArgs>
+                        <showWarnings>true</showWarnings>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
See bug report for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902984](https://bugs.openjdk.java.net/browse/CODETOOLS-7902984): jcstress: Fix lint warnings in generated code and utilities


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.java.net/jcstress pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/87.diff">https://git.openjdk.java.net/jcstress/pull/87.diff</a>

</details>
