### PR TITLE
CODETOOLS-7903070: jcstress: Typo in Classic_01_DiningPhilosophers sample

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -142,7 +142,7 @@ public class Classic_01_DiningPhilosophers {
             // Acquire forks
             while (true) {
                 synchronized (waiter) {
-                    if (!forks[f1] && !forks[f1]) {
+                    if (!forks[f1] && !forks[f2]) {
                         // Success!
                         forks[f1] = true;
                         forks[f2] = true;


### PR DESCRIPTION
SoundCloud found this little oddity. Let's fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903070](https://bugs.openjdk.java.net/browse/CODETOOLS-7903070): jcstress: Typo in Classic_01_DiningPhilosophers sample


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.java.net/jcstress pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/109.diff">https://git.openjdk.java.net/jcstress/pull/109.diff</a>

</details>
