### PR TITLE
7903429: jcstress: Increase synchronized locks coverage

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
@@ -144,7 +144,7 @@ public class Chapter0aTestGenerator {
                 dest,
                 GeneratorUtils.readFromResource("/accessAtomic/X-ArrayAtomicityTest.java.template"),
                 "accessAtomic.arrays",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0aTestGenerator.java
@@ -46,99 +46,98 @@ public class Chapter0aTestGenerator {
                 dest,
                 GeneratorUtils.readFromResource("/accessAtomic/X-FieldAtomicityTest.java.template"),
                 "accessAtomic.fields",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/accessAtomic/X-FieldConflictAtomicityTest.java.template"),
                 "accessAtomic.fields.conflict",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/defaultValues/X-FieldDefaultValuesTest.java.template"),
                 "defaultValues.fields",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "final", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-FieldInitTest.java.template"),
                 "init.fields",
-                new String[]{ "", "volatile", "final" }
+                new String[]{ "", "volatile", "final", "sync" }
         );
-
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-FieldInitClassTest.java.template"),
                 "initClass.fields",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/tearing/X-FieldTearingTest.java.template"),
                 "tearing.fields",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/defaultValues/X-ArrayDefaultValuesTest.java.template"),
                 "defaultValues.arrays.small",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/defaultValues/X-ArrayLargeDefaultValuesTest.java.template"),
                 "defaultValues.arrays.large",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayInitTest.java.template"),
                 "init.arrays.small",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayLargeInitTest.java.template"),
                 "init.arrays.large",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayInitClassTest.java.template"),
                 "initClass.arrays.small",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayLargeInitClassTest.java.template"),
                 "initClass.arrays.large",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayInitLengthTest.java.template"),
                 "initLen.arrays.small",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/init/X-ArrayLargeInitLengthTest.java.template"),
                 "initLen.arrays.large",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
@@ -173,34 +172,34 @@ public class Chapter0aTestGenerator {
                 dest,
                 GeneratorUtils.readFromResource("/tearing/X-ArrayTearingTest.java.template"),
                 "tearing.arrays.small",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/tearing/X-ArrayLargeTearingTest.java.template"),
                 "tearing.arrays.large",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/coherence/X-FieldCoherenceTest.java.template"),
                 "coherence.fields",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
 
         makeTests(
                 dest,
                 GeneratorUtils.readFromResource("/coherence/X-ArrayCoherenceTest.java.template"),
                 "coherence.arrays",
-                new String[]{ "", "volatile" }
+                new String[]{ "", "volatile", "sync" }
         );
     }
 
     private static void makeTests(String dest, String template, String label, String[] modifiers) throws IOException {
         for (String modifier : modifiers) {
-            String pack = PREFIX + "." + label + "." + (modifier.equals("") ? "plain" : modifier + "s");
+            String pack = PREFIX + "." + label + "." + packageModifier(modifier);
             for (String type : TYPES) {
                 if (!alwaysAtomic(modifier, type, label)) continue;
                 if (!coherent(modifier, type, label)) continue;
@@ -215,6 +214,32 @@ public class Chapter0aTestGenerator {
         }
     }
 
+    private static String packageModifier(String modifier) {
+        switch (modifier) {
+            case "":
+                return "plain";
+            case "sync":
+                return "sync";
+            case "volatile":
+            case "final":
+                return modifier + "s";
+            default:
+                throw new IllegalArgumentException("Unknown modifier: " + modifier);
+        }
+    }
+
+    private static String fieldModifier(String modifier) {
+        switch (modifier) {
+            case "":
+            case "sync":
+                return "";
+            case "volatile":
+            case "final":
+                return modifier + " ";
+            default:
+                throw new IllegalArgumentException("Unknown modifier: " + modifier);
+        }
+    }
 
     private static Map<String, String> vars(String modifier, String type, String pack, String name) {
         Map<String, String> map = new HashMap<>();
@@ -227,7 +252,7 @@ public class Chapter0aTestGenerator {
         map.put("defaultLiteral", Values.DEFAULTS_LITERAL.get(type));
         map.put("set", Values.VALUES.get(type));
         map.put("setLiteral", Values.VALUES_LITERAL.get(type));
-        map.put("modifier", (modifier.equals("") ? "" : modifier + " "));
+        map.put("modifier", fieldModifier(modifier));
         map.put("package", pack);
         return map;
     }
@@ -241,11 +266,13 @@ public class Chapter0aTestGenerator {
 
     private static boolean alwaysAtomic(String modifier, String type, String label) {
         return (modifier.equals("volatile") && !label.contains("array")) ||
-                !(type.equals("double") || type.equals("long"));
+                !(type.equals("double") || type.equals("long")) ||
+                modifier.equals("sync");
     }
 
     private static boolean coherent(String modifier, String type, String label) {
-        return (modifier.equals("volatile") && !label.contains("array"));
+        return (modifier.equals("volatile") && !label.contains("array")) ||
+                modifier.equals("sync");
     }
 
     private static String testName(String type) {

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-ArrayAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-ArrayAtomicityTest.java.template
@@ -43,12 +43,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         a[0] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$_Result r) {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         r.r1 = a[0];
+#if[sync]
+        }
+#end[sync]
     }
 
 }

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldAtomicityTest.java.template
@@ -43,12 +43,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         x = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$_Result r) {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         r.r1 = x;
+#if[sync]
+        }
+#end[sync]
     }
 
 }

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldConflictAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-FieldConflictAtomicityTest.java.template
@@ -43,12 +43,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         x = $defaultLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         x = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Arbiter

