### PR TITLE
CODETOOLS-7903086: jcstress: Deadlock testing mode

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Actor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Actor.java
@@ -31,13 +31,7 @@ import java.lang.annotation.Target;
 
 /**
  * {@link Actor} is the central test annotation. It marks the methods that hold the
- * actions done by the threads. The invariants that are maintained by the infrastructure
- * are as follows:
- *
- * <ol>
- *     <li>Each method is called only by one particular thread.</li>
- *     <li>Each method is called exactly once per {@link State} instance.</li>
- * </ol>
+ * actions done by the threads. Each method is called only by one fixed thread.
  *
  * <p>Note that the invocation order against other {@link Actor} methods is deliberately
  * not specified. Therefore, two or more {@link Actor} methods may be used to model

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
@@ -57,8 +57,10 @@ public enum Mode {
      * any actor deadlocks.
      *
      * <p>In contrast to other modes, each {@link Actor} methods is called over the
-     * same {@link State} instance. This allows testing deadlock conditions more
-     * precisely. If you need a test that still runs {@link Actor} once per
+     * same {@link State} instance, the same number of times. This allows testing
+     * deadlock conditions more precisely, while matching the test symmetry exactly.
+     *
+     * <p>If you need a test that still runs {@link Actor} once per
      * {@link State}, consider using {@link #Continuous} mode, producing
      * only {@link Expect#ACCEPTABLE} results.
      *

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
@@ -41,4 +41,10 @@ public enum Mode {
      */
     Termination,
 
