### PR TITLE
CODETOOLS-7903019: jcstress: Very long exceptions break the VM data streams

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -80,10 +80,10 @@ public class ForkedMain {
             forceExit = o.forceExit();
         } catch (ClassFormatError | NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             result = new TestResult(Status.API_MISMATCH);
-            result.addMessages(StringUtils.getStacktrace(e));
+            result.addMessages(e);
         } catch (Throwable ex) {
             result = new TestResult(Status.TEST_ERROR);
-            result.addMessages(StringUtils.getStacktrace(ex));
+            result.addMessages(ex);
         }
 
         if (forceExit) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -477,7 +477,7 @@ public class TestExecutor {
             // There is a pending exception that terminated the target VM.
             if (pendingException != null) {
                 result = new TestResult(Status.VM_ERROR);
-                result.addMessage(pendingException.getMessage());
+                result.addMessages(pendingException);
                 result.setConfig(task);
                 sink.add(result);
                 return;
@@ -501,7 +501,7 @@ public class TestExecutor {
                 sink.add(result);
             } catch (InterruptedException | ExecutionException ex) {
                 result = new TestResult(Status.VM_ERROR);
-                result.addMessage(ex.getMessage());
+                result.addMessages(ex);
                 result.setConfig(task);
                 sink.add(result);
             } finally {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -30,6 +30,7 @@ import org.openjdk.jcstress.infra.grading.TestGrading;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.util.Counter;
 import org.openjdk.jcstress.util.Environment;
+import org.openjdk.jcstress.util.StringUtils;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -117,31 +118,27 @@ public class TestResult implements Serializable {
         messages.add(msg);
     }
 
+    public void addMessages(Throwable throwable) {
+        addMessages(StringUtils.getStacktrace(throwable));
+    }
+
     public void addMessages(Collection<String> msgs) {
         for (String m : msgs) {
             addMessage(m);
         }
     }
 
-    public void addVMOut(String msg) {
-        if (ReportUtils.skipMessage(msg)) return;
-        vmOut.add(msg);
-    }
-
     public void addVMOuts(Collection<String> msgs) {
         for (String m : msgs) {
-            addVMOut(m);
+            if (ReportUtils.skipMessage(m)) continue;
+            vmOut.add(m);
         }
-    }
-
-    public void addVMErr(String msg) {
-        if (ReportUtils.skipMessage(msg)) return;
-        vmErr.add(msg);
     }
 
     public void addVMErrs(Collection<String> msgs) {
         for (String m : msgs) {
-            addVMErr(m);
+            if (ReportUtils.skipMessage(m)) continue;
+            vmErr.add(m);
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Runner.java
@@ -114,7 +114,7 @@ public abstract class Runner<R> {
     protected TestResult dumpFailure(Status status, String message, Throwable aux) {
         TestResult r = new TestResult(status);
         r.addMessage(message);
-        r.addMessages(StringUtils.getStacktrace(aux));
+        r.addMessages(aux);
         return r;
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -123,16 +123,7 @@ public class StringUtils {
         PrintWriter pw = new PrintWriter(sw);
         throwable.printStackTrace(pw);
         pw.close();
-        // TODO: This should be better
-        return Arrays.asList(sw.toString().split("\n"));
-    }
-
-    public static String getFirstLine(String src) {
-        int endLine = src.indexOf("\n");
-        if (endLine > 0) {
-            return src.substring(0, endLine).trim();
-        }
-        return src;
+        return Arrays.asList(sw.toString().split(System.lineSeparator()));
     }
 
     static final String[] PADS;

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/util/StringUtilsTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/util/StringUtilsTest.java
@@ -47,13 +47,7 @@ public class StringUtilsTest {
         List<String> actual = StringUtils.getStacktrace(new NullPointerException("my message"));
         String firstLine = actual.get(0);
 
-        Assert.assertEquals("java.lang.NullPointerException: my message", firstLine);
-    }
-
-    @Test
-    public void testGetFirstLine() {
-        Assert.assertEquals("First line", StringUtils.getFirstLine("First line"));
-        Assert.assertEquals("First line", StringUtils.getFirstLine("First line\nsecond line"));
+        Assert.assertTrue(firstLine, firstLine.startsWith("java.lang.NullPointerException: my message"));
     }
 
     @Test


### PR DESCRIPTION
See details in the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903019](https://bugs.openjdk.java.net/browse/CODETOOLS-7903019): jcstress: Very long exceptions break the VM data streams


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/jcstress pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/94.diff">https://git.openjdk.java.net/jcstress/pull/94.diff</a>

</details>
