### PR TITLE
CODETOOLS-7903039: jcstress: HTML reports should capture compilation/scheduling modes

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -368,7 +368,7 @@ public class HTMLReportPrinter {
         }
         o.println("</table>");
 
-        o.println("<h3>Observed states</h3>");
+        o.println("<h3>Results</h3>");
 
         Set<String> keys = new TreeSet<>();
         for (TestResult r : sorted) {
@@ -376,21 +376,24 @@ public class HTMLReportPrinter {
         }
 
         o.println("<table cellpadding=5 border=1>");
+
         o.println("<tr>");
         o.println("<th>Compilation Mode</th>");
         o.println("<th>Scheduling Class</th>");
         o.println("<th>Java Options</th>");
-        o.println("<th>Passed</th>");
+        o.println("<th>Status</th>");
+        o.println("<th colspan=" + keys.size() + ">Observed States</th>");
+        o.println("</tr>");
+
+        o.println("<tr>");
+        o.println("<th colspan=4></th>");
         for (String key : keys) {
             o.println("<th nowrap align='center'>" + key + "</th>");
         }
         o.println("</tr>");
 
         o.println("<tr>");
-        o.println("<td></td>");
-        o.println("<td></td>");
-        o.println("<td></td>");
-        o.println("<td></td>");
+        o.println("<td colspan=4></td>");
         for (String key : keys) {
             for (TestResult r : sorted) {
                 GradingResult c = r.grading().gradingResults.get(key);
@@ -403,10 +406,7 @@ public class HTMLReportPrinter {
         o.println("</tr>");
 
         o.println("<tr>");
-        o.println("<td></td>");
-        o.println("<td></td>");
-        o.println("<td></td>");
-        o.println("<td></td>");
+        o.println("<td colspan=4></td>");
         for (String key : keys) {
             for (TestResult r : sorted) {
                 GradingResult c = r.grading().gradingResults.get(key);
@@ -424,7 +424,7 @@ public class HTMLReportPrinter {
             TestConfig cfg = r.getConfig();
             o.println("<td nowrap valign=top width=10><pre>" + CompileMode.description(cfg.compileMode, cfg.actorNames) + "</pre></td>");
             o.println("<td nowrap valign=top width=10><pre>" + SchedulingClass.description(cfg.shClass, cfg.actorNames) + "</pre></td>");
-            o.println("<td nowrap valign=top width=10>");
+            o.println("<td        valign=top width=10>");
             if (!cfg.jvmArgs.isEmpty()) {
                 o.println("<pre>" + cfg.jvmArgs + "</pre>");
             }
@@ -451,7 +451,7 @@ public class HTMLReportPrinter {
 
         for (TestResult r : sorted) {
             if (!r.getMessages().isEmpty()) {
-                o.println("<p><b>" + r.getConfig() + "</b></p>");
+                resultHeader(o, r);
                 o.println("<pre>");
                 for (String data : r.getMessages()) {
                     o.println(data);
@@ -465,7 +465,7 @@ public class HTMLReportPrinter {
 
         for (TestResult r : sorted) {
             if (!r.getVmOut().isEmpty()) {
-                o.println("<p><b>" + r.getConfig() + "</b></p>");
+                resultHeader(o, r);
                 o.println("<pre>");
                 for (String data : r.getVmOut()) {
                     o.println(data);
@@ -479,7 +479,7 @@ public class HTMLReportPrinter {
 
         for (TestResult r : sorted) {
             if (!r.getVmErr().isEmpty()) {
-                o.println("<p><b>" + r.getConfig() + "</b></p>");
+                resultHeader(o, r);
                 o.println("<pre>");
                 for (String data : r.getVmErr()) {
                     o.println(data);
@@ -490,6 +490,18 @@ public class HTMLReportPrinter {
         }
 
         printFooter(o);
+    }
+
+    private void resultHeader(PrintWriter o, TestResult r) {
+        TestConfig cfg = r.getConfig();
+        o.println("<p><b>");
+        o.println("<pre>" + CompileMode.description(cfg.compileMode, cfg.actorNames) + "</pre>");
+        o.println("<pre>" + SchedulingClass.description(cfg.shClass, cfg.actorNames) + "</pre>");
+        o.println("");
+        if (!cfg.jvmArgs.isEmpty()) {
+            o.println("<pre>" + cfg.jvmArgs + "</pre>");
+        }
+        o.println("</b></p>");
     }
 
     public String selectHTMLColor(Expect type, boolean isZero) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -31,8 +31,11 @@ import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.InProcessCollector;
 import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.infra.runners.TestList;
+import org.openjdk.jcstress.os.SchedulingClass;
 import org.openjdk.jcstress.util.*;
+import org.openjdk.jcstress.vm.CompileMode;
 
 import java.awt.*;
 import java.io.File;
@@ -368,9 +371,16 @@ public class HTMLReportPrinter {
         int configs = 0;
         for (TestResult r : sorted) {
             o.println("<tr>");
-            o.println("<td nowrap><b>TC " + (configs + 1) + "</b></td>");
-            o.println("<td nowrap>" + r.getConfig() + "</td>");
+            o.println("<td nowrap rowspan=4 valign=top><b>TC " + (configs + 1) + "</b></td>");
             o.println("</tr>");
+            TestConfig cfg = r.getConfig();
+            o.println("<tr><td nowrap><pre>Compilation: " + CompileMode.description(cfg.compileMode, cfg.actorNames) + "</pre></td></tr>");
+            o.println("<tr><td nowrap><pre>Scheduling class:\n" + SchedulingClass.description(cfg.shClass, cfg.actorNames) + "</pre></td></tr>");
+            o.println("<tr><td nowrap>");
+            if (!cfg.jvmArgs.isEmpty()) {
+                o.println("<pre>JVM Options: " + cfg.jvmArgs + "</pre>");
+            }
+            o.println("</td></tr>");
             configs++;
         }
         o.println("</table>");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -105,8 +105,4 @@ public class TestConfig implements Serializable {
         return name.hashCode();
     }
 
-    @Override
-    public String toString() {
-        return "JVM options: " + jvmArgs +"; Compile mode: " + getCompileMode();
-    }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -105,4 +105,8 @@ public class TestConfig implements Serializable {
         return name.hashCode();
     }
 
+    public String toString() {
+        throw new IllegalStateException();
+    }
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -105,8 +105,4 @@ public class TestConfig implements Serializable {
         return name.hashCode();
     }
 
-    public String toString() {
-        throw new IllegalStateException();
-    }
-
 }


### PR DESCRIPTION
HTML report is quite misleading after recent compilation/scheduling modes introduction. It needs some rework.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903039](https://bugs.openjdk.java.net/browse/CODETOOLS-7903039): jcstress: HTML reports should capture compilation/scheduling modes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.java.net/jcstress pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/98.diff">https://git.openjdk.java.net/jcstress/pull/98.diff</a>

</details>
