### PR TITLE
7903491: jcstress: Run time budget

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -40,4 +40,4 @@ jobs:
         java-version: ${{ matrix.run-java }}
         check-latest: true
     - name: Run a trial test
-      run: java -jar tests-custom/target/jcstress.jar -t UnfencedDekker
+      run: java -jar tests-custom/target/jcstress.jar -t UnfencedDekker -tb 1m

--- a/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
+++ b/jcstress-benchmarks/src/main/java/org/openjdk/jcstress/SampleTestBench.java
@@ -58,10 +58,7 @@ public class SampleTestBench {
 
     static {
         try {
-            Options opts = new Options(new String[] {
-                    "-v",
-                    "-iters", "1",
-                    "-time", "10000"});
+            Options opts = new Options(new String[] {"-v"});
             opts.parse();
 
             String testName = SampleTest.class.getCanonicalName();
@@ -90,7 +87,7 @@ public class SampleTestBench {
 
     @Setup
     public void setup() throws Throwable {
-        o = (Runner<?>) CNSTR.newInstance(new ForkedTestConfig(CFGS[0]));
+        o = (Runner<?>) CNSTR.newInstance(new ForkedTestConfig(CFGS[0], 10_000));
     }
 
     @Benchmark

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -86,12 +86,15 @@ public class JCStress {
             return;
         }
 
-        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), configs.size());
+        TimeBudget timeBudget = new TimeBudget(configs.size(), opts.timeBudget());
+        timeBudget.printOn(out);
+
+        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), configs.size(), timeBudget);
         DiskWriteCollector diskCollector = new DiskWriteCollector(opts.getResultFile());
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
-        TestExecutor executor = new TestExecutor(opts.verbosity(), sink, scheduler);
+        TestExecutor executor = new TestExecutor(opts.verbosity(), sink, scheduler, timeBudget);
         printer.setExecutor(executor);
 
         executor.runAll(configs);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -144,7 +144,9 @@ public class Options {
         OptionSpec<Boolean> optPretouchHeap = parser.accepts("pth", "Pre-touch Java heap, if possible.")
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
-        OptionSpec<TimeValue> optTimeBudget = parser.accepts("tb", "Time budget to run the tests. Common time suffixes are accepted.")
+        OptionSpec<TimeValue> optTimeBudget = parser.accepts("tb", "Time budget to run the tests. Harness code would try to fit the entire " +
+                "run in the desired time-frame. This value is expected to be reasonable, as it is not guaranteed that tests would succeed " +
+                "in arbitrarily low time budget. Common time suffixes (s/m/h/d) are accepted.")
                 .withRequiredArg().ofType(TimeValue.class).describedAs("time").defaultsTo(new TimeValue(1, TimeUnit.HOURS));
 
         parser.accepts("v", "Be verbose.");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -32,12 +32,14 @@ import org.openjdk.jcstress.infra.runners.SpinLoopStyle;
 import org.openjdk.jcstress.os.AffinityMode;
 import org.openjdk.jcstress.util.OptionFormatter;
 import org.openjdk.jcstress.util.StringUtils;
+import org.openjdk.jcstress.util.TimeValue;
 import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Options.
@@ -49,8 +51,6 @@ public class Options {
     private String testFilter;
     private int strideSize;
     private int strideCount;
-    private int time;
-    private int iters;
     private final String[] args;
     private boolean parse;
     private boolean list;
@@ -59,7 +59,6 @@ public class Options {
     private int heapPerFork;
     private int forks;
     private int forksStressMultiplier;
-    private String mode;
     private SpinLoopStyle spinStyle;
     private String resultFile;
     private List<String> jvmArgs;
@@ -67,6 +66,7 @@ public class Options {
     private boolean splitCompilation;
     private AffinityMode affinityMode;
     private boolean pretouchHeap;
+    private TimeValue timeBudget;
 
     public Options(String[] args) {
         this.args = args;
@@ -96,11 +96,10 @@ public class Options {
                 "Larger value increases cache footprint.")
                 .withRequiredArg().ofType(Integer.class).describedAs("N");
 
-        OptionSpec<Integer> time = parser.accepts("time", "Time to spend in single test iteration. Larger value improves " +
-                "test reliability, since schedulers do better job in the long run.")
+        OptionSpec<Integer> optTime = parser.accepts("time", "(Deprecated, to be removed in next releases.)")
                 .withRequiredArg().ofType(Integer.class).describedAs("ms");
 
-        OptionSpec<Integer> iters = parser.accepts("iters", "Iterations per test.")
+        OptionSpec<Integer> optIters = parser.accepts("iters", "(Deprecated, to be removed in next releases.)")
                 .withRequiredArg().ofType(Integer.class).describedAs("N");
 
         OptionSpec<Integer> cpus = parser.accepts("c", "Number of CPUs to use. Defaults to all CPUs in the system. " +
@@ -123,7 +122,7 @@ public class Options {
                 "This allows more efficient randomized testing, as each fork would use a different seed.")
                 .withOptionalArg().ofType(Integer.class).describedAs("multiplier");
 
-        OptionSpec<String> modeStr = parser.accepts("m", "Test mode preset: sanity, quick, default, tough, stress.")
+        OptionSpec<String> optModeStr = parser.accepts("m", "(Deprecated, to be removed in next releases).")
                 .withRequiredArg().ofType(String.class).describedAs("mode");
 
         OptionSpec<String> optJvmArgs = parser.accepts("jvmArgs", "Use given JVM arguments. This disables JVM flags auto-detection, " +
@@ -144,6 +143,9 @@ public class Options {
 
         OptionSpec<Boolean> optPretouchHeap = parser.accepts("pth", "Pre-touch Java heap, if possible.")
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
+
+        OptionSpec<TimeValue> optTimeBudget = parser.accepts("tb", "Time budget to run the tests. Common time suffixes are accepted.")
+                .withRequiredArg().ofType(TimeValue.class).describedAs("time").defaultsTo(new TimeValue(1, TimeUnit.HOURS));
 
         parser.accepts("v", "Be verbose.");
         parser.accepts("vv", "Be extra verbose.");
@@ -202,45 +204,45 @@ public class Options {
 
         this.spinStyle = orDefault(set.valueOf(spinStyle), SpinLoopStyle.THREAD_SPIN_WAIT);
 
-        this.time = 1000;
-        this.iters = 5;
-        this.forks = 1;
-        this.forksStressMultiplier = 5;
-        this.strideSize = 256;
-        this.strideCount = 40;
-        this.pretouchHeap = true;
+        this.timeBudget = optTimeBudget.value(set);
 
-        mode = orDefault(modeStr.value(set), "default");
-        if (this.mode.equalsIgnoreCase("sanity")) {
-            this.time = 0;
-            this.iters = 1;
+        if (timeBudget.isZero()) {
+            // Special, extra-fast mode, good only for sanity testing
             this.forks = 1;
             this.forksStressMultiplier = 1;
             this.strideSize = 1;
             this.strideCount = 1;
             this.pretouchHeap = false;
-        } else if (this.mode.equalsIgnoreCase("quick")) {
-            this.time = 200;
-            this.forksStressMultiplier = 1;
-        } else if (this.mode.equalsIgnoreCase("default")) {
-            // Nothing changed.
-        } else if (this.mode.equalsIgnoreCase("tough")) {
-            this.iters = 10;
-            this.forks = 10;
-        } else if (this.mode.equalsIgnoreCase("stress")) {
-            this.iters = 50;
-            this.forks = 10;
-            this.forksStressMultiplier = 10;
         } else {
-            System.err.println("Unknown test mode: " + this.mode);
+            this.forks = 1;
+            this.forksStressMultiplier = 5;
+            this.strideSize = 256;
+            this.strideCount = 40;
+            this.pretouchHeap = true;
+        }
+
+        if (optModeStr.value(set) != null) {
+            System.err.println("-m option is not supported anymore, please use -tb.");
+            System.err.println();
+            parser.printHelpOn(System.err);
+            return false;
+        }
+
+        if (optTime.value(set) != null) {
+            System.err.println("-time option is not supported anymore, please use -tb.");
+            System.err.println();
+            parser.printHelpOn(System.err);
+            return false;
+        }
+
+        if (optIters.value(set) != null) {
+            System.err.println("-iters option is not supported anymore, please use -tb.");
             System.err.println();
             parser.printHelpOn(System.err);
             return false;
         }
 
         // override these, if present
-        this.time = orDefault(set.valueOf(time), this.time);
-        this.iters = orDefault(set.valueOf(iters), this.iters);
         this.forks = orDefault(set.valueOf(forks), this.forks);
         this.forksStressMultiplier = orDefault(set.valueOf(forksStressMultiplier), this.forksStressMultiplier);
         this.strideSize = orDefault(set.valueOf(strideSize), this.strideSize);
@@ -289,13 +291,10 @@ public class Options {
 
     public void printSettingsOn(PrintStream out) {
         out.println("  Test configuration:");
-        out.printf("    Test preset mode: \"%s\"%n", mode);
         out.printf("    Hardware CPUs in use: %d%n", getCPUCount());
         out.printf("    Spinning style: %s%n", getSpinStyle());
         out.printf("    Test selection: \"%s\"%n", getTestFilter());
         out.printf("    Forks per test: %d normal, %d stress%n", getForks(), getForks()*getForksStressMultiplier());
-        out.printf("    Iterations per fork: %d%n", getIterations());
-        out.printf("    Time per iteration: %d ms%n", getTime());
         out.printf("    Test stride: %d strides x %d tests, but taking no more than %d Mb%n", getStrideCount(), getStrideSize(), getMaxFootprintMb());
         out.printf("    Test result blob: \"%s\"%n", resultFile);
         out.printf("    Test results: \"%s\"%n", resultDir);
@@ -312,10 +311,6 @@ public class Options {
 
     public String getResultDest() {
         return resultDir;
-    }
-
-    public int getTime() {
-        return time;
     }
 
     public SpinLoopStyle getSpinStyle() {
@@ -345,10 +340,6 @@ public class Options {
 
     public String getTestFilter() {
         return testFilter;
-    }
-
-    public int getIterations() {
-        return iters;
     }
 
     public Verbosity verbosity() {
@@ -397,5 +388,7 @@ public class Options {
     public boolean isPretouchHeap() {
         return pretouchHeap;
     }
+
+    public TimeValue timeBudget() { return timeBudget; }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -145,9 +145,10 @@ public class Options {
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         OptionSpec<TimeValue> optTimeBudget = parser.accepts("tb", "Time budget to run the tests. Harness code would try to fit the entire " +
-                "run in the desired time-frame. This value is expected to be reasonable, as it is not guaranteed that tests would succeed " +
-                "in arbitrarily low time budget. Common time suffixes (s/m/h/d) are accepted.")
-                .withRequiredArg().ofType(TimeValue.class).describedAs("time").defaultsTo(new TimeValue(1, TimeUnit.HOURS));
+                "run in the desired timeframe. This value is expected to be reasonable, as it is not guaranteed that tests would succeed " +
+                "in arbitrarily low time budget. If not set, harness would try to decide a reasonable time, given the number of tests to run. " +
+                "Common time suffixes (s/m/h/d) are accepted.")
+                .withRequiredArg().ofType(TimeValue.class).describedAs("time");
 
         parser.accepts("v", "Be verbose.");
         parser.accepts("vv", "Be extra verbose.");
@@ -208,7 +209,7 @@ public class Options {
 
         this.timeBudget = optTimeBudget.value(set);
 
-        if (timeBudget.isZero()) {
+        if (timeBudget != null && timeBudget.isZero()) {
             // Special, extra-fast mode, good only for sanity testing
             this.forks = 1;
             this.forksStressMultiplier = 1;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress;
+
+import org.openjdk.jcstress.infra.grading.ReportUtils;
+import org.openjdk.jcstress.util.TimeValue;
+
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TimeBudget {
+
+    final long endTime;
+    final boolean zeroBudget;
+    final int expectedTests;
+
+    final AtomicInteger inflightTests;
+    final AtomicInteger maxInflightTests;
+    final AtomicInteger leftoverTests;
+
+    public TimeBudget(int expectedTests, TimeValue timeBudget) {
+        this.expectedTests = expectedTests;
+        this.endTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) + timeBudget.milliseconds();
+        this.zeroBudget = timeBudget.isZero();
+        this.inflightTests = new AtomicInteger();
+        this.maxInflightTests = new AtomicInteger();
+        this.leftoverTests = new AtomicInteger(expectedTests);
+    }
+
+    public void finishTest() {
+        inflightTests.decrementAndGet();
+        leftoverTests.decrementAndGet();
+    }
+
+    public void startTest() {
+        int inflight = inflightTests.incrementAndGet();
+        maxInflightTests.updateAndGet(x -> Math.max(x, inflight));
+    }
+
+    public int targetTestTimeMs() {
+        if (isZero()) {
+            return 0;
+        }
+
+        int parMult;
+
+        int testsLeft = leftoverTests.get();
+        int maxInflight = maxInflightTests.get();
+
+        if (testsLeft >= maxInflight) {
+            // Parallel multiplier is at least the number of currently
+            // running parallel tests.
+            parMult = inflightTests();
+            if (parMult <= 0) {
+                parMult = 1;
+            }
+        } else {
+            // If the last tests are running, we should not cut down
+            // the test time unnecessarily.
+            parMult = maxInflight;
+        }
+
+        long timeLeft = timeLeftMs();
+
+        long msPerTest = (timeLeft > 0 && testsLeft > 0) ?
+                timeLeft / testsLeft * parMult :
+                0;
+
+        // Enforce reasonable target brackets and leave some time
+        // for test infrastructure to run.
+        final int MIN_TIME_MS = 30;
+        final int MAX_TIME_MS = 60_000;
+        if (msPerTest > MIN_TIME_MS * 2) {
+            msPerTest -= MIN_TIME_MS;
+        }
+        msPerTest = Math.max(MIN_TIME_MS, msPerTest);
+        msPerTest = Math.min(MAX_TIME_MS, msPerTest);
+
+        return (int)msPerTest;
+    }
+
+    public long timeLeftMs() {
+        return endTime - TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+    }
+
+    public int inflightTests() {
+        return inflightTests.get();
+    }
+
+    public void printOn(PrintStream out) {
+        out.println("  Time budget:");
+        if (isZero()) {
+            out.println("    Zero budget, sanity test mode");
+        } else {
+            out.println("    Target completion: in " + ReportUtils.msToDate(timeLeftMs(), true));
+            out.println("    Initial test time: " + targetTestTimeMs() + " ms");
+        }
+        out.println();
+    }
+
+    public boolean isZero() {
+        return zeroBudget;
+    }
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -33,6 +33,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TimeBudget {
 
+    static final int MIN_TIME_MS = Integer.getInteger("jcstress.timeBudget.minTimeMs", 10);
+    static final int MAX_TIME_MS = Integer.getInteger("jcstress.timeBudget.maxTimeMs", 60_000);
+
     final long endTime;
     final boolean zeroBudget;
     final int expectedTests;
@@ -91,9 +94,7 @@ public class TimeBudget {
 
         // Enforce reasonable target brackets and leave some time
         // for test infrastructure to run.
-        final int MIN_TIME_MS = 30;
-        final int MAX_TIME_MS = 60_000;
-        if (msPerTest > MIN_TIME_MS * 2) {
+        if (msPerTest > MIN_TIME_MS * 2L) {
             msPerTest -= MIN_TIME_MS;
         }
         msPerTest = Math.max(MIN_TIME_MS, msPerTest);
@@ -115,7 +116,7 @@ public class TimeBudget {
         if (isZero()) {
             out.println("    Zero budget, sanity test mode");
         } else {
-            out.println("    Target completion: in " + ReportUtils.msToDate(timeLeftMs(), true));
+            out.println("    Initial completion estimate: " + ReportUtils.msToDate(timeLeftMs(), true));
             out.println("    Initial test time: " + targetTestTimeMs() + " ms");
         }
         out.println();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -26,6 +26,7 @@ package org.openjdk.jcstress;
 
 import org.openjdk.jcstress.infra.grading.ReportUtils;
 import org.openjdk.jcstress.util.TimeValue;
+import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
@@ -33,8 +34,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TimeBudget {
 
-    static final int DEFAULT_PER_TEST_MS = Integer.getInteger("jcstress.timeBudget.defaultPerTestMs", 1000);
-    static final int MIN_TIME_MS = Integer.getInteger("jcstress.timeBudget.minTimeMs", 10);
+    static final int DEFAULT_PER_TEST_MS = Integer.getInteger("jcstress.timeBudget.defaultPerTestMs", 5000);
+    static final int MIN_TIME_MS = Integer.getInteger("jcstress.timeBudget.minTimeMs", 30);
     static final int MAX_TIME_MS = Integer.getInteger("jcstress.timeBudget.maxTimeMs", 60_000);
 
     final long endTime;
@@ -59,7 +60,10 @@ public class TimeBudget {
             return timeBudget;
         }
 
-        return new TimeValue((long) expectedTests * DEFAULT_PER_TEST_MS, TimeUnit.MILLISECONDS);
+        // Assume the nearly worst case, all 4-actor tests taking the cores exclusively.
+        long expectedTotalTime = (long) expectedTests * DEFAULT_PER_TEST_MS;
+        long expectedPerTest = expectedTotalTime / Math.max(1, VMSupport.figureOutHotCPUs() / 8);
+        return new TimeValue(expectedPerTest, TimeUnit.MILLISECONDS);
     }
 
     public void finishTest() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -37,7 +37,11 @@ import org.openjdk.jcstress.util.*;
 import org.openjdk.jcstress.vm.CompileMode;
 
 import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 public class ReportUtils {
 
@@ -281,4 +285,43 @@ public class ReportUtils {
                 throw new IllegalStateException("Illegal status: " + result.status());
         }
     }
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("E, yyyy-MM-dd HH:mm:ss");
+
+    public static String msToDate(long ms, boolean finalDate) {
+        LocalDateTime ldt = LocalDateTime.now().plus(ms, ChronoUnit.MILLIS);
+
+        String result = "";
+
+        boolean overtime = ms < 0;
+        if (overtime) {
+            ms = -ms;
+        }
+
+        long days = TimeUnit.MILLISECONDS.toDays(ms);
+        if (days > 0) {
+            result += days + "d+";
+            ms -= TimeUnit.DAYS.toMillis(days);
+        }
+        long hours = TimeUnit.MILLISECONDS.toHours(ms);
+        ms -= TimeUnit.HOURS.toMillis(hours);
+
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(ms);
+        ms -= TimeUnit.MINUTES.toMillis(minutes);
+
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(ms);
+
+        if (overtime) {
+            result += "overtime ";
+        }
+        result += String.format("%02d:%02d:%02d", hours, minutes, seconds);
+        if (!overtime) {
+            result += " left";
+        }
+        if (finalDate) {
+            result += "; at " + ldt.format(DATE_TIME_FORMATTER);
+        }
+        return result;
+    }
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/processors/JCStressTestProcessor.java
@@ -886,13 +886,10 @@ public class JCStressTestProcessor extends AbstractProcessor {
         pw.println("    public TestResult run() {");
         pw.println("        Counter<Outcome> results = new Counter<>();");
         pw.println();
-        pw.println("        for (int c = 0; c < config.iters; c++) {");
-        pw.println("            run(results);");
+        pw.println("        run(results);");
         pw.println();
-        pw.println("            if (results.count(Outcome.STALE) > 0) {");
-        pw.println("                forceExit = true;");
-        pw.println("                break;");
-        pw.println("            }");
+        pw.println("        if (results.count(Outcome.STALE) > 0) {");
+        pw.println("            forceExit = true;");
         pw.println("        }");
         pw.println();
         pw.println("        return dump(results);");

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/ForkedTestConfig.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 public class ForkedTestConfig {
     public final SpinLoopStyle spinLoopStyle;
     public final int time;
-    public final int iters;
     public final String generatedRunnerName;
     public final int maxFootprintMB;
     public int strideSize;
@@ -42,10 +41,9 @@ public class ForkedTestConfig {
     public boolean localAffinity;
     public int[] localAffinityMap;
 
-    public ForkedTestConfig(TestConfig cfg) {
+    public ForkedTestConfig(TestConfig cfg, int testTime) {
         spinLoopStyle = cfg.spinLoopStyle;
-        time = cfg.time;
-        iters = cfg.iters;
+        time = testTime;
         generatedRunnerName = cfg.generatedRunnerName;
         maxFootprintMB = cfg.maxFootprintMB;
         strideSize = cfg.strideSize;
@@ -59,7 +57,6 @@ public class ForkedTestConfig {
     public ForkedTestConfig(DataInputStream dis) throws IOException {
         spinLoopStyle = SpinLoopStyle.values()[dis.readInt()];
         time = dis.readInt();
-        iters = dis.readInt();
         generatedRunnerName = dis.readUTF();
         maxFootprintMB = dis.readInt();
         strideSize = dis.readInt();
@@ -77,7 +74,6 @@ public class ForkedTestConfig {
     public void write(DataOutputStream dos) throws IOException {
         dos.writeInt(spinLoopStyle.ordinal());
         dos.writeInt(time);
-        dos.writeInt(iters);
         dos.writeUTF(generatedRunnerName);
         dos.writeInt(maxFootprintMB);
         dos.writeInt(strideSize);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -39,8 +39,6 @@ import java.util.List;
 
 public class TestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
-    public final int time;
-    public final int iters;
     public final int threads;
     public final String name;
     public final String binaryName;
@@ -62,10 +60,8 @@ public class TestConfig implements Serializable {
     public TestConfig(Options opts, TestInfo info, int forkId, List<String> jvmArgs, int compileMode, SchedulingClass scl) {
         this.forkId = forkId;
         this.jvmArgs = jvmArgs;
-        time = opts.getTime();
         strideSize = opts.getStrideSize();
         strideCount = opts.getStrideCount();
-        iters = opts.getIterations();
         spinLoopStyle = opts.getSpinStyle();
         maxFootprintMB = opts.getMaxFootprintMb();
         threads = info.threads();
@@ -96,8 +92,6 @@ public class TestConfig implements Serializable {
         if (spinLoopStyle != that.spinLoopStyle) return false;
         if (strideSize != that.strideSize) return false;
         if (strideCount != that.strideCount) return false;
-        if (time != that.time) return false;
-        if (iters != that.iters) return false;
         if (threads != that.threads) return false;
         if (compileMode != that.compileMode) return false;
         if (!jvmArgs.equals(that.jvmArgs)) return false;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/TimeValue.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/TimeValue.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.util;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+public class TimeValue implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long time;
+    private final TimeUnit tu;
+
+    public TimeValue(long time, TimeUnit tu) {
+        if (time < 0) {
+            throw new IllegalArgumentException("Time should not be negative: " + time);
+        }
+        this.time = time;
+        this.tu = tu;
+    }
+
+    // Called by command line parser
+    public static TimeValue valueOf(String str) {
+        if (str == null) {
+            throw new IllegalArgumentException("Option should not be null");
+        }
+        if (str.contains("s")) {
+            return new TimeValue(Integer.parseInt(str.substring(0, str.indexOf("s"))), TimeUnit.SECONDS);
+        } else if (str.contains("m")) {
+            return new TimeValue(Integer.parseInt(str.substring(0, str.indexOf("m"))), TimeUnit.MINUTES);
+        } else if (str.contains("h")) {
+            return new TimeValue(Integer.parseInt(str.substring(0, str.indexOf("h"))), TimeUnit.HOURS);
+        } else if (str.contains("d")) {
+            return new TimeValue(Integer.parseInt(str.substring(0, str.indexOf("d"))), TimeUnit.DAYS);
+        } else {
+            throw new IllegalArgumentException("Should specify the time suffix: s, m, h, d");
+        }
+    }
+
+    public long milliseconds() {
+        return TimeUnit.MILLISECONDS.convert(time, tu);
+    }
+
+    public boolean isZero() {
+        return (time == 0);
+    }
+}


### PR DESCRIPTION
Real-world testing with jcstress frequently runs into capacity problems. There are usually tons of tests in the suite, and there are many JVM options that default runner is traversing by default. This often comes as a nasty surprise for the testers, when the full run starts taking months.

There are "run profiles", selected with `-m`, which are supposed to help here, but they are not that handy to use, and are following the hand-selected hard-coded settings in the harness options.

Instead, we can do a better thing: introduce the "run time budget" option, where a user can say "I have around X hours to run these tests, figure out the best test configuration to fit this time".

This would make jcstress naturally usable in nightly runs, where we can ask for 1 hour run, weekly runs, where we can ask for 8 hour run, monthly runs, where we can ask for 24 hours run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903491](https://bugs.openjdk.org/browse/CODETOOLS-7903491): jcstress: Run time budget (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jcstress.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/139.diff">https://git.openjdk.org/jcstress/pull/139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/139#issuecomment-1582380861)