### PR TITLE
CODETOOLS-7903049: jcstress: Reconsider tested JDK versions

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 17-ea]
-        run-java: [8, 11, 16, 17-ea]
+        build-java: [11, 17, 18-ea]
+        run-java: [8, 11, 17, 18-ea]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}


### PR DESCRIPTION
With the release of JDK 17, we need to reconsider tested versions in GHA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903049](https://bugs.openjdk.java.net/browse/CODETOOLS-7903049): jcstress: Reconsider tested JDK versions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/jcstress pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/101.diff">https://git.openjdk.java.net/jcstress/pull/101.diff</a>

</details>
