### PR TITLE
CODETOOLS-7903292: jcstress: Allocation profiling is not available on older JDKs

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/AllocProfileSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/AllocProfileSupport.java
@@ -64,7 +64,7 @@ public class AllocProfileSupport {
 
             try {
                 THREAD_ID_GETTER = Thread.class.getMethod("threadId");
-            } catch (NoSuchMethodError nsme) {
+            } catch (NoSuchMethodException nsme) {
                 THREAD_ID_GETTER = Thread.class.getMethod("getId");
             }
 


### PR DESCRIPTION
[CODETOOLS-7903216](https://bugs.openjdk.org/browse/CODETOOLS-7903216) introduced a regression where allocation profiling was ruled to be unavailable on older JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903292](https://bugs.openjdk.org/browse/CODETOOLS-7903292): jcstress: Allocation profiling is not available on older JDKs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/jcstress pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/122.diff">https://git.openjdk.org/jcstress/pull/122.diff</a>

</details>
