### PR TITLE
7903679: jcstress: Upgrade some actions to avoid deprecated Node 16

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,27 +16,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build-java: [17, 20, 21-ea]
-        run-java: [8, 11, 17, 20, 21-ea]
+        build-java: [17, 21]
+        run-java: [8, 11, 17, 21]
         os: [ubuntu-22.04, windows-2022, macos-11]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up build JDK ${{ matrix.build-java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: ${{ matrix.build-java }}
         cache: maven
         check-latest: true
     - name: Build/test
       run: mvn clean install -T 1C -B --file pom.xml
     - name: Set up run JDK ${{ matrix.run-java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: ${{ matrix.run-java }}
         check-latest: true
     - name: Run a trial test


### PR DESCRIPTION
Node 16 is getting deprecated in GHA, we need to bump the versions for some GHA actions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903679](https://bugs.openjdk.org/browse/CODETOOLS-7903679): jcstress: Upgrade some actions to avoid deprecated Node 16 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jcstress.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/146.diff">https://git.openjdk.org/jcstress/pull/146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/146#issuecomment-1956583004)