### PR TITLE
CODETOOLS-7902999: jcstress: Make sure A*FU tests are holding instances in static finals

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_Updater_X.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/Atomic_Updater_X.java
@@ -50,7 +50,7 @@ public class Atomic_Updater_X implements Primitive {
 
     @Override
     public String printStateField(String klassName) {
-        return "final " + guardType.getSimpleName() + "<" + klassName + "> g = " + guardType.getSimpleName() + ".<" + klassName + ">newUpdater(" + klassName + ".class, \"v\");" + "\n"
+        return "static final " + guardType.getSimpleName() + "<" + klassName + "> g = " + guardType.getSimpleName() + ".<" + klassName + ">newUpdater(" + klassName + ".class, \"v\");" + "\n"
                + "volatile " + primType.getSimpleName() + " v;";
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomics/integer/AtomicIntegerFieldUpdaterPairwiseTests.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomics/integer/AtomicIntegerFieldUpdaterPairwiseTests.java
@@ -42,7 +42,7 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @State
     public static class S {
         public volatile int v;
-        public final AtomicIntegerFieldUpdater<S> u = AtomicIntegerFieldUpdater.newUpdater(S.class, "v");
+        public static final AtomicIntegerFieldUpdater<S> U = AtomicIntegerFieldUpdater.newUpdater(S.class, "v");
     }
 
     @Description("Tests pairwise operations on AtomicIntegerArray")
@@ -57,8 +57,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 5", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_AddAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.addAndGet(s, 5); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.addAndGet(s, 5); }
     }
 
     @JCStressTest
@@ -66,8 +66,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 4",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, -1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_DecAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.decrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.decrementAndGet(s); }
     }
 
     @JCStressTest
@@ -75,8 +75,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndAdd {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -84,8 +84,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndDec {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -93,8 +93,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "6, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndInc {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -102,8 +102,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "15, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -111,8 +111,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 6", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "6, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -120,8 +120,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "25, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -129,8 +129,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "25, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -138,8 +138,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "15, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is decAndGet
@@ -149,8 +149,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-2, -1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_DecAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.decrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.decrementAndGet(s); }
     }
 
     @JCStressTest
