### PR TITLE
7903408: jcstress: Add BiasedLocking options in test configurations

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -238,6 +238,10 @@ public class ReportUtils {
             return true;
         }
 
+        if (data.contains("Option UseBiasedLocking was deprecated")) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Different JDKs have differing opinions on the availability of UseBiasedLocking. For better locking path coverage, we might want to sense and add these options if available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903408](https://bugs.openjdk.org/browse/CODETOOLS-7903408): jcstress: Add BiasedLocking options in test configurations


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/jcstress pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/126.diff">https://git.openjdk.org/jcstress/pull/126.diff</a>

</details>
