### PR TITLE
CODETOOLS-7903365: jcstress: Update pre-integration testing workflows

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,24 +16,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 17, 19-ea]
-        run-java: [8, 11, 17, 19-ea]
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        build-java: [11, 17, 19, 20-ea]
+        run-java: [8, 11, 17, 19, 20-ea]
+        os: [ubuntu-22.04, windows-2022, macos-11]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up build JDK ${{ matrix.build-java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: ${{ matrix.build-java }}
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.github/workflows/pre-integration.yml') }}
-        restore-keys: ${{ runner.os }}-maven
+        cache: maven
     - name: Build/test
       run: mvn clean install -T 1C -B --file pom.xml
     - name: Set up run JDK ${{ matrix.run-java }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up build JDK ${{ matrix.build-java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v3.6.0
       with:
         distribution: temurin
         java-version: ${{ matrix.build-java }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up build JDK ${{ matrix.build-java }}
-      uses: actions/setup-java@v3.6.0
+      uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ matrix.build-java }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -33,8 +33,9 @@ jobs:
     - name: Build/test
       run: mvn clean install -T 1C -B --file pom.xml
     - name: Set up run JDK ${{ matrix.run-java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: ${{ matrix.run-java }}
     - name: Run a trial test
       run: java -jar tests-custom/target/jcstress.jar -t UnfencedDekker


### PR DESCRIPTION
Time to update our workflows: new JDKs, new OSes, new GH plugins.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903365](https://bugs.openjdk.org/browse/CODETOOLS-7903365): jcstress: Update pre-integration testing workflows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jcstress pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/123.diff">https://git.openjdk.org/jcstress/pull/123.diff</a>

</details>
