### PR TITLE
7903424: jcstress: Improve reliability of resource sanity checks

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -91,7 +91,7 @@ public class ForkedTestConfig {
         }
     }
 
-    public void adjustStrideCount(FootprintEstimator estimator) {
+    public void adjustStrideCount(ResourceEstimator estimator) {
         int count = 1;
         int succCount = count;
         while (tryWith(estimator, count)) {
@@ -104,36 +104,42 @@ public class ForkedTestConfig {
                 break;
             }
 
-            // slightly adjust for the next try
-            count = Math.max((int)(count * 1.5), count + 1);
+            // adjust for the next try
+            count *= 2;
         }
 
         strideSize = Math.min(succCount, strideSize);
         strideCount = succCount / strideSize;
     }
 
-    private boolean tryWith(FootprintEstimator estimator, int count) {
+    private boolean tryWith(ResourceEstimator estimator, int count) {
         try {
-            long[] cnts = new long[2];
-            estimator.runWith(count, cnts);
-            long footprint = cnts[0];
-            long usedTime = cnts[1];
+            final long footprintThresh = maxFootprintMB * 1024 * 1024;
+            final long timeThresh = TimeUnit.MILLISECONDS.toNanos(time);
 
-            if (footprint > maxFootprintMB * 1024 * 1024) {
-                // blown the footprint estimate
-                return false;
+            // Try several times, to be more reliable when the test does not
+            // run with the similar time/footprint at the same count.
+            final int tries = 5;
+
+            for (int t = 0; t < tries; t++) {
+                long[] cnts = new long[2];
+                estimator.runWith(count, cnts);
+                long footprint = cnts[0];
+                long usedTime = cnts[1];
+
+                if (footprint > footprintThresh) {
+                    return false;
+                }
+
+                if (usedTime > timeThresh) {
+                    return false;
+                }
             }
-
-            if (TimeUnit.NANOSECONDS.toMillis(usedTime) > time) {
-                // blown the time estimate
-                return false;
-            }
-
+            return true;
         } catch (OutOfMemoryError err) {
             // blown the heap size
             return false;
         }
-        return true;
     }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ResourceEstimator.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ResourceEstimator.java
@@ -24,6 +24,6 @@
  */
 package org.openjdk.jcstress.infra.runners;
 
-public interface FootprintEstimator {
+public interface ResourceEstimator {
     void runWith(int size, long[] counters);
 }


### PR DESCRIPTION
On slow boards, sometimes the tests are stalling due to long GCs/compilations, etc. Resource sanity checks do not catch this, because they move very fast to larger lengths. It would be better to improve this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903424](https://bugs.openjdk.org/browse/CODETOOLS-7903424): jcstress: Improve reliability of resource sanity checks


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jcstress pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/133.diff">https://git.openjdk.org/jcstress/pull/133.diff</a>

</details>