--- a/jcstress-test-gen/src/main/resources/acqrel/X-FieldAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-FieldAcqRelTest.java.template
@@ -55,16 +55,31 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         v = $defaultVLiteral$;
         v = $setVLiteral$;
         g = $setGLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($TV$$TV$$TG$_Result r) {
-        $typeV$ v1 = v;
-        $typeG$ g1 = g;
-        $typeV$ v2 = v;
+        $typeV$ v1;
+        $typeG$ g1;
+        $typeV$ v2;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        v1 = v;
+        g1 = g;
+        v2 = v;
+#if[sync]
+        }
+#end[sync]
         r.r1 = v1;
         r.r2 = v2;
         r.r3 = g1;

--- a/jcstress-test-gen/src/main/resources/coherence/X-ArrayCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-ArrayCoherenceTest.java.template
@@ -44,13 +44,29 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         a[0] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$$T$_Result r) {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         r.r1 = a[0];
+#if[sync]
+        }
+        synchronized (this) {
+#end[sync]
         r.r2 = a[0];
+#if[sync]
+        }
+#end[sync]
     }
 
 }

--- a/jcstress-test-gen/src/main/resources/coherence/X-FieldCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-FieldCoherenceTest.java.template
@@ -44,13 +44,29 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         x = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$$T$_Result r) {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         r.r1 = x;
+#if[sync]
+        }
+        synchronized (this) {
+#end[sync]
         r.r2 = x;
+#if[sync]
+        }
+#end[sync]
     }
 
 }

