### PR TITLE
7903425: jcstress: Pre-touch Java heap to avoid allocation stalls

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -66,6 +66,7 @@ public class Options {
     private List<String> jvmArgsPrepend;
     private boolean splitCompilation;
     private AffinityMode affinityMode;
+    private boolean pretouchHeap;
 
     public Options(String[] args) {
         this.args = args;
@@ -140,6 +141,9 @@ public class Options {
 
         OptionSpec<AffinityMode> optAffinityMode = parser.accepts("af", "Use the specific affinity mode, if available.")
                 .withOptionalArg().ofType(AffinityMode.class).describedAs("mode");
+
+        OptionSpec<Boolean> optPretouchHeap = parser.accepts("pth", "Pre-touch Java heap, if possible.")
+                .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         parser.accepts("v", "Be verbose.");
         parser.accepts("vv", "Be extra verbose.");
@@ -247,6 +251,8 @@ public class Options {
 
         this.splitCompilation = orDefault(set.valueOf(optSplitCompilation), true);
         this.affinityMode = orDefault(set.valueOf(optAffinityMode), AffinityMode.LOCAL);
+
+        this.pretouchHeap = orDefault(set.valueOf(optPretouchHeap), true);
 
         return true;
     }
@@ -380,4 +386,9 @@ public class Options {
     public AffinityMode affinityMode() {
         return affinityMode;
     }
+
+    public boolean isPretouchHeap() {
+        return pretouchHeap;
+    }
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -208,6 +208,7 @@ public class Options {
         this.forksStressMultiplier = 5;
         this.strideSize = 256;
         this.strideCount = 40;
+        this.pretouchHeap = true;
 
         mode = orDefault(modeStr.value(set), "default");
         if (this.mode.equalsIgnoreCase("sanity")) {
@@ -217,6 +218,7 @@ public class Options {
             this.forksStressMultiplier = 1;
             this.strideSize = 1;
             this.strideCount = 1;
+            this.pretouchHeap = false;
         } else if (this.mode.equalsIgnoreCase("quick")) {
             this.time = 200;
             this.forksStressMultiplier = 1;
@@ -243,6 +245,7 @@ public class Options {
         this.forksStressMultiplier = orDefault(set.valueOf(forksStressMultiplier), this.forksStressMultiplier);
         this.strideSize = orDefault(set.valueOf(strideSize), this.strideSize);
         this.strideCount = orDefault(set.valueOf(strideCount), this.strideCount);
+        this.pretouchHeap = orDefault(set.valueOf(optPretouchHeap), this.pretouchHeap);
 
         this.heapPerFork = orDefault(set.valueOf(heapPerFork), 256);
 
@@ -251,8 +254,6 @@ public class Options {
 
         this.splitCompilation = orDefault(set.valueOf(optSplitCompilation), true);
         this.affinityMode = orDefault(set.valueOf(optAffinityMode), AffinityMode.LOCAL);
-
-        this.pretouchHeap = orDefault(set.valueOf(optPretouchHeap), true);
 
         return true;
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -127,6 +127,20 @@ public class VMSupport {
                 GLOBAL_JVM_FLAGS,
                 "-Xms" + heap + "M", "-Xmx" + heap + "M");
 
+        // After heap size is set, check if we can pre-touch it. This would allow
+        // tests to run in fully committed heap without experiencing the occasional
+        // memory stalls. This also provides better safety in face of OS OOM-killers.
+        // On large heaps, this might take a while, so users are allowed to disable
+        // pre-touch for better performance.
+
+        if (opts.isPretouchHeap()) {
+            detect("Enabling Java heap pre-touch",
+                    SimpleTestMain.class,
+                    GLOBAL_JVM_FLAGS,
+                    "-XX:+AlwaysPreTouch"
+            );
+        }
+
         // The tests are usually not GC heavy. The minimum amount of threads a jcstress
         // test uses is 2, so we can expect the CPU affinity machinery to allocate at
         // least 2 CPUs per fork. This gives us the upper bound for the number of GC threads: 2,


### PR DESCRIPTION
Small boards apparently timeout some allocation-hungry tests, because on-demand commit during the page allocation stalls a lot. We can make it better by automatically enabling `-XX:+AlwaysPreTouch`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903425](https://bugs.openjdk.org/browse/CODETOOLS-7903425): jcstress: Pre-touch Java heap to avoid allocation stalls


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jcstress pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/134.diff">https://git.openjdk.org/jcstress/pull/134.diff</a>

</details>
