### PR TITLE
7903423: jcstress: Improve footprint by managing object lifecycles better

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -48,13 +48,6 @@ public class ForkedMain {
             throw new IllegalStateException("Expected three arguments");
         }
 
-        Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-            @Override
-            public void uncaughtException(Thread thread, Throwable throwable) {
-                System.out.println(throwable.getMessage());
-            }
-        });
-
         // Pre-initialize the allocation profiling support, so that infrastructure
         // code does not have to do this on critical path during the execution.
         new WarmupAllocProfileTask().start();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/ForkedMain.java
@@ -48,6 +48,13 @@ public class ForkedMain {
             throw new IllegalStateException("Expected three arguments");
         }
 
+        Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread thread, Throwable throwable) {
+                System.out.println(throwable.getMessage());
+            }
+        });
+
         // Pre-initialize the allocation profiling support, so that infrastructure
         // code does not have to do this on critical path during the execution.
         new WarmupAllocProfileTask().start();
@@ -110,6 +117,11 @@ public class ForkedMain {
                 // Do not care
             }
         }
+
+        @Override
+        public void purge() {
+            // Do nothing
+        }
     }
 
     private static class WarmupAllocProfileTask extends VoidThread {
@@ -124,6 +136,11 @@ public class ForkedMain {
             } catch (Exception e) {
                 // Do not care
             }
+        }
+
+        @Override
+        public void purge() {
+            // Do nothing
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
@@ -39,4 +39,6 @@ public abstract class AbstractThread extends Thread {
 
     public Throwable throwable() { return throwable; }
 
+    public abstract void purge();
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -98,13 +98,14 @@ public class ForkedTestConfig {
             // success!
             succCount = count;
 
-            // do not go over the the limit
+            // do not go over the limit
             if (succCount >= strideSize * strideCount) {
                 succCount = strideSize * strideCount;
                 break;
             }
 
-            count *= 2;
+            // slightly adjust for the next try
+            count = Math.max((int)(count * 1.5), count + 1);
         }
 
         strideSize = Math.min(succCount, strideSize);


### PR DESCRIPTION
Currently, we hold on to lots of state/results object from the test root, and from the fields in the checker/actor threads. This apparently is the source of some OOMEs/timeouts on smaller devices. We can make the lifecycle more explicit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903423](https://bugs.openjdk.org/browse/CODETOOLS-7903423): jcstress: Improve footprint by managing object lifecycles better


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jcstress pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/132.diff">https://git.openjdk.org/jcstress/pull/132.diff</a>

</details>
