### PR TITLE
7903756: jcstress: Skip debugging JVM options for sub-processes

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -40,6 +40,7 @@ import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Options.
@@ -393,5 +394,9 @@ public class Options {
     }
 
     public TimeValue timeBudget() { return timeBudget; }
+
+    public static List<String> filterAgentLib(List<String> originalArgs ) {
+        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib")).collect(Collectors.toList());
+    }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -395,8 +395,4 @@ public class Options {
 
     public TimeValue timeBudget() { return timeBudget; }
 
-    private static List<String> removeJdwpAgentLib(List<String> originalArgs ) {
-        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
-    }
-
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -395,8 +395,8 @@ public class Options {
 
     public TimeValue timeBudget() { return timeBudget; }
 
-    public static List<String> filterAgentLib(List<String> originalArgs ) {
-        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib")).collect(Collectors.toList());
+    private static List<String> removeJdwpAgentLib(List<String> originalArgs ) {
+        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
     }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -39,8 +39,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Options.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -38,7 +38,6 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * Manages test execution for the entire run.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -38,6 +38,7 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Manages test execution for the entire run.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -456,6 +456,8 @@ public class VMSupport {
                     .map(c -> prependArgs(c, inputArgs))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         }
+
+        // Filter out unwanted arguments.
         configs = configs.stream()
                 .map(c -> cleanArgs(c))
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -395,12 +395,8 @@ public class VMSupport {
     }
 
     private static Config cleanArgs(Config orig) {
-        List<String> l = removeJdwpAgentLib(orig.args);
+        List<String> l = orig.args.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
         return new Config(l, orig.onlyIfC2(), orig.stress());
-    }
-
-    private static List<String> removeJdwpAgentLib(List<String> originalArgs) {
-        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
     }
 
     public static void detectAvailableVMConfigs(boolean splitCompilation, List<String> jvmArgs, List<String> jvmArgsPrepend) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -395,8 +395,12 @@ public class VMSupport {
     }
 
     private static Config cleanArgs(Config orig) {
-        List<String> l = Options.filterAgentLib(orig.args);
+        List<String> l = removeJdwpAgentLib(orig.args);
         return new Config(l, orig.onlyIfC2(), orig.stress());
+    }
+
+    private static List<String> removeJdwpAgentLib(List<String> originalArgs ) {
+        return originalArgs.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
     }
 
     public static void detectAvailableVMConfigs(boolean splitCompilation, List<String> jvmArgs, List<String> jvmArgsPrepend) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -395,7 +395,9 @@ public class VMSupport {
     }
 
     private static Config cleanArgs(Config orig) {
-        List<String> l = orig.args.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
+        List<String> l = orig.args.stream()
+            .filter(s -> !s.startsWith("-agentlib:jdwp"))
+            .collect(Collectors.toList());
         return new Config(l, orig.onlyIfC2(), orig.stress());
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -394,6 +394,11 @@ public class VMSupport {
         return new Config(l, orig.onlyIfC2(), orig.stress());
     }
 
+    private static Config cleanArgs(Config orig) {
+        List<String> l = Options.filterAgentLib(orig.args);
+        return new Config(l, orig.onlyIfC2(), orig.stress());
+    }
+
     public static void detectAvailableVMConfigs(boolean splitCompilation, List<String> jvmArgs, List<String> jvmArgsPrepend) {
         System.out.println("Probing what VM configurations are available:");
         System.out.println(" (failures are non-fatal, but may miss some interesting cases)");
@@ -449,7 +454,9 @@ public class VMSupport {
                     .map(c -> prependArgs(c, inputArgs))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         }
-
+        configs = configs.stream()
+                .map(c -> cleanArgs(c))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         // Mix in prepends, if available
         if (jvmArgsPrepend != null) {
             configs = configs.stream()

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -399,7 +399,7 @@ public class VMSupport {
         return new Config(l, orig.onlyIfC2(), orig.stress());
     }
 
-    private static List<String> removeJdwpAgentLib(List<String> originalArgs ) {
+    private static List<String> removeJdwpAgentLib(List<String> originalArgs) {
         return originalArgs.stream().filter(s -> !s.startsWith("-agentlib:jdwp")).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
No longer passing any -agentlib to subprocesses, unless it is part of -jvmArgsPrepend, thus allowing to debug both jcstress itself or wrked vm as expected:
```
java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005  -jar tests-all/target/jcstress.jar -c 1 -jvmArgsPrepend "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006"
```
works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903756](https://bugs.openjdk.org/browse/CODETOOLS-7903756): jcstress: Skip debugging JVM options for sub-processes (**Bug** - P4)


### Reviewers
 * @matcdac (no known openjdk.org user name / role) ⚠️ Review applies to [6ffc620b](https://git.openjdk.org/jcstress/pull/150/files/6ffc620b3993c312adaad6e020c4385d6f3be630)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [b4c88fa1](https://git.openjdk.org/jcstress/pull/150/files/b4c88fa120e8d297866a4997a6f3d5a4c489865c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jcstress.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/150.diff">https://git.openjdk.org/jcstress/pull/150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/150#issuecomment-2202707228)