### PR TITLE
7903655: jcstress: Support StressMacroExpansion stress option

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -220,6 +220,12 @@ public class VMSupport {
                     "-XX:+StressIncrementalInlining"
             );
 
+            detect("Unlocking C2 macro expansion randomizer",
+                    SimpleTestMain.class,
+                    C2_STRESS_JVM_FLAGS,
+                    "-XX:+StressMacroExpansion"
+            );
+
             STRESS_SEED_AVAILABLE = detect("Checking if C2 randomizers accept stress seed",
                     SimpleTestMain.class,
                     null,


### PR DESCRIPTION
[JDK-8317349](https://bugs.openjdk.org/browse/JDK-8317349) added a new randomization option for C2, we would like to take it for jcstress, like other C2 stress options.