@@ -158,8 +158,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndAdd {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -167,8 +167,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-2, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndDec {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -176,8 +176,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "0, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndInc {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -185,8 +185,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "9, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -194,8 +194,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "0, 1",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -203,8 +203,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "19, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -212,8 +212,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "19, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -221,8 +221,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "9, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndAdd
@@ -232,8 +232,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndAdd {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -241,8 +241,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndDec {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -250,8 +250,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndInc {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -259,8 +259,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -268,8 +268,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 6", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -277,8 +277,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -286,8 +286,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -295,8 +295,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndDec
@@ -306,8 +306,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndDec {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -315,8 +315,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndInc {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -324,8 +324,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -333,8 +333,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -342,8 +342,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -351,8 +351,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -360,8 +360,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndInc
@@ -371,8 +371,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_GetAndInc {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -380,8 +380,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -389,8 +389,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -398,8 +398,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -407,8 +407,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -416,8 +416,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndSet
@@ -427,8 +427,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_GetAndSet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -436,8 +436,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 6",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -445,8 +445,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -454,8 +454,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -463,8 +463,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is incAndGet
@@ -474,8 +474,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "2, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_IncAndGet {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -483,8 +483,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "21, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -492,8 +492,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "21, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -501,8 +501,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "11, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is CAS
@@ -512,8 +512,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_CAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -521,8 +521,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -530,8 +530,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is WCAS
@@ -542,8 +542,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     @Outcome(id = "1, 10", expect = Expect.ACCEPTABLE_INTERESTING, desc = "T1 and T2 both spuriously failed")
     public static class WCAS_WCAS {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, II_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, II_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -551,8 +551,8 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class WCAS_Set {
-        @Actor public void actor1(S s, II_Result r) { r.r1 = s.u.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, II_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, II_Result r) { r.r1 = S.U.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, II_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is set
@@ -562,9 +562,9 @@ public class AtomicIntegerFieldUpdaterPairwiseTests {
     @Outcome(id = "5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class Set_Set {
-        @Actor public void actor1(S s, I_Result r) { s.u.set(s, 5); }
-        @Actor public void actor2(S s, I_Result r) { s.u.set(s, 10); }
-        @Arbiter public void arbiter1(S s, I_Result r) { r.r1 = s.u.get(s); }
+        @Actor public void actor1(S s, I_Result r) { S.U.set(s, 5); }
+        @Actor public void actor2(S s, I_Result r) { S.U.set(s, 10); }
+        @Arbiter public void arbiter1(S s, I_Result r) { r.r1 = S.U.get(s); }
     }
 
 }

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomics/longs/AtomicLongFieldUpdaterPairwiseTests.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomics/longs/AtomicLongFieldUpdaterPairwiseTests.java
@@ -42,7 +42,7 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @State
     public static class S {
         public volatile long v;
-        public final AtomicLongFieldUpdater<S> u = AtomicLongFieldUpdater.newUpdater(S.class, "v");
+        public static final AtomicLongFieldUpdater<S> U = AtomicLongFieldUpdater.newUpdater(S.class, "v");
     }
 
     @Description("Tests pairwise operations on AtomicLongFieldUpdater")
@@ -57,8 +57,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 5", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_AddAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.addAndGet(s, 5); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.addAndGet(s, 5); }
     }
 
     @JCStressTest
@@ -66,8 +66,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 4",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, -1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_DecAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.decrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.decrementAndGet(s); }
     }
 
     @JCStressTest
@@ -75,8 +75,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndAdd {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -84,8 +84,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndDec {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -93,8 +93,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "6, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndInc {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -102,8 +102,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "15, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -111,8 +111,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 6", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "6, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -120,8 +120,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "25, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -129,8 +129,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "25, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -138,8 +138,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "15, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class AddAndGet_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.addAndGet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.addAndGet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is decAndGet
@@ -149,8 +149,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-2, -1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_DecAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.decrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.decrementAndGet(s); }
     }
 
     @JCStressTest
@@ -158,8 +158,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "4, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndAdd {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -167,8 +167,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-2, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndDec {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -176,8 +176,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "0, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndInc {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -185,8 +185,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "9, 0",   expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -194,8 +194,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "0, 1",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -203,8 +203,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "19, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -212,8 +212,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "19, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -221,8 +221,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "9, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class DecAndGet_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.decrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.decrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndAdd
@@ -232,8 +232,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndAdd {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndAdd(s, 5); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndAdd(s, 5); }
     }
 
     @JCStressTest
@@ -241,8 +241,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndDec {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -250,8 +250,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndInc {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -259,8 +259,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -268,8 +268,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 6", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -277,8 +277,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -286,8 +286,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -295,8 +295,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndAdd_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndAdd(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndAdd(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndDec
@@ -306,8 +306,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "-1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndDec {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndDecrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndDecrement(s); }
     }
 
     @JCStressTest
@@ -315,8 +315,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0",  expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndInc {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -324,8 +324,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, -1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -333,8 +333,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -342,8 +342,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -351,8 +351,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -360,8 +360,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndDec_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndDecrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndDecrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndInc
@@ -371,8 +371,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_GetAndInc {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndIncrement(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndIncrement(s); }
     }
 
     @JCStressTest
@@ -380,8 +380,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -389,8 +389,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -398,8 +398,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -407,8 +407,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -416,8 +416,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndInc_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndIncrement(s); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndIncrement(s); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is getAndSet
@@ -427,8 +427,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 5",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_GetAndSet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.getAndSet(s, 10); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.getAndSet(s, 10); }
     }
 
     @JCStressTest
@@ -436,8 +436,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 6",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -445,8 +445,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -454,8 +454,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "20, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -463,8 +463,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "0, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class GetAndSet_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.getAndSet(s, 5); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.getAndSet(s, 5); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is incAndGet
@@ -474,8 +474,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "2, 1", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_IncAndGet {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.incrementAndGet(s); }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.incrementAndGet(s); }
     }
 
     @JCStressTest
@@ -483,8 +483,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "21, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -492,8 +492,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 10",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "21, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -501,8 +501,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 0",  expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "11, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class IncAndGet_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.incrementAndGet(s); }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.incrementAndGet(s); }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is CAS
@@ -512,8 +512,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_CAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.compareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.compareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -521,8 +521,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 10", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -530,8 +530,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class CAS_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.compareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.compareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is WCAS
@@ -542,8 +542,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "1, 20", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     @Outcome(id = "1, 10", expect = Expect.ACCEPTABLE_INTERESTING, desc = "T1 and T2 both spuriously failed")
     public static class WCAS_WCAS {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, JJ_Result r) { r.r2 = s.u.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, JJ_Result r) { r.r2 = S.U.weakCompareAndSet(s, 0, 20) ? 20 : 10; }
     }
 
     @JCStressTest
@@ -551,8 +551,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5, 0", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class WCAS_Set {
-        @Actor public void actor1(S s, JJ_Result r) { r.r1 = s.u.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
-        @Actor public void actor2(S s, JJ_Result r) { s.u.set(s, 10); r.r2 = 0; }
+        @Actor public void actor1(S s, JJ_Result r) { r.r1 = S.U.weakCompareAndSet(s, 0, 5) ? 5 : 1; }
+        @Actor public void actor2(S s, JJ_Result r) { S.U.set(s, 10); r.r2 = 0; }
     }
 
     // ------------------- first is set
@@ -562,8 +562,8 @@ public class AtomicLongFieldUpdaterPairwiseTests {
     @Outcome(id = "5", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
     @Outcome(id = "10", expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
     public static class Set_Set {
-        @Actor public void actor1(S s, J_Result r) { s.u.set(s, 5); }
-        @Actor public void actor2(S s, J_Result r) { s.u.set(s, 10); }
-        @Arbiter public void arbiter1(S s, J_Result r) { r.r1 = s.u.get(s); }
+        @Actor public void actor1(S s, J_Result r) { S.U.set(s, 5); }
+        @Actor public void actor2(S s, J_Result r) { S.U.set(s, 10); }
+        @Arbiter public void arbiter1(S s, J_Result r) { r.r1 = S.U.get(s); }
     }
 }


### PR DESCRIPTION
A*FU performance depends on the ability to fold the internal checks, which is possible when instances are in "static final". We need to make sure tests do that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902999](https://bugs.openjdk.java.net/browse/CODETOOLS-7902999): jcstress: Make sure A*FU tests are holding instances in static finals


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.java.net/jcstress pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/91.diff">https://git.openjdk.java.net/jcstress/pull/91.diff</a>

</details>
