### PR TITLE
7903494: jcstress: seqcst tests arbiters should take the lock

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
@@ -281,9 +281,16 @@ public class SeqCstTraceGenerator {
         pw.println("    @Arbiter");
         pw.println("    public void arbiter(" + resultName + " r) {");
         int idx = mt.loadCount() + 1;
+        if (target == Target.SYNCHRONIZED) {
+            pw.println("        synchronized (this) {");
+            pw.print("    ");
+        }
         for (Integer varId : mt.allVariables()) {
             pw.println("        r.r" + idx + " = x" + varId + ";");
             idx++;
+        }
+        if (target == Target.SYNCHRONIZED) {
+            pw.println("        }");
         }
         pw.println("    }");
         pw.println();


### PR DESCRIPTION
Found this while peeking into the generated code: the arbiters code is not `synchronized` for sync tests, although it should match what other threads are doing. This seems to be innocuous on current platforms, because arbiter always runs "last" with the relevant volatile sychronization. This is not guaranteed to work generally, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903494](https://bugs.openjdk.org/browse/CODETOOLS-7903494): jcstress: seqcst tests arbiters should take the lock (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jcstress.git pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/140.diff">https://git.openjdk.org/jcstress/pull/140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/140#issuecomment-1587368324)