### PR TITLE
7903383: jcstress: All State objects should be processed

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -270,9 +270,12 @@ public class TestExecutor {
             pw.println("    inline: \"-" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + "*\",");
 
             // Force inline the auxiliary methods and classes in the run loop
-            pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
+            pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.CONSUME_PREFIX + "*\",");
             pw.println("    inline: \"+" + WorkerSync.class.getName() + "::*\",");
             pw.println("    inline: \"+java.util.concurrent.atomic.*::*\",");
+
+            // Omit inlining of non-essential methods
+            pw.println("    inline: \"-" + task.generatedRunnerName + "::" + JCStressTestProcessor.CONSUME_NI_PREFIX + "*\",");
 
             // The test is running in resource-constrained JVM. Block the task loop execution until
             // compiled code is available. This would allow compilers to work in relative peace.
@@ -299,7 +302,8 @@ public class TestExecutor {
 
                 pw.println("  {");
                 pw.println("    match: \"" + task.generatedRunnerName + "::" + JCStressTestProcessor.RUN_LOOP_PREFIX + an + "\",");
-                pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.AUX_PREFIX + "*\",");
+                pw.println("    inline: \"+" + task.generatedRunnerName + "::" + JCStressTestProcessor.CONSUME_PREFIX + "*\",");
+                pw.println("    inline: \"-" + task.generatedRunnerName + "::" + JCStressTestProcessor.CONSUME_NI_PREFIX + "*\",");
 
                 // Force inline of actor methods if run in compiled mode: this would inherit
                 // compiler for them. Forbid inlining of actor methods in interpreted mode:

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Control.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/Control.java
@@ -28,5 +28,5 @@ package org.openjdk.jcstress.infra.runners;
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
  */
 public class Control {
-    public volatile boolean isStopped;
+    public volatile boolean stopping;
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/WorkerSync.java
@@ -35,7 +35,7 @@ import java.util.concurrent.locks.LockSupport;
 @jdk.internal.vm.annotation.Contended
 public class WorkerSync {
 
-    public final boolean stopped;
+    public final boolean stopping;
     public final SpinLoopStyle spinStyle;
 
     private volatile int notConsumed;
@@ -46,8 +46,8 @@ public class WorkerSync {
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_NOT_UPDATED = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "notUpdated");
     static final AtomicIntegerFieldUpdater<WorkerSync> UPDATER_CHECKPOINT = AtomicIntegerFieldUpdater.newUpdater(WorkerSync.class, "checkpoint");
 
-    public WorkerSync(boolean stopped, int expectedWorkers, SpinLoopStyle spinStyle) {
-        this.stopped = stopped;
+    public WorkerSync(boolean stopping, int expectedWorkers, SpinLoopStyle spinStyle) {
+        this.stopping = stopping;
         this.spinStyle = spinStyle;
         this.notConsumed = expectedWorkers;
         this.notUpdated = expectedWorkers;


### PR DESCRIPTION
There is a reasonable expectation that once `@State` object is created, it would eventually be acted upon. In fact, the Javadoc for `@Actor`/`@Arbiter` mentions that actor methods would be called on each state object exactly once. There are cases where users rely on this implicit lifecycle assumption to perform cleanups at `@Arbiter` methods.

Unfortunately, once jcstress leaves the test, it keeps last created state object slice unprocessed, which breaks this assumption.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903383](https://bugs.openjdk.org/browse/CODETOOLS-7903383): jcstress: All State objects should be processed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jcstress pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/124.diff">https://git.openjdk.org/jcstress/pull/124.diff</a>

</details>
