### PR TITLE
7903848: JCStress: Use "out" field consistently

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -99,8 +99,8 @@ public class JCStress {
         SortedSet<String> tests = getTests();
 
         Topology topology = Topology.get();
-        System.out.println("Detecting CPU topology and computing scheduling classes:");
-        topology.printStatus(System.out);
+        out.println("Detecting CPU topology and computing scheduling classes:");
+        topology.printStatus(out);
         out.println();
 
         out.println("  Scheduling classes for matching tests:");
@@ -238,12 +238,12 @@ public class JCStress {
             }
         }
         if (opts.verbosity().printAllTests()) {
-            System.out.println("All matching tests combinations - " + testsToPrint.size());
+            out.println("All matching tests combinations - " + testsToPrint.size());
         } else {
-            System.out.println("All matching tests - " + testsToPrint.size());
+            out.println("All matching tests - " + testsToPrint.size());
         }
         for (String test : testsToPrint) {
-            System.out.println(test);
+            out.println(test);
         }
         return testsToPrint.size();
     }


### PR DESCRIPTION
This PR changes to use `out` field consistently in the `JCStress` as it would be better for internal consistency although it's effectively same as before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903848](https://bugs.openjdk.org/browse/CODETOOLS-7903848): JCStress: Use "out" field consistently (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/jcstress.git pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/151.diff">https://git.openjdk.org/jcstress/pull/151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/151#issuecomment-2380645599)