### PR TITLE
7903407: jcstress: Main cannot compile with -Werror due to URL deprecation

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -62,16 +62,12 @@ public class Main {
     }
 
     static void printVersion(PrintStream out) {
-        Class<?> clazz = Main.class;
-        String className = clazz.getSimpleName() + ".class";
-        String classPath = clazz.getResource(className).toString();
-        if (!classPath.startsWith("jar")) {
-            return;
-        }
-        String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
-        InputStream stream = null;
-        try {
-            stream = new URL(manifestPath).openStream();
+        try (InputStream stream = Main.class.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+            if (stream == null) {
+                // No manifest?
+                out.println("Rev: unknown");
+                return;
+            }
             Manifest manifest = new Manifest(stream);
             Attributes attr = manifest.getMainAttributes();
             out.printf("Rev: %s, built by %s with %s at %s%n",
@@ -82,14 +78,6 @@ public class Main {
             );
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            try {
-                if (stream != null) {
-                    stream.close();
-                }
-            } catch (IOException e) {
-                // swallow
-            }
         }
     }
 


### PR DESCRIPTION
```
Warning: COMPILATION WARNING :
[INFO] -------------------------------------------------------------
Warning: /home/runner/work/jcstress/jcstress/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java:[74,22] URL(java.lang.String) in java.net.URL has been deprecated
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903407](https://bugs.openjdk.org/browse/CODETOOLS-7903407): jcstress: Main cannot compile with -Werror due to URL deprecation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jcstress pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/125.diff">https://git.openjdk.org/jcstress/pull/125.diff</a>

</details>
