### PR TITLE
CODETOOLS-7903052: jcstress: Failure witness examples

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_10_FailureWitness.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_10_FailureWitness.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.samples.high.rmw;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.ZI_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class RMW_10_FailureWitness {
+
+    /*
+        How to run this test:
+            $ java -jar jcstress-samples/target/jcstress.jar -t RMW_10_FailureWitness[.SubTestName]
+     */
+
+    abstract static class Base {
+        static final VarHandle VH;
+
+        static {
+            try {
+                VH = MethodHandles.lookup().findVarHandle(Base.class, "v", int.class);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        int v;
+    }
+
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        This example shows one of the cases where having a "failure witness" for the failing CAS
+        operation is useful. Failure witness is the memory value that CAS had failed on -- the one
+        that was not expected by the CAS.
+
+        Re-reading the memory value "right after" the CAS update can show oddities: it could
+        show the interfering updated that now matches the expected value from the CAS! This would
+        look like a spurious failure in CAS, except that it is allowed by a simple interleaving.
+
+        In this example, a CAS that expected "0" failed, and yet there is "0" in memory.
+
+        On x86_64:
+            RESULT         SAMPLES     FREQ       EXPECT  DESCRIPTION
+          false, 0      65,410,888    0.13%  Interesting  Whoa
+          false, 1  24,486,524,897   47.97%   Acceptable  Trivial
+           true, 0      25,634,745    0.05%   Acceptable  Trivial
+           true, 1  26,473,074,974   51.86%   Acceptable  Trivial
+     */
+
+    @JCStressTest
+    @Outcome(id = "false, 0",                         expect = ACCEPTABLE_INTERESTING, desc = "Whoa")
+    @Outcome(id = {"false, 1", "true, 0", "true, 1"}, expect = ACCEPTABLE, desc = "Trivial")
+    @State
+    public static class BooleanCAS extends Base {
+        @Actor
+        public void actor1(ZI_Result r) {
+            r.r1 = VH.compareAndSet(this, 0, 1);
+            r.r2 = (int) VH.get(this);
+        }
+
+        @Actor
+        public void actor2() {
+            VH.set(this, 0);
+        }
+
+        @Actor
+        public void actor3() {
+            VH.set(this, 1);
+        }
+    }
+
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        With witness, we clearly know what was the memory value CAS had failed on, so the
+        interesting outcome is now forbidden.
+
+        On x86_64:
+            RESULT         SAMPLES     FREQ      EXPECT  DESCRIPTION
+          false, 0               0    0.00%   Forbidden  Cannot happen
+          false, 1  26,892,302,582   49.43%  Acceptable  Trivial
+           true, 0  27,516,182,282   50.57%  Acceptable  Trivial
+           true, 1               0    0.00%  Acceptable  Trivial
+     */
+
+    @JCStressTest
+    @Outcome(id = "false, 0",                         expect = FORBIDDEN,  desc = "Cannot happen")
+    @Outcome(id = {"false, 1", "true, 0", "true, 1"}, expect = ACCEPTABLE, desc = "Trivial")
+    @State
+    public static class WitnessCAS extends Base {
+        @Actor
+        public void actor1(ZI_Result r) {
+            int witness = (int) VH.compareAndExchange(this, 0, 1);
+            r.r1 = (witness == 0);
+            r.r2 = witness;
+        }
+
+        @Actor
+        public void actor2() {
+            VH.set(this, 0);
+        }
+
+        @Actor
+        public void actor3() {
+            VH.set(this, 1);
+        }
+    }
+
+}

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_11_FailureWitnessRWL.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_11_FailureWitnessRWL.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.samples.high.rmw;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.LLLL_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+
+@JCStressTest
+@Outcome(id = {"WRITE-BLOCKED, WRITE-BLOCKED, WRITE-BLOCKED, write-lock",
+               "WRITE-BLOCKED, WRITE-BLOCKED, write-lock, WRITE-BLOCKED"},
+        expect = ACCEPTABLE, desc = "One writer locked")
+@Outcome(id = {"read-lock-1, read-lock-2, READ-BLOCKED, READ-BLOCKED",
+               "read-lock-2, read-lock-1, READ-BLOCKED, READ-BLOCKED"},
+        expect = ACCEPTABLE, desc = "Two readers locked")
+@State
+public class RMW_11_FailureWitnessRWL {
+
+    /*
+        How to run this test:
+            $ java -jar jcstress-samples/target/jcstress.jar -t RMW_11_FailureWitnessRWL[.SubTestName]
+     */
+
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        Failure witness is helpful when the updates are not monotonic, and you would like to see
+        what exact value you have failed against. Re-reading the value would not help, because it
+        might be racy, as RMW_10_FailureWitness shows.
+
+        Consider, for example, a reduced version of read-write lock. With failure witness, we can
+        easily disambiguate whether we have conflicted with another reader or another writer.
+
+        On x86_64:
+                                                           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
+          WRITE-BLOCKED, WRITE-BLOCKED, WRITE-BLOCKED, write-lock  2,123,068,906   25.22%  Acceptable  One writer locked
+          WRITE-BLOCKED, WRITE-BLOCKED, write-lock, WRITE-BLOCKED  1,992,233,099   23.67%  Acceptable  One writer locked
+             read-lock-1, read-lock-2, READ-BLOCKED, READ-BLOCKED  2,258,993,329   26.84%  Acceptable  Two readers locked
+             read-lock-2, read-lock-1, READ-BLOCKED, READ-BLOCKED  2,043,097,306   24.27%  Acceptable  Two readers locked
+     */
+
+    static final VarHandle VH;
+
+    static {
+        try {
+            VH = MethodHandles.lookup().findVarHandle(RMW_11_FailureWitnessRWL.class, "state", int.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // RWL state:
+    //   0..+inf: acquired for (multiple) readers
+    //         0: free
+    //        -1: acquired for single writer
+    int state;
+
+    private String takeForRead() {
+        int witness = (int)VH.compareAndExchange(this, 0, 1);
+        if (witness == 0) {
+            // Read lock acquired.
+            return "read-lock-1";
+        } else if (witness < 0) {
+            // Another thread acquired for write.
+            return "WRITE-BLOCKED";
+        } else {
+            // Another thread acquired for read.
+            return "read-lock-2";
+        }
+    }
+
+    private String takeForWrite() {
+        int witness = (int)VH.compareAndExchange(this, 0, -1);
+        if (witness == 0) {
+            // Write lock acquired.
+            return "write-lock";
+        } else if (witness < 0) {
+            // Another thread acquired for write.
+            return "WRITE-BLOCKED";
+        } else {
+            // Another thread acquired for read.
+            return "READ-BLOCKED";
+        }
+    }
+
+    @Actor
+    public void actor1(LLLL_Result r) {
+        r.r1 = takeForRead();
+    }
+
+    @Actor
+    public void actor2(LLLL_Result r) {
+        r.r2 = takeForRead();
+    }
+
+    @Actor
+    public void actor3(LLLL_Result r) {
+        r.r3 = takeForWrite();
+    }
+
+    @Actor
+    public void actor4(LLLL_Result r) {
+        r.r4 = takeForWrite();
+    }
+
+}

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_12_FailureWitnessLoops.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/high/rmw/RMW_12_FailureWitnessLoops.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.samples.high.rmw;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.III_Result;
+import org.openjdk.jcstress.infra.results.ZZI_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class RMW_12_FailureWitnessLoops {
+
+    /*
+        How to run this test:
+            $ java -jar jcstress-samples/target/jcstress.jar -t RMW_12_FailureWitnessLoops[.SubTestName]
+     */
+
+    abstract static class Base {
+        static final VarHandle VH;
+
+        static {
+            try {
+                VH = MethodHandles.lookup().findVarHandle(Base.class, "v", int.class);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        int v = 1;
+    }
+
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        Failure witness can also be used to get the fresh value in update loops. First, consider
+        the "normal" loop: read the latest value, prepare the update, CAS it, check if successful.
+        This is the usual way to do the CAS-update-loop.
+
+        On x86_64:
+           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
+          2, 4, 4  2,602,060,422   50.34%  Acceptable  Trivial
+          4, 2, 4  2,566,882,682   49.66%  Acceptable  Trivial
+     */
+
+    @JCStressTest
+    @Outcome(id = {"2, 4, 4", "4, 2, 4"}, expect = ACCEPTABLE, desc = "Trivial")
+    @Outcome(                             expect = FORBIDDEN,  desc = "Cannot happen")
+    @State
+    public static class NormalLoop extends Base {
+        private int update() {
+            while (true) {
+                int val = (int) VH.get(this);
+                int newVal = val * 2;
+                if (VH.compareAndSet(this, val, newVal)) {
+                    return newVal;
+                }
+            }
+        }
+
+        @Actor
+        public void actor1(III_Result r) {
+            r.r1 = update();
+        }
+
+        @Actor
+        public void actor2(III_Result r) {
+            r.r2 = update();
+        }
+
+        @Arbiter
+        public void check(III_Result r) {
+            r.r3 = (int) VH.get(this);
+        }
+    }
+
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        With failure witness, we can use it as the "latest" value for retry, thus avoiding the
+        reload in the hot loop.
+
+        Note that the actual performance really depends on the hardware implementation,
+        the contention in the loop, scheduling lags, etc. Do not assume that sparing a read
+        would have an universally positive impact. See for example:
+            https://bugs.openjdk.java.net/browse/JDK-8141640
+
+        On x86_64:
+           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
+          2, 4, 4  2,484,075,481   47.92%  Acceptable  Trivial
+          4, 2, 4  2,699,879,463   52.08%  Acceptable  Trivial
+     */
+
+    @JCStressTest
+    @Outcome(id = {"2, 4, 4", "4, 2, 4"}, expect = ACCEPTABLE, desc = "Trivial")
+    @Outcome(                             expect = FORBIDDEN,  desc = "Cannot happen")
+    @State
+    public static class WitnessLoop extends Base {
+        private int update() {
+            int val = (int) VH.get(this);
+            while (true) {
+                int newVal = val*2;
+                int witness = (int) VH.compareAndExchange(this, val, newVal);
+                if (val == witness) {
+                    return newVal;
+                }
+                val = witness;
+            }
+        }
+
+        @Actor
+        public void actor1(III_Result r) {
+            r.r1 = update();
+        }
+
+        @Actor
+        public void actor2(III_Result r) {
+            r.r2 = update();
+        }
+
+        @Arbiter
+        public void check(III_Result r) {
+            r.r3 = (int) VH.get(this);
+        }
+    }
+
+}


### PR DESCRIPTION
We need to improve the jcstress samples with some failure witness examples. 

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903052](https://bugs.openjdk.java.net/browse/CODETOOLS-7903052): jcstress: Failure witness examples


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/jcstress pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/96.diff">https://git.openjdk.java.net/jcstress/pull/96.diff</a>

</details>
