### PR TITLE
CODETOOLS-7903112: jcstress: GHA: Allow one concurrent run per PR only 

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Similar to [JDK-8282225](https://bugs.openjdk.java.net/browse/JDK-8282225), we want the same for jcstress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903112](https://bugs.openjdk.java.net/browse/CODETOOLS-7903112): jcstress: GHA: Allow one concurrent run per PR only


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcstress pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.java.net/jcstress pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcstress/pull/113.diff">https://git.openjdk.java.net/jcstress/pull/113.diff</a>

</details>
