### PR TITLE
7903489: JCStress: Upgrade pre-integration workflows

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -30,6 +30,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.build-java }}
         cache: maven
+        check-latest: true
     - name: Build/test
       run: mvn clean install -T 1C -B --file pom.xml
     - name: Set up run JDK ${{ matrix.run-java }}
@@ -37,5 +38,6 @@ jobs:
       with:
         distribution: temurin
         java-version: ${{ matrix.run-java }}
+        check-latest: true
     - name: Run a trial test
       run: java -jar tests-custom/target/jcstress.jar -t UnfencedDekker

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 17, 20, 21-ea]
+        build-java: [17, 20, 21-ea]
         run-java: [8, 11, 17, 20, 21-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
       fail-fast: false

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [11, 17, 19, 20-ea]
-        run-java: [8, 11, 17, 19, 20-ea]
+        build-java: [11, 17, 20, 21-ea]
+        run-java: [8, 11, 17, 20, 21-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/AbstractThread.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractThread extends Thread {
     protected volatile Throwable throwable;
 
+    @SuppressWarnings("this-escape")
     public AbstractThread(String name) {
         setDaemon(true);
         setName(name);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/AbstractTopology.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/AbstractTopology.java
@@ -107,7 +107,7 @@ public abstract class AbstractTopology implements Topology {
         coreToThread.put(coreId, threadId);
     }
 
-    protected <K, V> Multimap<K, V> remapKeys(Multimap<K, V> src, Map<K, K> remap) {
+    protected static <K, V> Multimap<K, V> remapKeys(Multimap<K, V> src, Map<K, K> remap) {
         TreesetMultimap<K, V> dst = new TreesetMultimap<>();
         for (K k : src.keys()) {
             K nk = remap.get(k);
@@ -118,7 +118,7 @@ public abstract class AbstractTopology implements Topology {
         return dst;
     }
 
-    protected <K, V> Multimap<K, V> remapValues(Multimap<K, V> src, Map<V, V> remap) {
+    protected static <K, V> Multimap<K, V> remapValues(Multimap<K, V> src, Map<V, V> remap) {
         TreesetMultimap<K, V> dst = new TreesetMultimap<>();
         for (K k : src.keys()) {
             for (V v : src.get(k)) {
@@ -128,7 +128,7 @@ public abstract class AbstractTopology implements Topology {
         return dst;
     }
 
-    protected <K, V> SortedMap<K, V> remapValues(SortedMap<K, V> src, Map<V, V> remap) {
+    protected static <K, V> SortedMap<K, V> remapValues(SortedMap<K, V> src, Map<V, V> remap) {
         SortedMap<K, V> dst = new TreeMap<>();
         for (K k : src.keySet()) {
             dst.put(k, remap.get(src.get(k)));
@@ -136,7 +136,7 @@ public abstract class AbstractTopology implements Topology {
         return dst;
     }
 
-    protected <K, V> SortedMap<K, V> remapKeys(SortedMap<K, V> src, Map<K, K> remap) {
+    protected static <K, V> SortedMap<K, V> remapKeys(SortedMap<K, V> src, Map<K, K> remap) {
         SortedMap<K, V> dst = new TreeMap<>();
         for (K k : src.keySet()) {
             dst.put(remap.get(k), src.get(k));
@@ -144,7 +144,7 @@ public abstract class AbstractTopology implements Topology {
         return dst;
     }
 
-    protected <K> Map<K, K> renumber(Set<K> src, Function<Integer, K> gen) {
+    protected static <K> Map<K, K> renumber(Set<K> src, Function<Integer, K> gen) {
         Map<K, K> dst = new HashMap<>();
         int nid = 0;
         for (K k : src) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/LinuxProcfsTopology.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/LinuxProcfsTopology.java
@@ -41,6 +41,7 @@ public class LinuxProcfsTopology extends AbstractTopology {
         this("/proc/cpuinfo");
     }
 
+    @SuppressWarnings("this-escape")
     public LinuxProcfsTopology(String file) throws TopologyParseException {
         this.file = file;
         try {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/LinuxSysfsTopology.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/LinuxSysfsTopology.java
@@ -63,6 +63,7 @@ public class LinuxSysfsTopology extends AbstractTopology {
         this(new File("/sys/devices/system/").toPath());
     }
 
+    @SuppressWarnings("this-escape")
     public LinuxSysfsTopology(Path root) throws TopologyParseException {
         this.cpuRoot = root.resolve("cpu");
         this.nodeRoot = root.resolve("node");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/PresetRegularTopology.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/topology/PresetRegularTopology.java
@@ -26,6 +26,7 @@ package org.openjdk.jcstress.os.topology;
 
 public class PresetRegularTopology extends AbstractTopology {
 
+    @SuppressWarnings("this-escape")
     public PresetRegularTopology(int nodesPerSystem, int coresPerNode, int threadsPerCore) throws TopologyParseException {
         for (int t = 0; t < threadsPerCore; t++) {
             for (int p = 0; p < nodesPerSystem; p++) {


### PR DESCRIPTION
We need to start testing 21-ea for upcoming release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903489](https://bugs.openjdk.org/browse/CODETOOLS-7903489): JCStress: Upgrade pre-integration workflows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jcstress.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/138.diff">https://git.openjdk.org/jcstress/pull/138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/138#issuecomment-1578380695)