### PR TITLE
7903428: jcstress: Adjust max memory per test

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -376,8 +376,14 @@ public class Options {
     }
 
     public int getMaxFootprintMb() {
-        // Half of heap size.
-        return getHeapPerForkMb() / 2;
+        // The tests can copy the entirety of their state, which means
+        // we need at least twice the space in heap. The copied state
+        // may also fragment the heap, especially with potential humongous
+        // allocations, which can also take "twice" the space in the heap.
+        //
+        // Adding some slack for testing infra itself, we better allocate
+        // about a quarter of heap size.
+        return getHeapPerForkMb() / 4;
     }
 
     public boolean isSplitCompilation() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -105,7 +105,7 @@ public class ForkedTestConfig {
             }
 
             // adjust for the next try
-            count *= 2;
+            count = Math.max((int)(count*1.2), count+1);
         }
 
         strideSize = Math.min(succCount, strideSize);


### PR DESCRIPTION
There is an evidence that some tests fragment the heap significantly, without any recourse -- for example with humongous allocations in the large array tests. The current estimate of "take half of the heap for the test" is cutting it dangerously close. G1 routinely fails some of the init.arrays.large tests because of this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903428](https://bugs.openjdk.org/browse/CODETOOLS-7903428): jcstress: Adjust max memory per test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.org/jcstress pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/136.diff">https://git.openjdk.org/jcstress/pull/136.diff</a>

</details>
