### PR TITLE
CODETOOLS-7903236: jcstress: Improve Classic_01_DiningPhilosophers test

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_04_Progress.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_04_Progress.java
@@ -144,4 +144,43 @@ public class BasicJMM_04_Progress {
         }
     }
 
+    /*
+      ----------------------------------------------------------------------------------------------------------
+
+        For completeness, writing and reading the variable under explicit synchronization
+        also provides the progress guarantees. The writes under one thread releasing the lock
+        are visible to the thread subsequently acquiring the lock. Therefore, the loop eventually
+        terminates.
+
+        Indeed, this is guaranteed to happen on all platforms:
+
+              RESULT  SAMPLES     FREQ       EXPECT  DESCRIPTION
+               STALE        0    0.00%  Interesting  Test is stuck
+          TERMINATED   35,750  100.00%   Acceptable  Gracefully finished
+     */
+
+    @JCStressTest(Mode.Termination)
+    @Outcome(id = "TERMINATED", expect = ACCEPTABLE,             desc = "Gracefully finished")
+    @Outcome(id = "STALE",      expect = ACCEPTABLE_INTERESTING, desc = "Test is stuck")
+    @State
+    public static class SyncSpin {
+        boolean ready;
+
+        @Actor
+        public void actor1() {
+            while (true) { // spin
+               synchronized (this) {
+                   if (ready) break;
+               }
+            }
+        }
+
+        @Signal
+        public void signal() {
+            synchronized (this) {
+                ready = true;
+            }
+        }
+    }
+
 }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -105,6 +105,10 @@ public class Classic_01_DiningPhilosophers {
         solves the deadlock by not letting circular resource waits. For the purposes of this test,
         philosopher busy-wait (sic!) on a waiter.
 
+        Note that we also synchronize the fork releases to guarantee progress. Making the fork
+        accesses "opaque" would also suffice, but using the same lock on reader and writer side
+        is cleaner here. See also BasicJMM_04_Progress sample.
+
         Indeed, no deadlock occurs:
           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
             true  6,270,081,024  100.00%  Acceptable  Trivial.

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/problems/classic/Classic_01_DiningPhilosophers.java
@@ -152,8 +152,10 @@ public class Classic_01_DiningPhilosophers {
             }
 
             // Release forks
-            forks[f1] = false;
-            forks[f2] = false;
+            synchronized (waiter) {
+                forks[f1] = false;
+                forks[f2] = false;
+            }
         }
     }
 


### PR DESCRIPTION
Improves the progress guarantees handling in samples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903236](https://bugs.openjdk.org/browse/CODETOOLS-7903236): jcstress: Improve Classic_01_DiningPhilosophers test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.org/jcstress pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/117.diff">https://git.openjdk.org/jcstress/pull/117.diff</a>

</details>
