### PR TITLE
CODETOOLS-7903066: jcstress: Do not print fake CPU mappings from FallbackTopology

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/FallbackTopology.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/FallbackTopology.java
@@ -36,7 +36,6 @@ public class FallbackTopology extends PresetRegularTopology {
 
     public void printStatus(PrintStream pw) {
         pw.println("  Fallback topology, faking CPU layout, downgrading to \"NONE\" affinity mode");
-        super.printStatus(pw);
     }
 
     @Override


### PR DESCRIPTION
Those layouts are fake, they are not used anywhere, and can be skipped from printing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903066](https://bugs.openjdk.java.net/browse/CODETOOLS-7903066): jcstress: Do not print fake CPU mappings from FallbackTopology


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.java.net/jcstress pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/108.diff">https://git.openjdk.java.net/jcstress/pull/108.diff</a>

</details>