+    /**
+     * Deadlock mode: run several {@link Actor} threads continuously, and see if
+     * any actor deadlocks.
+     */
+    Deadlock,
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
@@ -33,9 +33,10 @@ public enum Mode {
      * Continuous mode: run several {@link Actor}, {@link Arbiter} threads, and
      * collect the histogram of {@link Result}s.
      *
-     * In this mode, each {@link Actor} and {@link Arbiter} method is called
-     * exactly once per {@link State} instance. The test runs continuously until
-     * the test time expires.
+     * <p>In this mode, each {@link Actor} and {@link Arbiter} method is called
+     * exactly once per {@link State} instance.
+     *
+     * <p>The test runs continuously until the test time expires.
      */
     Continuous,
 
@@ -43,9 +44,11 @@ public enum Mode {
      * Termination mode: run a single {@link Actor} with a blocking/looping operation,
      * and see if it responds to a {@link Signal}.
      *
-     * In this mode, each {@link Actor} and {@link Signal} method is called
-     * exactly once per {@link State} instance. The test finishes as soon as
-     * {@link Actor} exits (possibly as the reaction to a {@link Signal}).
+     * <p>In this mode, each {@link Actor} and {@link Signal} method is called
+     * exactly once per {@link State} instance.
+     *
+     * <p>The test finishes as soon as {@link Actor} exits, possibly as the reaction
+     * to a {@link Signal}.
      */
     Termination,
 
@@ -53,8 +56,13 @@ public enum Mode {
      * Deadlock mode: run several {@link Actor} threads continuously, and see if
      * any actor deadlocks.
      *
-     * In contrast to other modes, each {@link Actor} methods is called over the
-     * same {@link State} instance. This allows testing
+     * <p>In contrast to other modes, each {@link Actor} methods is called over the
+     * same {@link State} instance. This allows testing deadlock conditions more
+     * precisely. If you need a test that still runs {@link Actor} once per
+     * {@link State}, consider using {@link #Continuous} mode, producing
+     * only {@link Expect#ACCEPTABLE} results.
+     *
+     * <p>The test runs continuously until the test time expires.
      */
     Deadlock,
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/annotations/Mode.java
@@ -32,18 +32,29 @@ public enum Mode {
     /**
      * Continuous mode: run several {@link Actor}, {@link Arbiter} threads, and
      * collect the histogram of {@link Result}s.
+     *
+     * In this mode, each {@link Actor} and {@link Arbiter} method is called
+     * exactly once per {@link State} instance. The test runs continuously until
+     * the test time expires.
      */
     Continuous,
 
     /**
      * Termination mode: run a single {@link Actor} with a blocking/looping operation,
      * and see if it responds to a {@link Signal}.
+     *
+     * In this mode, each {@link Actor} and {@link Signal} method is called
+     * exactly once per {@link State} instance. The test finishes as soon as
+     * {@link Actor} exits (possibly as the reaction to a {@link Signal}).
      */
     Termination,
 
     /**
      * Deadlock mode: run several {@link Actor} threads continuously, and see if
      * any actor deadlocks.
+     *
+     * In contrast to other modes, each {@link Actor} methods is called over the
+     * same {@link State} instance. This allows testing
      */
     Deadlock,
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -1034,17 +1034,19 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("            final " + t + " test = new " + t + "();");
         }
 
+        pw.println("            long remainingTime = Math.max(config.time, Runner.MIN_TIMEOUT_MS);");
+
+        pw.println("            while (remainingTime > 0) {");
         for (int a = 0; a < info.getActors().size(); a++) {
             pw.println("            final Holder h" + a + " = new Holder();");
         }
-        pw.println("            final Control control = new Control();");
         pw.println();
 
         for (int a = 0; a < info.getActors().size(); a++) {
             ExecutableElement actor = info.getActors().get(a);
             pw.println("            Thread t" + a + " = new Thread(new Runnable() {");
             pw.println("                public void run() {");
-            pw.println("                    while (!control.terminated) {");
+            pw.println("                    for (int c = 0; c < 10000; c++) {"); // TODO: hook stride values here
             pw.println("                        try {");
             pw.println("                            h" + a + ".started = true;");
 
@@ -1066,16 +1068,6 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("            t" + a + ".start();");
         }
         pw.println();
-
-        pw.println("            try {");
-        pw.println("                TimeUnit.MILLISECONDS.sleep(config.time);");
-        pw.println("            } catch (InterruptedException e) {");
-        pw.println("                // do nothing");
-        pw.println("            }");
-        pw.println();
-        pw.println("            control.terminated = true;");
-        pw.println();
-        pw.println("            long remainingTime = Math.max(config.time, Runner.MIN_TIMEOUT_MS);");
 
         for (int a = 0; a < info.getActors().size(); a++) {
             pw.println("            if (remainingTime > 0) {");
@@ -1102,6 +1094,9 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("                return;");
             pw.println("            }");
         }
+
+        pw.println("            }");
+
         pw.println("        }");
         pw.println("    }");
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -103,6 +103,9 @@ public class JCStressTestProcessor extends AbstractProcessor {
                         case Termination:
                             generateTermination(info);
                             break;
+                        case Deadlock:
+                            generateDeadlock(info);
+                            break;
                         default:
                             throw new GenerationException("Unknown mode: " + mode, e);
                     }
@@ -749,6 +752,219 @@ public class JCStressTestProcessor extends AbstractProcessor {
     }
 
     private void generateTermination(TestInfo info) {
+        if (info.getSignal() == null) {
+            throw new GenerationException("@" + JCStressTest.class.getSimpleName() + " with mode=" + Mode.Termination +
+                    " should have a @" + Signal.class.getSimpleName() + " method", info.getTest());
+        }
+
+        if (info.getActors().size() != 1) {
+            throw new GenerationException("@" + JCStressTest.class.getSimpleName() + " with mode=" + Mode.Termination +
+                    " should have only the single @" + Actor.class.getName(), info.getTest());
+        }
+
+        String generatedName = getGeneratedName(info.getTest());
+
+        PrintWriter pw;
+        Writer writer;
+        try {
+            writer = processingEnv.getFiler().createSourceFile(getPackageName(info.getTest()) + "." + generatedName).openWriter();
+            pw = new PrintWriter(writer);
+        } catch (IOException e) {
+            throw new GenerationException("IOException: " + e.getMessage(), info.getTest());
+        }
+
+        String t = info.getTest().getSimpleName().toString();
+
+        ExecutableElement actor = info.getActors().get(0);
+
+        pw.println("package " + getPackageName(info.getTest()) + ";");
+
+        printImports(pw, info);
+
+        pw.println("public class " + generatedName + " extends Runner<" + generatedName + ".Outcome> {");
+        pw.println();
+
+        pw.println("    public " + generatedName + "(ForkedTestConfig config) {");
+        pw.println("        super(config);");
+        pw.println("    }");
+        pw.println();
+
+        pw.println("    @Override");
+        pw.println("    public TestResult run() {");
+        pw.println("        Counter<Outcome> results = new Counter<>();");
+        pw.println();
+        pw.println("        for (int c = 0; c < config.iters; c++) {");
+        pw.println("            run(results);");
+        pw.println();
+        pw.println("            if (results.count(Outcome.STALE) > 0) {");
+        pw.println("                forceExit = true;");
+        pw.println("                break;");
+        pw.println("            }");
+        pw.println("        }");
+        pw.println();
+        pw.println("        return dump(results);");
+        pw.println("    }");
+        pw.println();
+        pw.println("    @Override");
+        pw.println("    public void sanityCheck(Counter<Outcome> counter) throws Throwable {");
+        pw.println("        throw new UnsupportedOperationException();");
+        pw.println("    }");
+        pw.println();
+        pw.println("    @Override");
+        pw.println("    public ArrayList<CounterThread<Outcome>> internalRun() {");
+        pw.println("        throw new UnsupportedOperationException();");
+        pw.println("    }");
+        pw.println();
+        pw.println("    private void run(Counter<Outcome> results) {");
+        pw.println("        long target = System.currentTimeMillis() + config.time;");
+        pw.println("        while (System.currentTimeMillis() < target) {");
+        pw.println();
+
+        if (info.getTest().equals(info.getState())) {
+            pw.println("            final " + info.getState().getSimpleName() + " state = new " + info.getState().getSimpleName() + "();");
+        } else {
+            if (info.getState() != null) {
+                pw.println("            final " + info.getState().getSimpleName() + " state = new " + info.getState().getSimpleName() + "();");
+            }
+            pw.println("            final " + t + " test = new " + t + "();");
+        }
+
+        pw.println("            final Holder holder = new Holder();");
+        pw.println();
+        pw.println("            Thread t1 = new Thread(new Runnable() {");
+        pw.println("                public void run() {");
+        pw.println("                    try {");
+        pw.println("                        holder.started = true;");
+
+        if (info.getTest().equals(info.getState())) {
+            emitMethodTermination(pw, actor, "                        state." + actor.getSimpleName(), "state");
+        } else {
+            emitMethodTermination(pw, actor, "                        test." + actor.getSimpleName(), "state");
+        }
+
+        pw.println("                    } catch (Exception e) {");
+        pw.println("                        holder.error = true;");
+        pw.println("                    }");
+        pw.println("                    holder.terminated = true;");
+        pw.println("                }");
+        pw.println("            });");
+        pw.println("            t1.setDaemon(true);");
+        pw.println("            t1.start();");
+        pw.println();
+        pw.println("            while (!holder.started) {");
+        pw.println("                try {");
+        pw.println("                    TimeUnit.MILLISECONDS.sleep(1);");
+        pw.println("                } catch (InterruptedException e) {");
+        pw.println("                    // do nothing");
+        pw.println("                }");
+        pw.println("            }");
+        pw.println();
+        pw.println("            try {");
+
+        if (info.getTest().equals(info.getState())) {
+            emitMethodTermination(pw, info.getSignal(), "                state." + info.getSignal().getSimpleName(), "state");
+        } else {
+            emitMethodTermination(pw, info.getSignal(), "                test." + info.getSignal().getSimpleName(), "state");
+        }
+
+        pw.println("            } catch (Exception e) {");
+        pw.println("                holder.error = true;");
+        pw.println("            }");
+        pw.println();
+        pw.println("            try {");
+        pw.println("                t1.join(Math.max(2*config.time, Runner.MIN_TIMEOUT_MS));");
+        pw.println("            } catch (InterruptedException e) {");
+        pw.println("                // do nothing");
+        pw.println("            }");
+        pw.println();
+        pw.println("            if (holder.terminated) {");
+        pw.println("                if (holder.error) {");
+        pw.println("                    results.record(Outcome.ERROR);");
+        pw.println("                } else {");
+        pw.println("                    results.record(Outcome.TERMINATED);");
+        pw.println("                }");
+        pw.println("            } else {");
+        pw.println("                results.record(Outcome.STALE);");
+        pw.println("                return;");
+        pw.println("            }");
+        pw.println("        }");
+        pw.println("    }");
+        pw.println();
+        pw.println("    private static class Holder {");
+        pw.println("        volatile boolean started;");
+        pw.println("        volatile boolean terminated;");
+        pw.println("        volatile boolean error;");
+        pw.println("    }");
+        pw.println();
+        pw.println("    public enum Outcome {");
+        pw.println("        TERMINATED,");
+        pw.println("        STALE,");
+        pw.println("        ERROR,");
+        pw.println("    }");
+        pw.println("}");
+        pw.close();
+    }
+
+    private boolean hasResultArgs(ExecutableElement el) {
+        for (VariableElement var : el.getParameters()) {
+            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
+            if (paramClass.getAnnotation(Result.class) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void emitMethod(PrintWriter pw, ExecutableElement el, String lvalue, String stateAccessor, String resultAccessor, boolean terminate) {
+        pw.print(lvalue + "(");
+
+        boolean isFirst = true;
+        for (VariableElement var : el.getParameters()) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                pw.print(", ");
+            }
+            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
+            if (paramClass.getAnnotation(State.class) != null) {
+                pw.print(stateAccessor);
+            } else if (paramClass.getAnnotation(Result.class) != null) {
+                pw.print(resultAccessor);
+            }
+        }
+        pw.print(")");
+        if (terminate) {
+            pw.println(";");
+        }
+    }
+
+    private void emitMethodTermination(PrintWriter pw, ExecutableElement el, String lvalue, String stateAccessor) {
+        pw.print(lvalue + "(");
+
+        boolean isFirst = true;
+        for (VariableElement var : el.getParameters()) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                pw.print(", ");
+            }
+            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
+            if (paramClass.getAnnotation(State.class) != null) {
+                pw.print(stateAccessor);
+            }
+            if (paramClass.getQualifiedName().toString().equals("java.lang.Thread")) {
+                pw.print("t1");
+            }
+        }
+        pw.println(");");
+    }
+
+    private void generateDeadlock(TestInfo info) {
+        if (info.getSignal() != null) {
+            throw new GenerationException("@" + JCStressTest.class.getSimpleName() + " with mode=" + Mode.Deadlock +
+                    " does not support @" + Signal.class.getSimpleName() + " methods", info.getTest());
+        }
+
         String generatedName = getGeneratedName(info.getTest());
 
         PrintWriter pw;
@@ -854,20 +1070,6 @@ public class JCStressTestProcessor extends AbstractProcessor {
         }
         pw.println();
 
-        if (info.getSignal() != null) {
-            pw.println("            try {");
-            if (info.getTest().equals(info.getState())) {
-                emitMethodTermination(pw, info.getSignal(), "                state." + info.getSignal().getSimpleName(), "state");
-            } else {
-                emitMethodTermination(pw, info.getSignal(), "                test." + info.getSignal().getSimpleName(), "state");
-            }
-            pw.println("            } catch (Exception e) {");
-            // TODO: This assumes h0 exists
-            pw.println("                h0.error = true;");
-            pw.println("            }");
-        }
-        pw.println();
-
         for (int a = 0; a < info.getActors().size(); a++) {
             pw.println("            try {");
             pw.println("                t" + a + ".join(Math.max(2*config.time, Runner.MIN_TIMEOUT_MS));");
@@ -906,61 +1108,6 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("    }");
         pw.println("}");
         pw.close();
-    }
-
-    private boolean hasResultArgs(ExecutableElement el) {
-        for (VariableElement var : el.getParameters()) {
-            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
-            if (paramClass.getAnnotation(Result.class) != null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void emitMethod(PrintWriter pw, ExecutableElement el, String lvalue, String stateAccessor, String resultAccessor, boolean terminate) {
-        pw.print(lvalue + "(");
-
-        boolean isFirst = true;
-        for (VariableElement var : el.getParameters()) {
-            if (isFirst) {
-                isFirst = false;
-            } else {
-                pw.print(", ");
-            }
-            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
-            if (paramClass.getAnnotation(State.class) != null) {
-                pw.print(stateAccessor);
-            } else if (paramClass.getAnnotation(Result.class) != null) {
-                pw.print(resultAccessor);
-            }
-        }
-        pw.print(")");
-        if (terminate) {
-            pw.println(";");
-        }
-    }
-
-    private void emitMethodTermination(PrintWriter pw, ExecutableElement el, String lvalue, String stateAccessor) {
-        pw.print(lvalue + "(");
-
-        boolean isFirst = true;
-        for (VariableElement var : el.getParameters()) {
-            if (isFirst) {
-                isFirst = false;
-            } else {
-                pw.print(", ");
-            }
-            TypeElement paramClass = (TypeElement) processingEnv.getTypeUtils().asElement(var.asType());
-            if (paramClass.getAnnotation(State.class) != null) {
-                pw.print(stateAccessor);
-            }
-            if (paramClass.getQualifiedName().toString().equals("java.lang.Thread")) {
-                // TODO: Should be as many threads as Actors?
-                pw.print("t0");
-            }
-        }
-        pw.println(");");
     }
 
     private void printImports(PrintWriter pw, TestInfo info) {

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_07_Deadlock.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/api/API_07_Deadlock.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.samples.api;
+
+import org.openjdk.jcstress.annotations.*;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class API_07_Deadlock {
+
+    /*
+        How to run this test:
+            $ java -jar jcstress-samples/target/jcstress.jar -t API_07_Deadlock[.SubTestName]
+     */
+
+    /*
+        ----------------------------------------------------------------------------------------------------------
+
+        Some concurrency tests are naturally testing for deadlocks. This is supported by
+        the special Mode.Deadlock.
+
+        Here, we have two @Actor-s that acquire locks in the same order. JCStress would
+        run both methods continuously over the same @State object, and see if these methods
+        deadlock. If the test exits in reasonable time, it will record "FINISHED" result,
+        otherwise it will record "STALE".
+
+        This one, correctly synchronized one, yields no deadlocks:
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED      280  100.00%  Acceptable  Gracefully finished.
+             STALE        0    0.00%   Forbidden  Deadlock?
+     */
+
+    @JCStressTest(Mode.Deadlock)
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE, desc = "Gracefully finished.")
+    @Outcome(id = "STALE",    expect = FORBIDDEN,  desc = "Deadlock?")
+    @State
+    public static class Correct {
+        private final Object o1 = new Object();
+        private final Object o2 = new Object();
+
+        @Actor
+        public void actor1() {
+            synchronized (o1) {
+                synchronized (o2) {
+                    // Deliberately empty
+                }
+            }
+        }
+
+        @Actor
+        public void actor2() {
+            synchronized (o1) {
+                synchronized (o2) {
+                    // Deliberately empty
+                }
+            }
+        }
+    }
+
+    /*
+        ----------------------------------------------------------------------------------------------------------
+
+        This variant, however, contains a deadlock.
+
+        Indeed, this would be the test result:
+            RESULT  SAMPLES     FREQ       EXPECT  DESCRIPTION
+          FINISHED        0    0.00%   Acceptable  Gracefully finished.
+             STALE       28  100.00%  Interesting  Deadlock?
+
+          Messages:
+            Have stale threads, forcing VM to exit for proper cleanup.
+     */
+
+    @JCStressTest(Mode.Deadlock)
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE,             desc = "Gracefully finished.")
+    @Outcome(id = "STALE",    expect = ACCEPTABLE_INTERESTING, desc = "Deadlock?")
+    @State
+    public static class Incorrect {
+        private final Object o1 = new Object();
+        private final Object o2 = new Object();
+
+        @Actor
+        public void actor1() {
+            synchronized (o1) {
+                synchronized (o2) {
+                    // Deliberately empty
+                }
+            }
+        }
+
+        @Actor
+        public void actor2() {
+            synchronized (o2) {      // Acquiring in reverse, potential deadlock
+                synchronized (o1) {
+                    // Deliberately empty
+                }
+            }
+        }
+    }
+
+}

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -59,13 +59,14 @@ public class Classic_01_DiningPhilosophers {
         last philosopher to take the forks in the _different_ order.
 
         Indeed, no deadlock occurs:
-          RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
-            true  6,325,295,104  100.00%  Acceptable  Trivial.
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED       60  100.00%  Acceptable  Gracefully finished
+             STALE        0    0.00%   Forbidden  Deadlock?
      */
 
     @JCStressTest(Mode.Deadlock)
-    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
-    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",    expect = FORBIDDEN,  desc = "Deadlock?")
     @State
     public static class ResourceHierarchy {
         private final Object[] forks = new Object[] { new Object(), new Object(), new Object() };
@@ -102,13 +103,14 @@ public class Classic_01_DiningPhilosophers {
         philosopher busy-wait (sic!) on a waiter.
 
         Indeed, no deadlock occurs:
-          RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
-            true  6,270,081,024  100.00%  Acceptable  Trivial.
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED       60  100.00%  Acceptable  Gracefully finished
+             STALE        0    0.00%   Forbidden  Deadlock?
      */
 
     @JCStressTest(Mode.Deadlock)
-    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
-    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",    expect = FORBIDDEN,  desc = "Deadlock?")
     @State
     public static class Arbitrator  {
         private final boolean[] forks = new boolean[3];
@@ -156,13 +158,14 @@ public class Classic_01_DiningPhilosophers {
         to complete before trying to acquire forks.
 
         Indeed, no deadlock occurs:
-          RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
-            true  5,377,787,904  100.00%  Acceptable  Trivial.
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED       60  100.00%  Acceptable  Gracefully finished
+             STALE        0    0.00%   Forbidden  Deadlock?
      */
 
     @JCStressTest(Mode.Deadlock)
-    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
-    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",    expect = FORBIDDEN,  desc = "Deadlock?")
     @State
     public static class OneDinerFewer {
         private final AtomicIntegerArray forks = new AtomicIntegerArray(3);

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -63,7 +63,7 @@ public class Classic_01_DiningPhilosophers {
             true  6,325,295,104  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest(Mode.Termination)
+    @JCStressTest(Mode.Deadlock)
     @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
     @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
@@ -106,7 +106,7 @@ public class Classic_01_DiningPhilosophers {
             true  6,270,081,024  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest(Mode.Termination)
+    @JCStressTest(Mode.Deadlock)
     @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
     @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
@@ -160,7 +160,7 @@ public class Classic_01_DiningPhilosophers {
             true  5,377,787,904  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest(Mode.Termination)
+    @JCStressTest(Mode.Deadlock)
     @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
     @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
 
 public class Classic_01_DiningPhilosophers {
 
@@ -52,7 +53,7 @@ public class Classic_01_DiningPhilosophers {
 
         The trivial deadlock in this problem is when every philosopher holds one fork,
         and waits for other fork to drop. If all philosophers take the fork on one side,
-        no philosophers would be able to complete. // TODO: Demo with multi-actor termination tests.
+        no philosophers would be able to complete.
 
         The first solution is "Resource Hierarchy": it avoids the deadlock by asking the
         last philosopher to take the forks in the _different_ order.
@@ -62,8 +63,9 @@ public class Classic_01_DiningPhilosophers {
             true  6,325,295,104  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest
-    @Outcome(expect = ACCEPTABLE, desc = "Trivial.")
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
     public static class ResourceHierarchy {
         private final Object[] forks = new Object[] { new Object(), new Object(), new Object() };
@@ -81,12 +83,6 @@ public class Classic_01_DiningPhilosophers {
         @Actor
         public void p3() {
             eat(0, 2); // in different order
-        }
-
-        @Arbiter
-        public void fake(Z_Result r) {
-            // Fake the result. The actual failure is deadlock.
-            r.r1 = true;
         }
 
         final protected void eat(int fork1, int fork2) {
@@ -110,8 +106,9 @@ public class Classic_01_DiningPhilosophers {
             true  6,270,081,024  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest
-    @Outcome(id = "true", expect = ACCEPTABLE, desc = "Trivial.")
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
     public static class Arbitrator  {
         private final boolean[] forks = new boolean[3];
@@ -130,12 +127,6 @@ public class Classic_01_DiningPhilosophers {
         @Actor
         public void p3() {
             eat(2, 0);
-        }
-
-        @Arbiter
-        public void fake(Z_Result r) {
-            // Fake the result. The actual failure is deadlock.
-            r.r1 = true;
         }
 
         void eat(int f1, int f2) {
@@ -169,8 +160,9 @@ public class Classic_01_DiningPhilosophers {
             true  5,377,787,904  100.00%  Acceptable  Trivial.
      */
 
-    @JCStressTest
-    @Outcome(id = "true", expect = ACCEPTABLE, desc = "Trivial.")
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
     public static class OneDinerFewer {
         private final AtomicIntegerArray forks = new AtomicIntegerArray(3);
@@ -189,12 +181,6 @@ public class Classic_01_DiningPhilosophers {
         @Actor
         public void p3() {
             eat(2, 0);
-        }
-
-        @Arbiter
-        public void fake(Z_Result r) {
-            // Fake the result. The actual failure is deadlock.
-            r.r1 = true;
         }
 
         void eat(int f1, int f2) {

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
@@ -112,12 +112,14 @@ public class Classic_02_ProducerConsumerProblem {
         This solution shows how semaphores can be used to solve the producer-consumer problem
         for only one producer and only one consumer.
 
-          RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
-            true  685.944.832  100,00%  Acceptable  Trivial
+        Indeed, it works correctly:
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED       60  100.00%  Acceptable  Gracefully finished
+             STALE        0    0.00%   Forbidden  Deadlock?
      */
     @JCStressTest(Mode.Deadlock)
-    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
-    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",    expect = FORBIDDEN,  desc = "Deadlock?")
     @State
     public static class OneProducerOneConsumer extends SemaphoresBase {
         @Actor
@@ -314,12 +316,13 @@ public class Classic_02_ProducerConsumerProblem {
         This solution with AtomicIntegers only works with one producer and one consumer.
         It fails if an int overflow happens.
 
-          RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
-            true  558.057.472  100,00%  Acceptable  One producer produced 2 items which were consumed.
+            RESULT  SAMPLES     FREQ      EXPECT  DESCRIPTION
+          FINISHED      203   93.98%  Acceptable  Gracefully finished
+             STALE       13    6.02%   Forbidden  Deadlock?
      */
     @JCStressTest(Mode.Deadlock)
-    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
-    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
+    @Outcome(id = "FINISHED", expect = ACCEPTABLE,             desc = "Gracefully finished")
+    @Outcome(id = "STALE",    expect = ACCEPTABLE_INTERESTING, desc = "Deadlock?")
     @State
     public static class AtomicIntegers {
         private final AtomicInteger produced = new AtomicInteger();

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
@@ -33,8 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
-import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE_INTERESTING;
+import static org.openjdk.jcstress.annotations.Expect.*;
 
 public class Classic_02_ProducerConsumerProblem {
     /*
@@ -116,8 +115,9 @@ public class Classic_02_ProducerConsumerProblem {
           RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
             true  685.944.832  100,00%  Acceptable  Trivial
      */
-    @JCStressTest
-    @Outcome(id = "true", expect = ACCEPTABLE, desc = "Trivial")
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
     public static class OneProducerOneConsumer extends SemaphoresBase {
         @Actor
@@ -130,11 +130,6 @@ public class Classic_02_ProducerConsumerProblem {
         void consumer() {
             consume();
             consume();
-        }
-
-        @Arbiter
-        public void fake(Z_Result r) {
-            r.r1 = true;
         }
     }
 
@@ -322,8 +317,9 @@ public class Classic_02_ProducerConsumerProblem {
           RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
             true  558.057.472  100,00%  Acceptable  One producer produced 2 items which were consumed.
      */
-    @JCStressTest
-    @Outcome(id = "true", expect = ACCEPTABLE, desc = "One producer produced 2 items which were consumed.")
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
     public static class AtomicIntegers {
         private final AtomicInteger produced = new AtomicInteger();
@@ -349,11 +345,6 @@ public class Classic_02_ProducerConsumerProblem {
         public void consume() {
             while (produced.get() - consumed.get() == 0); // spin
             consumed.getAndIncrement();
-        }
-
-        @Arbiter
-        public void fake(Z_Result r) {
-            r.r1 = true;
         }
     }
 }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_02_ProducerConsumerProblem.java
@@ -115,7 +115,7 @@ public class Classic_02_ProducerConsumerProblem {
           RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
             true  685.944.832  100,00%  Acceptable  Trivial
      */
-    @JCStressTest(Mode.Termination)
+    @JCStressTest(Mode.Deadlock)
     @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
     @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State
@@ -317,7 +317,7 @@ public class Classic_02_ProducerConsumerProblem {
           RESULT      SAMPLES     FREQ      EXPECT  DESCRIPTION
             true  558.057.472  100,00%  Acceptable  One producer produced 2 items which were consumed.
      */
-    @JCStressTest(Mode.Termination)
+    @JCStressTest(Mode.Deadlock)
     @Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Gracefully finished")
     @Outcome(id = "STALE",      expect = FORBIDDEN,  desc = "Test is stuck")
     @State


### PR DESCRIPTION
A few samples, notably DiningPhilosophers and ProducerConsumer are actually testing for multi-actor deadlock. It is now faked by using the @Arbiter and default (continuous) mode, but it comes with a few drawbacks.

First, it is kludgy. Second, that mode runs @Actor once per @State, and so deadlock opportunity is rather narrow.

Instead, we should be having a special deadlock mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903086](https://bugs.openjdk.org/browse/CODETOOLS-7903086): jcstress: Deadlock testing mode (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jcstress.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/110.diff">https://git.openjdk.org/jcstress/pull/110.diff</a>

</details>
