### PR TITLE
CODETOOLS-7902992: jcstress: Amend *NotFences tests to use weakest fences

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_SynchronizedAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_12_SynchronizedAreNotFences.java
@@ -104,14 +104,14 @@ public class AdvancedJMM_12_SynchronizedAreNotFences {
         @Actor
         public void actor1() {
             x = 1;
-            UNSAFE.fullFence();
+            UNSAFE.storeFence();
             y = 1;
         }
 
         @Actor
         public void actor2(II_Result r) {
             r.r1 = y;
-            UNSAFE.fullFence();
+            UNSAFE.loadFence();
             r.r2 = x;
         }
     }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_13_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_13_VolatilesAreNotFences.java
@@ -106,14 +106,14 @@ public class AdvancedJMM_13_VolatilesAreNotFences {
         @Actor
         void thread1() {
             x = 1;
-            UNSAFE.fullFence();
+            UNSAFE.storeFence();
             y = 1;
         }
 
         @Actor
         void thread2(II_Result r) {
             r.r1 = y;
-            UNSAFE.fullFence();
+            UNSAFE.loadFence();
             r.r2 = x;
         }
     }


### PR DESCRIPTION
It would be a good example to actually use load/storeFences in the examples instead of fullFence. This demonstrates the effect better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902992](https://bugs.openjdk.java.net/browse/CODETOOLS-7902992): jcstress: Amend *NotFences tests to use weakest fences


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.java.net/jcstress pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/89.diff">https://git.openjdk.java.net/jcstress/pull/89.diff</a>

</details>
