### PR TITLE
7903594: jcstress: Support -XX:+StressIncrementalInlining

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -214,6 +214,12 @@ public class VMSupport {
                     "-XX:+StressCCP"
             );
 
+            detect("Unlocking C2 incremental inlining randomizer",
+                    SimpleTestMain.class,
+                    C2_STRESS_JVM_FLAGS,
+                    "-XX:+StressIncrementalInlining"
+            );
+
             STRESS_SEED_AVAILABLE = detect("Checking if C2 randomizers accept stress seed",
                     SimpleTestMain.class,
                     null,


### PR DESCRIPTION
[JDK-8319879](https://bugs.openjdk.org/browse/JDK-8319879) added another C2 stress option, which we want to use in compiler stress modes.