### PR TITLE
7903420: jcstress: Trim down the large array tests

### DIFF
--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraycopy.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraycopy.java.template
@@ -34,22 +34,22 @@ import org.openjdk.jcstress.infra.results.*;
  * Tests if arrays experience coherence failures.
  */
 @JCStressTest
-@Outcome(id = "true, 2097152, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
+@Outcome(id = "true, 131072, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
 #if[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #else[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #end[safe]
 @State
 public class $name$ {
 
     static final $type$[] src;
     static {
-       src = new $type$[2 * 1024 * 1024];
+       src = new $type$[131072];
        for (int c = 0; c < src.length; c++) {
          src[c] = $setLiteral$;
        }
@@ -59,8 +59,8 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        $type$[] c = new $type$[2097152];
-        System.arraycopy(src, 0, c, 0, 2097152);
+        $type$[] c = new $type$[131072];
+        System.arraycopy(src, 0, c, 0, 131072);
         copy = c;
     }
 
@@ -81,7 +81,7 @@ public class $name$ {
           r.r3 = (hasDefaults ? 1 : 0) + (hasWeird ? 2 : 0);
         } else {
           r.r1 = true;
-          r.r2 = 2097152;
+          r.r2 = 131072;
           r.r3 = 0;
         }
     }

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraysCopyOf.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeArraysCopyOf.java.template
@@ -34,22 +34,22 @@ import org.openjdk.jcstress.infra.results.*;
  * Tests if arrays experience coherence failures.
  */
 @JCStressTest
-@Outcome(id = "true, 2097152, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
+@Outcome(id = "true, 131072, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
 #if[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #else[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #end[safe]
 @State
 public class $name$ {
 
     static final $type$[] src;
     static {
-       src = new $type$[2 * 1024 * 1024];
+       src = new $type$[131072];
        for (int c = 0; c < src.length; c++) {
          src[c] = $setLiteral$;
        }
@@ -59,7 +59,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        copy = Arrays.copyOf(src, 2097152);
+        copy = Arrays.copyOf(src, 131072);
     }
 
     @Actor
@@ -79,7 +79,7 @@ public class $name$ {
           r.r3 = (hasDefaults ? 1 : 0) + (hasWeird ? 2 : 0);
         } else {
           r.r1 = true;
-          r.r2 = 2097152;
+          r.r2 = 131072;
           r.r3 = 0;
         }
     }

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeClone.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeClone.java.template
@@ -34,22 +34,22 @@ import org.openjdk.jcstress.infra.results.*;
  * Tests if arrays experience coherence failures.
  */
 @JCStressTest
-@Outcome(id = "true, 2097152, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
+@Outcome(id = "true, 131072, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
 #if[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #else[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #end[safe]
 @State
 public class $name$ {
 
     static final $type$[] src;
     static {
-       src = new $type$[2 * 1024 * 1024];
+       src = new $type$[131072];
        for (int c = 0; c < src.length; c++) {
          src[c] = $setLiteral$;
        }
@@ -79,7 +79,7 @@ public class $name$ {
           r.r3 = (hasDefaults ? 1 : 0) + (hasWeird ? 2 : 0);
         } else {
           r.r1 = true;
-          r.r2 = 2097152;
+          r.r2 = 131072;
           r.r3 = 0;
         }
     }

--- a/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeManual.java.template
+++ b/jcstress-test-gen/src/main/resources/copy/arrays/X-LargeManual.java.template
@@ -34,22 +34,22 @@ import org.openjdk.jcstress.infra.results.*;
  * Tests if arrays experience coherence failures.
  */
 @JCStressTest
-@Outcome(id = "true, 2097152, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
+@Outcome(id = "true, 131072, 0", expect = Expect.ACCEPTABLE,  desc = "Seeing array with all elements set.")
 #if[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #else[safe]
-@Outcome(id = "true, 2097152, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
-@Outcome(id = "true, 2097152, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
-@Outcome(id = "true, 2097152, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
+@Outcome(id = "true, 131072, 1", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are default")
+@Outcome(id = "true, 131072, 2", expect = Expect.ACCEPTABLE,  desc = "Seeing array, but some contents are weird")
+@Outcome(id = "true, 131072, 3", expect = Expect.FORBIDDEN,   desc = "Seeing array, but some contents are default/weird")
 #end[safe]
 @State
 public class $name$ {
 
     static final $type$[] src;
     static {
-       src = new $type$[2 * 1024 * 1024];
+       src = new $type$[131072];
        for (int c = 0; c < src.length; c++) {
          src[c] = $setLiteral$;
        }
@@ -59,7 +59,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        $type$[] c = new $type$[2097152];
+        $type$[] c = new $type$[131072];
         for (int t = 0; t < src.length; t++) {
            c[t] = src[t];
         }
@@ -83,7 +83,7 @@ public class $name$ {
           r.r3 = (hasDefaults ? 1 : 0) + (hasWeird ? 2 : 0);
         } else {
           r.r1 = true;
-          r.r2 = 2097152;
+          r.r2 = 131072;
           r.r3 = 0;
         }
     }

--- a/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayLargeDefaultValuesTest.java.template
+++ b/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayLargeDefaultValuesTest.java.template
@@ -44,7 +44,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        arr = new $type$[2 * 1024 * 1024];
+        arr = new $type$[131072];
     }
 
     @Actor

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitClassTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitClassTest.java.template
@@ -38,7 +38,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        arr = new $type$[2 * 1024 * 1024];
+        arr = new $type$[131072];
     }
 
     @Actor

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitLengthTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitLengthTest.java.template
@@ -31,7 +31,7 @@ import org.openjdk.jcstress.infra.results.*;
 
 @JCStressTest
 @Outcome(id = "0", expect = Expect.ACCEPTABLE, desc = "Haven't seen yet.")
-@Outcome(id = "2097152", expect = Expect.ACCEPTABLE, desc = "Seeing good length.")
+@Outcome(id = "131072", expect = Expect.ACCEPTABLE, desc = "Seeing good length.")
 @State
 public class $name$ {
 
@@ -39,7 +39,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        arr = new $type$[2 * 1024 * 1024];
+        arr = new $type$[131072];
     }
 
     @Actor

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitTest.java.template
@@ -45,7 +45,7 @@ public class $name$ {
 
     @Actor
     public void actor1() {
-        $type$[] a = new $type$[2 * 1024 * 1024];
+        $type$[] a = new $type$[131072];
         for (int c = 0; c < a.length; c++) a[c] = $setLiteral$;
         arr = a;
     }

--- a/jcstress-test-gen/src/main/resources/tearing/X-ArrayLargeTearingTest.java.template
+++ b/jcstress-test-gen/src/main/resources/tearing/X-ArrayLargeTearingTest.java.template
@@ -39,8 +39,8 @@ import java.util.concurrent.*;
 @State
 public class $name$ {
 
-    $modifier$$type$[] arr =  new $type$[2 * 1024 * 1024];
-    int idx1 = ThreadLocalRandom.current().nextInt(2 * 1024 * 1024 - 1);
+    $modifier$$type$[] arr =  new $type$[131072];
+    int idx1 = ThreadLocalRandom.current().nextInt(131072 - 1);
     int idx2 = idx1 + 1;
 
     @Actor


### PR DESCRIPTION
These frequently time out on slower development boards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903420](https://bugs.openjdk.org/browse/CODETOOLS-7903420): jcstress: Trim down the large array tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/jcstress pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/130.diff">https://git.openjdk.org/jcstress/pull/130.diff</a>

</details>
