### PR TITLE
CODETOOLS-7903065: jcstress: Do not print CPU allocations for NONE affinity mode

### DIFF
--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -65,7 +65,7 @@ public class SampleTestBench {
         int[] map = new int[2];
         map[0] = -1;
         map[1] = -1;
-        cfg.setCPUMap(new CPUMap(map, map, map, map, false));
+        cfg.setCPUMap(new CPUMap(map, map, map, map, map));
 
         pool = Executors.newCachedThreadPool();
 

--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -65,7 +65,7 @@ public class SampleTestBench {
         int[] map = new int[2];
         map[0] = -1;
         map[1] = -1;
-        cfg.setCPUMap(new CPUMap(map, map, map, map));
+        cfg.setCPUMap(new CPUMap(map, map, map, map, false));
 
         pool = Executors.newCachedThreadPool();
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -197,12 +197,8 @@ public class TestExecutor {
         return reclaimed;
     }
 
-    public int getActorCpus() {
-        return scheduler.getActorCpus();
-    }
-
-    public int getSystemCpus() {
-        return scheduler.getSystemCpus();
+    public int getCpus() {
+        return scheduler.getCpus();
     }
 
     public int getJVMsStarting() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -392,10 +392,13 @@ public class TestExecutor {
             try {
                 List<String> command = new ArrayList<>();
 
-                if (OSSupport.taskSetAvailable() && (task.shClass.mode() != AffinityMode.NONE)) {
-                    command.add("taskset");
-                    command.add("-c");
-                    command.add(cpuMap.globalAffinityMap());
+                if (OSSupport.taskSetAvailable()) {
+                    String map = cpuMap.globalAffinityMap();
+                    if (!map.isEmpty()) {
+                        command.add("taskset");
+                        command.add("-c");
+                        command.add(map);
+                    }
                 }
 
                 // basic Java line

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -72,10 +72,12 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private long softErrors;
     private long hardErrors;
     private TestExecutor executor;
+    private final int totalCpuCount;
 
     public ConsoleReportPrinter(Options opts, PrintWriter pw, long expectedForks) {
         this.output = pw;
         this.expectedResults = expectedForks;
+        totalCpuCount = opts.getCPUCount();
         verbosity = opts.verbosity();
         progressLen = new int[PROGRESS_COMPONENTS];
         Arrays.fill(progressLen, 1);
@@ -159,8 +161,7 @@ public class ConsoleReportPrinter implements TestResultCollector {
 
     private void printStatusLine() {
         long currentTime = System.nanoTime();
-        final int actorCpus = executor.getActorCpus();
-        final int systemCpus = executor.getSystemCpus();
+        final int cpus = executor.getCpus();
 
         String l0 = String.format("(ETA: %s)",
                 computeETA());
@@ -168,8 +169,8 @@ public class ConsoleReportPrinter implements TestResultCollector {
                 computeSpeed());
         String l2 = String.format("(JVMs: %d starting, %d running, %d finishing)",
                 executor.getJVMsStarting(), executor.getJVMsRunning(), executor.getJVMsFinishing());
-        String l3 = String.format("(CPUs: %d actor, %d system, %d total)",
-                actorCpus, systemCpus, actorCpus + systemCpus);
+        String l3 = String.format("(CPUs: %d configured, %d allocated)",
+                totalCpuCount, cpus);
         String l4 = String.format("(Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
                 expectedResults, passed, failed, softErrors, hardErrors);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -122,8 +122,7 @@ public class ReportUtils {
         } else {
             pw.format("  Scheduling class:%n");
             pw.println(SchedulingClass.description(config.getSchedulingClass(), config.actorNames));
-            pw.format("  CPU allocation:%n");
-            pw.println(CPUMap.description(config.cpuMap, config.actorNames));
+            pw.format("  CPU allocation: %s%n", CPUMap.description(config.cpuMap, config.actorNames));
             pw.format("  Compilation: %s%n", CompileMode.description(config.getCompileMode(), config.actorNames));
             pw.format("  JVM args: %s%n", config.jvmArgs);
             pw.format("  Fork: #%d%n", config.forkId + 1);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/CPUMap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/CPUMap.java
@@ -32,14 +32,18 @@ public class CPUMap implements Serializable {
     private final int[] systemMap;
     private final int[] packageMap;
     private final int[] coreMap;
-    private final boolean affinity;
+    private final int[] allocatedMap;
 
-    public CPUMap(int[] actorMap, int[] systemMap, int[] packageMap, int[] coreMap, boolean affinity) {
+    public CPUMap(int[] allocatedMap, int[] actorMap, int[] systemMap, int[] packageMap, int[] coreMap) {
+        this.allocatedMap = allocatedMap;
         this.actorMap = actorMap;
         this.systemMap = systemMap;
         this.packageMap = packageMap;
         this.coreMap = coreMap;
-        this.affinity = affinity;
+    }
+
+    public int[] allocatedMap() {
+        return allocatedMap;
     }
 
     public int[] actorMap() {
@@ -51,19 +55,20 @@ public class CPUMap implements Serializable {
     }
 
     public static String description(CPUMap map, List<String> actorNames) {
-        if (!map.affinity) {
-            return "no special handling";
-        }
-
         int[] actorMap = map.actorMap;
         int[] systemMap = map.systemMap;
         int[] packageMap = map.packageMap;
         int[] coreMap = map.coreMap;
 
+        boolean hasOne = false;
+
         StringBuilder sb = new StringBuilder();
-        sb.append("\n");
         for (int a = 0; a < actorMap.length; a++) {
             if (actorMap[a] != -1) {
+                if (!hasOne) {
+                    sb.append("\n");
+                    hasOne = true;
+                }
                 sb.append("    ");
                 sb.append(actorNames.get(a));
                 sb.append(": ");
@@ -78,6 +83,10 @@ public class CPUMap implements Serializable {
         }
         for (int a = 0; a < systemMap.length; a++) {
             if (systemMap[a] != -1) {
+                if (!hasOne) {
+                    sb.append("\n");
+                    hasOne = true;
+                }
                 sb.append("    <system>: ");
                 sb.append("CPU #");
                 sb.append(systemMap[a]);
@@ -88,14 +97,15 @@ public class CPUMap implements Serializable {
                 sb.append(System.lineSeparator());
             }
         }
+        if (!hasOne) {
+            sb.append("unspecified");
+            sb.append(System.lineSeparator());
+        }
+
         return sb.toString();
     }
 
     public String globalAffinityMap() {
-        if (!affinity) {
-            return "";
-        }
-
         StringBuilder sb = new StringBuilder();
 
         boolean first = true;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/CPUMap.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/CPUMap.java
@@ -28,18 +28,18 @@ import java.io.Serializable;
 import java.util.List;
 
 public class CPUMap implements Serializable {
-    public static final CPUMap UNSET = new CPUMap(new int[] {}, new int[] {}, new int[] {}, new int[] {});
-
     private final int[] actorMap;
     private final int[] systemMap;
     private final int[] packageMap;
     private final int[] coreMap;
+    private final boolean affinity;
 
-    public CPUMap(int[] actorMap, int[] systemMap, int[] packageMap, int[] coreMap) {
+    public CPUMap(int[] actorMap, int[] systemMap, int[] packageMap, int[] coreMap, boolean affinity) {
         this.actorMap = actorMap;
         this.systemMap = systemMap;
         this.packageMap = packageMap;
         this.coreMap = coreMap;
+        this.affinity = affinity;
     }
 
     public int[] actorMap() {
@@ -51,12 +51,17 @@ public class CPUMap implements Serializable {
     }
 
     public static String description(CPUMap map, List<String> actorNames) {
+        if (!map.affinity) {
+            return "no special handling";
+        }
+
         int[] actorMap = map.actorMap;
         int[] systemMap = map.systemMap;
         int[] packageMap = map.packageMap;
         int[] coreMap = map.coreMap;
 
         StringBuilder sb = new StringBuilder();
+        sb.append("\n");
         for (int a = 0; a < actorMap.length; a++) {
             if (actorMap[a] != -1) {
                 sb.append("    ");
@@ -87,6 +92,10 @@ public class CPUMap implements Serializable {
     }
 
     public String globalAffinityMap() {
+        if (!affinity) {
+            return "";
+        }
+
         StringBuilder sb = new StringBuilder();
 
         boolean first = true;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
@@ -66,10 +66,11 @@ public class Scheduler {
 
         switch (scl.mode()) {
             case NONE:
-                cpuMap = scheduleNone(scl);
+                // Pretty much the same, but do not publish system map
+                cpuMap = scheduleGlobal(scl, false);
                 break;
             case GLOBAL:
-                cpuMap = scheduleGlobal(scl);
+                cpuMap = scheduleGlobal(scl, true);
                 break;
             case LOCAL:
                 cpuMap = scheduleLocal(scl);
@@ -193,10 +194,10 @@ public class Scheduler {
             coreMap[thread] = topology.threadToCore(thread);
         }
 
-        return new CPUMap(actorMap, systemMap, packageMap, coreMap);
+        return new CPUMap(actorMap, systemMap, packageMap, coreMap, true);
     }
 
-    private CPUMap scheduleGlobal(SchedulingClass scl) {
+    private CPUMap scheduleGlobal(SchedulingClass scl, boolean affinity) {
         // This ignores per-actor assignments completely.
         // It only allocates a separate core per actor, from the pool of all available cores.
 
@@ -249,12 +250,7 @@ public class Scheduler {
             coreMap[thread] = topology.threadToCore(thread);
         }
 
-        return new CPUMap(actorMap, systemMap, packageMap, coreMap);
-    }
-
-    private CPUMap scheduleNone(SchedulingClass scl) {
-        // TODO: Does this mean "none" is actually fake?
-        return scheduleGlobal(scl);
+        return new CPUMap(actorMap, systemMap, packageMap, coreMap, affinity);
     }
 
     private void checkInvariants(String when) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/Scheduler.java
@@ -225,7 +225,7 @@ public class Scheduler {
         }
 
         // Take all affected cores as assignment
-        int[] takenCPUs = new int[topology.totalThreads()];
+        int[] allocatedMap = new int[topology.totalThreads()];
         int cnt = 0;
 
         for (int core : actorToCore) {
@@ -234,7 +234,7 @@ public class Scheduler {
                     throw new IllegalStateException("Thread should be free");
                 }
                 availableCPUs.set(thread, false);
-                takenCPUs[cnt++] = thread;
+                allocatedMap[cnt++] = thread;
                 currentUse++;
             }
         }
@@ -242,26 +242,26 @@ public class Scheduler {
         int[] actorMap = new int[scl.numActors()];
         Arrays.fill(actorMap, -1);
 
-        takenCPUs = Arrays.copyOf(takenCPUs, cnt);
+        allocatedMap = Arrays.copyOf(allocatedMap, cnt);
         int[] systemMap;
         if (none) {
             // No assignments for system
             systemMap = new int[0];
         } else {
             // All assignments go to system
-            systemMap = Arrays.copyOf(takenCPUs, cnt);
+            systemMap = Arrays.copyOf(allocatedMap, cnt);
         }
 
         int[] coreMap = new int[topology.totalThreads()];
         int[] packageMap = new int[topology.totalThreads()];
         Arrays.fill(coreMap, -1);
         Arrays.fill(packageMap, -1);
-        for (int thread : takenCPUs) {
+        for (int thread : allocatedMap) {
             packageMap[thread] = topology.threadToPackage(thread);
             coreMap[thread] = topology.threadToCore(thread);
         }
 
-        return new CPUMap(takenCPUs, actorMap, systemMap, packageMap, coreMap);
+        return new CPUMap(allocatedMap, actorMap, systemMap, packageMap, coreMap);
     }
 
     private void checkInvariants(String when) {

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/os/AbstractSchedulerAffinityTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/os/AbstractSchedulerAffinityTest.java
@@ -25,9 +25,7 @@
 package org.openjdk.jcstress.os;
 
 import org.junit.Assert;
-import org.openjdk.jcstress.os.topology.PresetRegularTopology;
 import org.openjdk.jcstress.os.topology.Topology;
-import org.openjdk.jcstress.os.topology.TopologyParseException;
 
 import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -63,6 +61,8 @@ public class AbstractSchedulerAffinityTest {
                 Assert.assertEquals(-1, c);
             }
             Assert.assertNotEquals(0, cpuMap.systemMap().length);
+            Assert.assertNotEquals("", cpuMap.globalAffinityMap());
+            Assert.assertNotEquals(0, cpuMap.allocatedMap().length);
         }
     }
 
@@ -109,6 +109,8 @@ public class AbstractSchedulerAffinityTest {
                     }
                 }
             }
+
+            Assert.assertNotEquals("", cpuMap.globalAffinityMap());
         }
     }
 
@@ -139,7 +141,9 @@ public class AbstractSchedulerAffinityTest {
             for (int c : cpuMap.actorMap()) {
                 Assert.assertEquals(-1, c);
             }
-            Assert.assertNotEquals(0, cpuMap.systemMap().length);
+            Assert.assertEquals(0, cpuMap.systemMap().length);
+            Assert.assertEquals("", cpuMap.globalAffinityMap());
+            Assert.assertNotEquals(0, cpuMap.allocatedMap().length);
         }
     }
 


### PR DESCRIPTION
Currently, running with -af NONE, still prints CPU allocation lists. Those are actually fake, and bear no meaning. They should not be printed at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903065](https://bugs.openjdk.java.net/browse/CODETOOLS-7903065): jcstress: Do not print CPU allocations for NONE affinity mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.java.net/jcstress pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/107.diff">https://git.openjdk.java.net/jcstress/pull/107.diff</a>

</details>