--- a/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayDefaultValuesTest.java.template
+++ b/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayDefaultValuesTest.java.template
@@ -42,12 +42,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[4];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$$T$$T$$T$_Result r) {
-        $type$[] a = arr;
+        $type$[] a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             // Pretend we have seen the default values
             r.r1 = r.r2 = r.r3 = r.r4 = $defaultLiteral$;

--- a/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayLargeDefaultValuesTest.java.template
+++ b/jcstress-test-gen/src/main/resources/defaultValues/X-ArrayLargeDefaultValuesTest.java.template
@@ -44,12 +44,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[131072];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(I_Result r) {
         $type$[] a = arr;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = -1;
         } else {

--- a/jcstress-test-gen/src/main/resources/defaultValues/X-FieldDefaultValuesTest.java.template
+++ b/jcstress-test-gen/src/main/resources/defaultValues/X-FieldDefaultValuesTest.java.template
@@ -46,12 +46,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         data = new Data();
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$$T$$T$$T$_Result r) {
-        Data d = this.data;
+        Data d;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        d = this.data;
+#if[sync]
+        }
+#end[sync]
         if (d == null) {
             // Pretend we have seen the default values
             r.r1 = r.r2 = r.r3 = r.r4 = $defaultLiteral$;

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayInitClassTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayInitClassTest.java.template
@@ -41,12 +41,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[4];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(Z_Result r) {
-        Object a = arr;
+        Object a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = true;
         } else {

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayInitLengthTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayInitLengthTest.java.template
@@ -35,20 +35,33 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $name$ {
 
-    $modifier$ Object arr;
+    $modifier$ $type$[] arr;
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[4];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(I_Result r) {
-        Object a = arr;
+        $type$[] a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = 0;
         } else {
-            r.r1 = (($type$[])a).length;
+            r.r1 = a.length;
         }
     }
 

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayInitTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayInitTest.java.template
@@ -45,14 +45,27 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         $type$[] a = new $type$[4];
         a[0] = a[1] = a[2] = a[3] = $setLiteral$;
         arr = a;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(I_Result r) {
-        $type$[] a = arr;
+        $type$[] a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = -1;
         } else {

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitClassTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitClassTest.java.template
@@ -38,12 +38,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[131072];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(Z_Result r) {
-        Object a = arr;
+        Object a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = true;
         } else {

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitLengthTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitLengthTest.java.template
@@ -35,20 +35,33 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $name$ {
 
-    $modifier$ Object arr;
+    $modifier$ $type$[] arr;
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr = new $type$[131072];
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(I_Result r) {
-        Object a = arr;
+        $type$[] a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = 0;
         } else {
-            r.r1 = (($type$[])a).length;
+            r.r1 = a.length;
         }
     }
 

--- a/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-ArrayLargeInitTest.java.template
@@ -45,14 +45,27 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         $type$[] a = new $type$[131072];
         for (int c = 0; c < a.length; c++) a[c] = $setLiteral$;
         arr = a;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(I_Result r) {
-        $type$[] a = arr;
+        $type$[] a;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        a = arr;
+#if[sync]
+        }
+#end[sync]
         if (a == null) {
             r.r1 = -1;
         } else {

--- a/jcstress-test-gen/src/main/resources/init/X-FieldInitClassTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-FieldInitClassTest.java.template
@@ -40,12 +40,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         data = new Data();
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2(Z_Result r) {
-        Object d = this.data;
+        Object d;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        d = this.data;
+#if[sync]
+        }
+#end[sync]
         if (d == null) {
             // Pretend we have seen the set value
             r.r1 = true;

--- a/jcstress-test-gen/src/main/resources/init/X-FieldInitTest.java.template
+++ b/jcstress-test-gen/src/main/resources/init/X-FieldInitTest.java.template
@@ -49,12 +49,25 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         data = new Data();
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2($T$_Result r) {
-        Data d = this.data;
+        Data d;
+#if[sync]
+        synchronized (this) {
+#end[sync]
+        d = this.data;
+#if[sync]
+        }
+#end[sync]
         if (d == null) {
             // Pretend we have seen the set value
             r.r1 = $setLiteral$;

--- a/jcstress-test-gen/src/main/resources/tearing/X-ArrayLargeTearingTest.java.template
+++ b/jcstress-test-gen/src/main/resources/tearing/X-ArrayLargeTearingTest.java.template
@@ -45,12 +45,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr[idx1] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr[idx2] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Arbiter

--- a/jcstress-test-gen/src/main/resources/tearing/X-ArrayTearingTest.java.template
+++ b/jcstress-test-gen/src/main/resources/tearing/X-ArrayTearingTest.java.template
@@ -42,12 +42,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr[0] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         arr[1] = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Arbiter

--- a/jcstress-test-gen/src/main/resources/tearing/X-FieldTearingTest.java.template
+++ b/jcstress-test-gen/src/main/resources/tearing/X-FieldTearingTest.java.template
@@ -47,12 +47,24 @@ public class $name$ {
 
     @Actor
     public void actor1() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         data.x1 = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Actor
     public void actor2() {
+#if[sync]
+        synchronized (this) {
+#end[sync]
         data.x2 = $setLiteral$;
+#if[sync]
+        }
+#end[sync]
     }
 
     @Arbiter


### PR DESCRIPTION
With Loom and Lilliput work, we want to test synchronized locks more broadly. Extending existing tests to also test synchronized would be beneficial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903429](https://bugs.openjdk.org/browse/CODETOOLS-7903429): jcstress: Increase synchronized locks coverage


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jcstress pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/137.diff">https://git.openjdk.org/jcstress/pull/137.diff</a>

</details>
