### PR TITLE
CODETOOLS-7903290: jcstress: Inline Counter.record(R) method

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -396,7 +396,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             emitMethod(pw, info.getArbiter(), (isStateItself ? "s." : "t.") + info.getArbiter().getSimpleName(), "s", "r", false);
             pw.println(";");
         }
-        pw.println("        counter.record(r);");
+        pw.println("        counter.record(r, 1);");
         pw.println("    }");
         pw.println();
 
@@ -454,7 +454,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
         }
 
         pw.println("            for (int c = 0; c < size; c++) {");
-        pw.println("                counter.record(lr[c]);");
+        pw.println("                counter.record(lr[c], 1);");
         pw.println("            }");
         pw.println("            long time2 = System.nanoTime();");
         pw.println("            long alloc2 = AllocProfileSupport.getAllocatedBytes();");
@@ -548,7 +548,7 @@ public class JCStressTestProcessor extends AbstractProcessor {
             pw.println("            ls[c] = new " + s + "();");
         }
 
-        pw.println("            cnt.record(r);");
+        pw.println("            cnt.record(r, 1);");
 
         for (VariableElement var : ElementFilter.fieldsIn(info.getResult().getEnclosedElements())) {
             if (var.getSimpleName().toString().equals("jcstress_trap")) continue;
@@ -876,12 +876,12 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println();
         pw.println("            if (holder.terminated) {");
         pw.println("                if (holder.error) {");
-        pw.println("                    results.record(Outcome.ERROR);");
+        pw.println("                    results.record(Outcome.ERROR, 1);");
         pw.println("                } else {");
-        pw.println("                    results.record(Outcome.TERMINATED);");
+        pw.println("                    results.record(Outcome.TERMINATED, 1);");
         pw.println("                }");
         pw.println("            } else {");
-        pw.println("                results.record(Outcome.STALE);");
+        pw.println("                results.record(Outcome.STALE, 1);");
         pw.println("                return;");
         pw.println("            }");
         pw.println("        }");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/Counter.java
@@ -95,21 +95,11 @@ public final class Counter<R> implements Serializable {
     }
 
     /**
-     * Records the result.
-     * The result can mutate after the record() is finished.
-     *
-     * @param result result to record
-     */
-    public final void record(R result) {
-        record(result, 1);
-    }
-
-    /**
      * Records the result with given occurrences count.
      * The result can mutate after the call is finished.
      *
      * @param result result to record
-     * @param count number of occurences to record
+     * @param count number of occurrences to record
      */
     public final void record(R result, long count) {
         int idx = result.hashCode() & (length - 1);

--- a/jcstress-core/src/test/java/org/openjdk/jcstress/util/CounterTest.java
+++ b/jcstress-core/src/test/java/org/openjdk/jcstress/util/CounterTest.java
@@ -34,7 +34,7 @@ public class CounterTest {
     @Test
     public void test1() {
         Counter<String> cnt = new Counter<>();
-        cnt.record("Foo");
+        cnt.record("Foo", 1);
 
         Assert.assertEquals(1, cnt.count("Foo"));
         Assert.assertEquals(1, cnt.elementSet().size());


### PR DESCRIPTION
Currently, jcstress uses a "convenience" method on a hot path, which delegates to the real one. This relies on JIT compilers to inline it through. We don't have to rely on this, and can call the full method directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903290](https://bugs.openjdk.org/browse/CODETOOLS-7903290): jcstress: Inline Counter.record(R) method


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jcstress pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/120.diff">https://git.openjdk.org/jcstress/pull/120.diff</a>

</details>
