### PR TITLE
CODETOOLS-7903040: jcstress: Introduce stress configuration multipliers

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -178,14 +178,16 @@ public class JCStress {
                 // testing time.
                 continue;
             }
-            for (int f = 0; f < opts.getForks(); f++) {
+            int forks = opts.getForks() * (config.stress() ? opts.getForksStressMultiplier() : 1);
+            for (int f = 0; f < forks; f++) {
                 testConfigs.add(new TestConfig(opts, info, f, config.args(), cc, scl));
             }
         }
     }
 
     private void forkedUnified(List<TestConfig> testConfigs, VMSupport.Config config, TestInfo info, SchedulingClass scl) {
-        for (int f = 0; f < opts.getForks(); f++) {
+        int forks = opts.getForks() * (config.stress() ? opts.getForksStressMultiplier() : 1);
+        for (int f = 0; f < forks; f++) {
             testConfigs.add(new TestConfig(opts, info, f, config.args(), CompileMode.UNIFIED, scl));
         }
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -261,27 +261,27 @@ public class VMSupport {
         LinkedHashSet<Config> configs = new LinkedHashSet<>();
 
         if (!jvmArgs.isEmpty()) {
-            configs.add(new Config(jvmArgs, false));
+            configs.add(new Config(jvmArgs, false, false));
         } else if (splitCompilation && COMPILER_DIRECTIVES_AVAILABLE) {
             System.out.println(" (split compilation is requested and compiler directives are available)");
             // Default global
-            configs.add(new Config(Collections.emptyList(), false));
+            configs.add(new Config(Collections.emptyList(), false, false));
             if (C2_AVAILABLE) {
                 // C2 compilations stress
-                configs.add(new Config(C2_STRESS_JVM_FLAGS, true));
+                configs.add(new Config(C2_STRESS_JVM_FLAGS, true, true));
             }
         } else {
             // Interpreted
-            configs.add(new Config(Arrays.asList("-Xint"), false));
+            configs.add(new Config(Arrays.asList("-Xint"), false, false));
             if (C1_AVAILABLE) {
                 // C1
-                configs.add(new Config(Arrays.asList("-XX:TieredStopAtLevel=1"), false));
+                configs.add(new Config(Arrays.asList("-XX:TieredStopAtLevel=1"), false, false));
             }
             if (C2_AVAILABLE) {
                 // C2
-                configs.add(new Config(Arrays.asList("-XX:-TieredCompilation"), false));
+                configs.add(new Config(Arrays.asList("-XX:-TieredCompilation"), false, false));
                 // C2 only + stress
-                configs.add(new Config(C2_ONLY_STRESS_JVM_FLAGS, true));
+                configs.add(new Config(C2_ONLY_STRESS_JVM_FLAGS, true, true));
             }
         }
 
@@ -299,7 +299,7 @@ public class VMSupport {
                 List<String> l = new ArrayList<>();
                 l.addAll(inputArgs);
                 l.addAll(c.args());
-                return new Config(l, c.onlyIfC2());
+                return new Config(l, c.onlyIfC2(), c.stress());
             }).collect(Collectors.toCollection(LinkedHashSet::new));
         }
 
@@ -309,7 +309,7 @@ public class VMSupport {
                 List<String> l = new ArrayList<>();
                 l.addAll(jvmArgsPrepend);
                 l.addAll(c.args());
-                return new Config(l, c.onlyIfC2());
+                return new Config(l, c.onlyIfC2(), c.stress());
             }).collect(Collectors.toCollection(LinkedHashSet::new));
         }
 
@@ -467,14 +467,20 @@ public class VMSupport {
     public static class Config {
         private final List<String> args;
         private final boolean onlyIfC2;
+        private final boolean stress;
 
-        private Config(List<String> args, boolean onlyIfC2) {
+        private Config(List<String> args, boolean onlyIfC2, boolean stress) {
             this.args = args;
             this.onlyIfC2 = onlyIfC2;
+            this.stress = stress;
         }
 
         public boolean onlyIfC2() {
             return onlyIfC2;
+        }
+
+        public boolean stress() {
+            return stress;
         }
 
         public List<String> args() {


### PR DESCRIPTION
Stress C2 modes are random, it makes sense to run them in more forks to have more opportunities for (un)lucky compilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903040](https://bugs.openjdk.java.net/browse/CODETOOLS-7903040): jcstress: Introduce stress configuration multipliers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.java.net/jcstress pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/99.diff">https://git.openjdk.java.net/jcstress/pull/99.diff</a>

</details>
