### PR TITLE
 CODETOOLS-7903748 - jcstress: Test list should honor concurrency settings

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -56,8 +56,10 @@ public class JCStress {
     }
 
     public void run() throws Exception {
-        ConfigsWithScheduler configsWithScheduler = getConfigs();
-        if (configsWithScheduler == null) return;
+        ConfigsWithScheduler configs = getConfigs();
+        if (configs == null) {
+            return;
+        }
 
         TimeBudget timeBudget = new TimeBudget(configsWithScheduler.configs.size(), opts.timeBudget());
         timeBudget.printOn(out);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -84,6 +84,7 @@ public class JCStress {
 
         parseResults();
     }
+
     private ConfigsWithScheduler getConfigs() {
         OSSupport.init();
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -84,8 +84,6 @@ public class JCStress {
 
         parseResults();
     }
-
-
     public ConfigsWithScheduler getConfigs() {
         OSSupport.init();
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -227,8 +227,8 @@ public class JCStress {
         return s;
    }
 
-    public int listTests(Options opts, JCStress jcstress) {
-        JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
+    public int listTests(Options opts) {
+        JCStress.ConfigsWithScheduler configsWithScheduler = getConfigs();
         Set<String> testsToPrint = new TreeSet<>();
         for (TestConfig test : configsWithScheduler.configs) {
             if (opts.verbosity().printAllTests()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -56,8 +56,8 @@ public class JCStress {
     }
 
     public void run() throws Exception {
-        ConfigsWithScheduler configs = getConfigs();
-        if (configs == null) {
+        ConfigsWithScheduler configsWithScheduler = getConfigs();
+        if (configsWithScheduler == null) {
             return;
         }
 
@@ -84,7 +84,7 @@ public class JCStress {
 
         parseResults();
     }
-    public ConfigsWithScheduler getConfigs() {
+    private ConfigsWithScheduler getConfigs() {
         OSSupport.init();
 
         VMSupport.initFlags(opts);
@@ -118,7 +118,7 @@ public class JCStress {
         return new ConfigsWithScheduler(scheduler, configs);
     }
 
-    public static class ConfigsWithScheduler {
+    private static class ConfigsWithScheduler {
         public final Scheduler scheduler;
         public final List<TestConfig> configs;
 
@@ -225,5 +225,26 @@ public class JCStress {
         }
         return s;
    }
+
+    public int listTests(Options opts, JCStress jcstress) {
+        JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
+        Set<String> testsToPrint = new TreeSet<>();
+        for (TestConfig test : configsWithScheduler.configs) {
+            if (opts.verbosity().printAllTests()) {
+                testsToPrint.add(test.toDetailedTest());
+            } else {
+                testsToPrint.add(test.name);
+            }
+        }
+        if (opts.verbosity().printAllTests()) {
+            System.out.println("All matching tests combinations - " + testsToPrint.size());
+        } else {
+            System.out.println("All matching tests - " + testsToPrint.size());
+        }
+        for (String test : testsToPrint) {
+            System.out.println(test);
+        }
+        return testsToPrint.size();
+    }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -56,23 +56,23 @@ public class JCStress {
     }
 
     public void run() throws Exception {
-        ConfigsWithScheduler configsWithScheduler = getConfigs();
-        if (configsWithScheduler == null) {
+        ConfigsWithScheduler config = getConfigs();
+        if (config == null) {
             return;
         }
 
-        TimeBudget timeBudget = new TimeBudget(configsWithScheduler.configs.size(), opts.timeBudget());
+        TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
         timeBudget.printOn(out);
 
-        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), configsWithScheduler.configs.size(), timeBudget);
+        ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), config.configs.size(), timeBudget);
         DiskWriteCollector diskCollector = new DiskWriteCollector(opts.getResultFile());
         TestResultCollector mux = MuxCollector.of(printer, diskCollector);
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
-        TestExecutor executor = new TestExecutor(opts.verbosity(), sink, configsWithScheduler.scheduler, timeBudget);
+        TestExecutor executor = new TestExecutor(opts.verbosity(), sink, config.scheduler, timeBudget);
         printer.setExecutor(executor);
 
-        executor.runAll(configsWithScheduler.configs);
+        executor.runAll(config.configs);
 
         sink.close();
         diskCollector.close();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -114,8 +114,8 @@ public class JCStress {
             out.println("FATAL: No matching tests.");
             return null;
         }
-        ConfigsWithScheduler configsWithScheduler = new ConfigsWithScheduler(scheduler, configs);
-        return configsWithScheduler;
+
+        return new ConfigsWithScheduler(scheduler, configs);
     }
 
     public static class ConfigsWithScheduler {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -24,8 +24,6 @@
  */
 package org.openjdk.jcstress;
 
-import org.openjdk.jcstress.infra.runners.TestConfig;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -52,7 +50,7 @@ public class Main {
 
         JCStress jcstress = new JCStress(opts);
         if (opts.shouldList()) {
-            jcstress.listTests(opts, jcstress);
+            jcstress.listTests(opts);
         } else if (opts.shouldParse()) {
             jcstress.parseResults();
         } else {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -29,9 +29,6 @@ import org.openjdk.jcstress.infra.runners.TestConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.net.URL;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -55,31 +52,11 @@ public class Main {
 
         JCStress jcstress = new JCStress(opts);
         if (opts.shouldList()) {
-            listTests(opts, jcstress);
+            jcstress.listTests(opts, jcstress);
         } else if (opts.shouldParse()) {
             jcstress.parseResults();
         } else {
             jcstress.run();
-        }
-    }
-
-    private static void listTests(Options opts, JCStress jcstress) {
-        JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
-        Set<String> testsToPrint = new TreeSet<>();
-        for (TestConfig test : configsWithScheduler.configs) {
-            if (opts.verbosity().printAllTests()) {
-                testsToPrint.add(test.toDetailedTest());
-            } else {
-                testsToPrint.add(test.name);
-            }
-        }
-        if (opts.verbosity().printAllTests()) {
-            System.out.println("All matching tests combinations - " + testsToPrint.size());
-        } else {
-            System.out.println("All matching tests - " + testsToPrint.size());
-        }
-        for (String test : testsToPrint) {
-            System.out.println(test);
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -55,27 +55,31 @@ public class Main {
 
         JCStress jcstress = new JCStress(opts);
         if (opts.shouldList()) {
-            JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
-            Set<String> testsToPrint = new TreeSet<>();
-            for (TestConfig test : configsWithScheduler.configs) {
-                if (opts.verbosity().printAllTests()) {
-                    testsToPrint.add(test.toDetailedTest());
-                } else {
-                    testsToPrint.add(test.name);
-                }
-            }
-            if (opts.verbosity().printAllTests()) {
-                System.out.println("All matching tests combinations - " + testsToPrint.size());
-            } else {
-                System.out.println("All matching tests - " + testsToPrint.size());
-            }
-            for (String test : testsToPrint) {
-                System.out.println(test);
-            }
+            listTests(opts, jcstress);
         } else if (opts.shouldParse()) {
             jcstress.parseResults();
         } else {
             jcstress.run();
+        }
+    }
+
+    private static void listTests(Options opts, JCStress jcstress) {
+        JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
+        Set<String> testsToPrint = new TreeSet<>();
+        for (TestConfig test : configsWithScheduler.configs) {
+            if (opts.verbosity().printAllTests()) {
+                testsToPrint.add(test.toDetailedTest());
+            } else {
+                testsToPrint.add(test.name);
+            }
+        }
+        if (opts.verbosity().printAllTests()) {
+            System.out.println("All matching tests combinations - " + testsToPrint.size());
+        } else {
+            System.out.println("All matching tests - " + testsToPrint.size());
+        }
+        for (String test : testsToPrint) {
+            System.out.println(test);
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -24,10 +24,14 @@
  */
 package org.openjdk.jcstress;
 
+import org.openjdk.jcstress.infra.runners.TestConfig;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URL;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -51,7 +55,21 @@ public class Main {
 
         JCStress jcstress = new JCStress(opts);
         if (opts.shouldList()) {
-            for (String test : jcstress.getTests()) {
+            JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
+            Set<String> testsToPrint = new TreeSet<>();
+            for (TestConfig test : configsWithScheduler.configs) {
+                if (opts.verbosity().printAllTests()) {
+                    testsToPrint.add(test.toDetailedTest());
+                } else {
+                    testsToPrint.add(test.name);
+                }
+            }
+            if (opts.verbosity().printAllTests()) {
+                System.out.println("All matching tests combinations - " + testsToPrint.size());
+            } else {
+                System.out.println("All matching tests - " + testsToPrint.size());
+            }
+            for (String test : testsToPrint) {
                 System.out.println(test);
             }
         } else if (opts.shouldParse()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -46,9 +46,6 @@ import java.util.*;
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
  */
 public class Options {
-
-    private static final String LIST_OPTION_DESCRIPTION="List the available tests matching the requested settings, " +
-            "after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.";
     private String resultDir;
     private String testFilter;
     private int strideSize;
@@ -84,7 +81,8 @@ public class Options {
         OptionSpec<String> parse = parser.accepts("p", "Re-run parser on the result file. This will not run any tests.")
                 .withRequiredArg().ofType(String.class).describedAs("result file");
 
-        OptionSpec<Boolean> list = parser.accepts("l", LIST_OPTION_DESCRIPTION)
+        OptionSpec<Boolean> list = parser.accepts("l", "List the available tests matching the requested settings, " +
+                        "after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.")
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         OptionSpec<String> testFilter = parser.accepts("t", "Regexp selector for tests.")

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Options.
@@ -82,7 +81,8 @@ public class Options {
         OptionSpec<String> parse = parser.accepts("p", "Re-run parser on the result file. This will not run any tests.")
                 .withRequiredArg().ofType(String.class).describedAs("result file");
 
-        OptionSpec<Boolean> list = parser.accepts("l", "List the available tests matching the requested settings.")
+        OptionSpec<Boolean> list = parser.accepts("l", "List the available tests matching the requested settings, " +
+                        "after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.")
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         OptionSpec<String> testFilter = parser.accepts("t", "Regexp selector for tests.")

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -47,7 +47,8 @@ import java.util.*;
  */
 public class Options {
 
-    private static final String LIST_OPTION_DESCRIPTION="List the available tests matching the requested settings, after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.";
+    private static final String LIST_OPTION_DESCRIPTION="List the available tests matching the requested settings, " +
+            "after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.";
     private String resultDir;
     private String testFilter;
     private int strideSize;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -46,6 +46,8 @@ import java.util.*;
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
  */
 public class Options {
+
+    private static final String LIST_OPTION_DESCRIPTION="List the available tests matching the requested settings, after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.";
     private String resultDir;
     private String testFilter;
     private int strideSize;
@@ -81,8 +83,7 @@ public class Options {
         OptionSpec<String> parse = parser.accepts("p", "Re-run parser on the result file. This will not run any tests.")
                 .withRequiredArg().ofType(String.class).describedAs("result file");
 
-        OptionSpec<Boolean> list = parser.accepts("l", "List the available tests matching the requested settings, " +
-                        "after all filters (like CPU count) are applied. In verbose mode it prints all real combinations which will run.")
+        OptionSpec<Boolean> list = parser.accepts("l", LIST_OPTION_DESCRIPTION)
                 .withOptionalArg().ofType(Boolean.class).describedAs("bool");
 
         OptionSpec<String> testFilter = parser.accepts("t", "Regexp selector for tests.")

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -250,17 +250,20 @@ public class TestConfig implements Serializable {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
-        return name +
-                " {" + actorNames +
-                ", spinLoopStyle: " + spinLoopStyle +
-                ", threads: " + threads +
-                ", forkId: " + forkId +
-                ", maxFootprintMB: " + maxFootprintMB +
-                ", compileMode: " + compileMode +
-                ", shClass: " + shClass +
-                ", strideSize: " + strideSize +
-                ", strideCount: " + strideCount +
-                ", cpuMap: " + cpuMap +
-                ", " + jvmArgs + "}";
+        StringBuilder verboseOutput = new StringBuilder(name);
+        verboseOutput.append(" {")
+                .append(actorNames)
+                .append(", spinLoopStyle: ").append(spinLoopStyle)
+                .append(", threads: ").append(threads)
+                .append(", forkId: ").append(forkId)
+                .append(", maxFootprintMB: ").append(maxFootprintMB)
+                .append(", compileMode: ").append(compileMode)
+                .append(", shClass: ").append(shClass)
+                .append(", strideSize: ").append(strideSize)
+                .append(", strideCount: ").append(strideCount)
+                .append(", cpuMap: ").append(cpuMap)
+                .append(", ").append(jvmArgs)
+                .append("}");
+        return verboseOutput.toString();
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -36,7 +36,6 @@ import org.openjdk.jcstress.vm.VMSupport;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
@@ -253,15 +252,15 @@ public class TestConfig implements Serializable {
         //super.toString() as TestConfig@hash - omitted
         return name +
                 " {" + actorNames +
-                ", spinLoopStyle=" + spinLoopStyle +
-                ", threads=" + threads +
-                ", forkId=" + forkId +
-                ", maxFootprintMB=" + maxFootprintMB +
-                ", compileMode=" + compileMode +
-                ", shClass=" + shClass +
-                ", strideSize=" + strideSize +
-                ", strideCount=" + strideCount +
-                ", cpuMap=" + cpuMap +
+                ", spinLoopStyle: " + spinLoopStyle +
+                ", threads: " + threads +
+                ", forkId: " + forkId +
+                ", maxFootprintMB: " + maxFootprintMB +
+                ", compileMode: " + compileMode +
+                ", shClass: " + shClass +
+                ", strideSize: " + strideSize +
+                ", strideCount: " + strideCount +
+                ", cpuMap: " + cpuMap +
                 ", " + jvmArgs + "}";
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -36,6 +36,7 @@ import org.openjdk.jcstress.vm.VMSupport;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
@@ -243,5 +244,24 @@ public class TestConfig implements Serializable {
         }
         pw.println("]");
         pw.flush();
+    }
+
+
+    public String toDetailedTest() {
+        //binaryName have correct $ instead of . in name; omitted
+        //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
+        //super.toString() as TestConfig@hash - omitted
+        return name +
+                " {" + actorNames +
+                ", spinLoopStyle=" + spinLoopStyle +
+                ", threads=" + threads +
+                ", forkId=" + forkId +
+                ", maxFootprintMB=" + maxFootprintMB +
+                ", compileMode=" + compileMode +
+                ", shClass=" + shClass +
+                ", strideSize=" + strideSize +
+                ", strideCount=" + strideCount +
+                ", cpuMap=" + cpuMap +
+                ", " + jvmArgs + "}";
     }
 }


### PR DESCRIPTION
This is extracting  List<TestConfig> configs =prepareRunProgram(classes, tests);
with all he HW/switches setup to separated method and reusing it in `-l` mode

I'm aware of triplicated removal of -agentlib, and will clean it up as
CODETOOLS-7903756 will progress.

-l now honours also verbose mode, in which it prints not just matching
tests but all really run tests, and thus enabling much more easy
determining of all tests

help adjusted.

Maybe I'm missing plain quick initial all tests metod now, but with 
artificial -c MAX it seems doing exactly that

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903748](https://bugs.openjdk.org/browse/CODETOOLS-7903748): jcstress: Test list should honor concurrency settings (**Bug** - P4)


### Reviewers
 * @matcdac (no known openjdk.org user name / role) ⚠️ Review applies to [4ee850d8](https://git.openjdk.org/jcstress/pull/149/files/4ee850d84e36de366e1e1446a3a9f1f11c6c10a1)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jcstress.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/149.diff">https://git.openjdk.org/jcstress/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/149#issuecomment-2178672828)