### PR TITLE
7903493: jcstress: Cut down test configurations

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -218,7 +218,7 @@ public class Options {
             this.pretouchHeap = false;
         } else {
             this.forks = 1;
-            this.forksStressMultiplier = 5;
+            this.forksStressMultiplier = 3;
             this.strideSize = 256;
             this.strideCount = 40;
             this.pretouchHeap = true;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TimeBudget {
 
-    static final int DEFAULT_PER_TEST_MS = Integer.getInteger("jcstress.timeBudget.defaultPerTestMs", 5000);
+    static final int DEFAULT_PER_TEST_MS = Integer.getInteger("jcstress.timeBudget.defaultPerTestMs", 3000);
     static final int MIN_TIME_MS = Integer.getInteger("jcstress.timeBudget.minTimeMs", 30);
     static final int MAX_TIME_MS = Integer.getInteger("jcstress.timeBudget.maxTimeMs", 60_000);
 

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/SeqCstTraceGenerator.java
@@ -59,23 +59,17 @@ public class SeqCstTraceGenerator {
         // (ops, variables, threads)
         int[][] triplets = {
                 {2, 1, 2},
-
                 {3, 1, 2},
-
                 {4, 1, 2},
                 {4, 2, 2},
-                {4, 2, 3},
-                {4, 2, 4},
 
+                {4, 2, 3},
                 {5, 1, 3},
-                {5, 1, 4},
                 {5, 2, 3},
-                {5, 2, 4},
+                {6, 3, 3},
 
                 {6, 1, 4},
                 {6, 2, 4},
-                {6, 3, 3},
-                {6, 3, 4},
         };
 
         for (int[] tri : triplets) {


### PR DESCRIPTION
Current full jcstress run takes about 60+ days on 36-core machine. This is driven by too many test configurations tested in the default config. We can cut down the test times (again) by re-examining the default run options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903493](https://bugs.openjdk.org/browse/CODETOOLS-7903493): jcstress: Cut down test configurations (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jcstress.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/142.diff">https://git.openjdk.org/jcstress/pull/142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/142#issuecomment-1587392625)