### PR TITLE
CODETOOLS-7903233: jcstress: Improve GHA triggers

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -1,8 +1,10 @@
 name: JCStress Pre-Integration Tests
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+  push:
+    branches-ignore:
+      - master
+      - pr/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
GHA workflows need to have a push-based trigger instead of pull_request one, in order to comply with current scheme of running actions in private forks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903233](https://bugs.openjdk.org/browse/CODETOOLS-7903233): jcstress: Improve GHA triggers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jcstress pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/116.diff">https://git.openjdk.org/jcstress/pull/116.diff</a>

</details>
