### PR TITLE
7903495: jcstress: Generated test actors should not request the result when not needed

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/TestGenerator.java
@@ -128,7 +128,7 @@ public class TestGenerator {
         pw.println("    public " + types.type(1) + " a;");
         pw.println();
         pw.println("    @Actor");
-        pw.println("    public void actor1(" + resultName +" r) {");
+        pw.println("    public void actor1() {");
         pw.println("        " + prim.printRelease("        a = " + getRValue(types.type(1)) +";"));
         pw.println("    }");
         pw.println();

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
@@ -246,10 +246,13 @@ public class SeqCstTraceGenerator {
         pw.println();
 
         for (int t = 0; t < threads; t++) {
-            pw.println("    @Actor");
-            pw.println("    public void actor" + (t+1) + "(" + resultName + " r) {");
+            Trace trace = mt.threads().get(t);
 
-            for (Op op : mt.threads().get(t).ops()) {
+            pw.println("    @Actor");
+            String sig = trace.hasLoads() ? "(" + resultName + " r)" : "()";
+            pw.println("    public void actor" + (t + 1) + sig + " {");
+
+            for (Op op : trace.ops()) {
                 switch (op.getType()) {
                     case LOAD:
                         if (target == Target.SYNCHRONIZED) {


### PR DESCRIPTION
Many @Actor-s in generated tests do not actually require a result. Avoiding the unnecessary result load optimizes the interpreter and C1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903495](https://bugs.openjdk.org/browse/CODETOOLS-7903495): jcstress: Generated test actors should not request the result when not needed (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.org/jcstress.git pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/141.diff">https://git.openjdk.org/jcstress/pull/141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/141#issuecomment-1587391596)