### PR TITLE
7903774: make all tests combinations printing nicer and/or configurable

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -236,8 +236,11 @@ public class JCStress {
 
     public SortedSet<String> getTests() {
         String filter = opts.getTestFilter();
-        SortedSet<String> s = new TreeSet<>();
+        return getTests(filter);
+    }
 
+    public SortedSet<String> getTests(String filter) {
+        SortedSet<String> s = new TreeSet<>();
         Pattern pattern = Pattern.compile(filter);
         for (String testName : TestList.tests()) {
             if (pattern.matcher(testName).find()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -85,7 +85,7 @@ public class JCStress {
         parseResults();
     }
 
-    private ConfigsWithScheduler getConfigs() {
+    ConfigsWithScheduler getConfigs() {
         VMSupport.initFlags(opts);
 
         OSSupport.init();
@@ -119,7 +119,7 @@ public class JCStress {
         return new ConfigsWithScheduler(scheduler, configs);
     }
 
-    private static class ConfigsWithScheduler {
+    static class ConfigsWithScheduler {
         public final Scheduler scheduler;
         public final List<TestConfig> configs;
 
@@ -246,26 +246,5 @@ public class JCStress {
         }
         return s;
    }
-
-    public int listTests(Options opts) {
-        JCStress.ConfigsWithScheduler configsWithScheduler = getConfigs();
-        Set<String> testsToPrint = new TreeSet<>();
-        for (TestConfig test : configsWithScheduler.configs) {
-            if (opts.verbosity().printAllTests()) {
-                testsToPrint.add(test.toDetailedTest());
-            } else {
-                testsToPrint.add(test.name);
-            }
-        }
-        if (opts.verbosity().printAllTests()) {
-            out.println("All matching tests combinations - " + testsToPrint.size());
-        } else {
-            out.println("All matching tests - " + testsToPrint.size());
-        }
-        for (String test : testsToPrint) {
-            out.println(test);
-        }
-        return testsToPrint.size();
-    }
 
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Main.java
@@ -50,7 +50,8 @@ public class Main {
 
         JCStress jcstress = new JCStress(opts);
         if (opts.shouldList()) {
-            jcstress.listTests(opts);
+            TestListing testListing = new TestListing(jcstress);
+            testListing.listTests();
         } else if (opts.shouldParse()) {
             jcstress.parseResults();
         } else {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress;
+
+import org.openjdk.jcstress.infra.runners.TestConfig;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class TestListing {
+
+    private final JCStress jcstress;
+
+    public TestListing(JCStress jcstress) {
+        this.jcstress = jcstress;
+    }
+
+    public int listTests() {
+        JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
+        Set<String> testsToPrint = new TreeSet<>();
+        for (TestConfig test : configsWithScheduler.configs) {
+            if (jcstress.opts.verbosity().printAllTests()) {
+                testsToPrint.add(test.toDetailedTest());
+            } else {
+                testsToPrint.add(test.name);
+            }
+        }
+        if (jcstress.opts.verbosity().printAllTests()) {
+            jcstress.out.println("All matching tests combinations - " + testsToPrint.size());
+        } else {
+            jcstress.out.println("All matching tests - " + testsToPrint.size());
+        }
+        for (String test : testsToPrint) {
+            jcstress.out.println(test);
+        }
+        return testsToPrint.size();
+    }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -21,24 +21,34 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
+
  */
 package org.openjdk.jcstress;
 
 import org.openjdk.jcstress.infra.runners.TestConfig;
+
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class TestListing {
 
     public enum ListingTypes {
-        NONE, ALL, ALL_MATCHING, ALL_MATCHING_COMBINATIONS;
+        NONE, ALL, ALL_MATCHING, ALL_MATCHING_COMBINATIONS,
+        MATCHING_GROUPS, MATCHING_GROUPS_COUNT,
+        MATCHING_IGROUPS, MATCHING_IGROUPS_COUNT;
 
         public static String toDescription() {
             return "Optional parameter is: "
                     + ALL + " - all tests; "
                     + ALL_MATCHING + " all tests eligible for this system and configuration (like CPU count); "
-                    + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup." +
-                    " Defaults to " + ALL_MATCHING + " if none provided.";
+                    + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup."
+                    + MATCHING_GROUPS + " similar to above but the shared part is printed only once"
+                    + MATCHING_GROUPS_COUNT + " same as above, only instead of lsiting, just count is used"
+                    + MATCHING_IGROUPS + ", " + MATCHING_IGROUPS_COUNT + " same as above, only inverted"
+                    + " Defaults to " + ALL_MATCHING + " if none provided.";
         }
     }
 
@@ -48,33 +58,79 @@ public class TestListing {
         this.jcstress = jcstress;
     }
 
+    @SuppressWarnings("unchecked")
     public int listTests() {
         JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
-        Set<String> testsToPrint = new TreeSet<>();
+        Map<String, Object> testsToPrint = new TreeMap<>();
         switch (jcstress.opts.listingType()) {
             case ALL_MATCHING_COMBINATIONS:
                 for (TestConfig test : configsWithScheduler.configs) {
-                    testsToPrint.add(test.toDetailedTest());
+                    testsToPrint.put(test.toDetailedTest(), null);
                 }
                 jcstress.out.println("All matching tests combinations - " + testsToPrint.size());
                 break;
+            case MATCHING_GROUPS_COUNT:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    Integer counter = (Integer) testsToPrint.getOrDefault(test.getTestVariant(false), 0);
+                    counter++;
+                    testsToPrint.put(test.getTestVariant(false), counter);
+                }
+                jcstress.out.println("All existing combinations (each with count of test) " + testsToPrint.size());
+                break;
+            case MATCHING_IGROUPS_COUNT:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    Integer counter = (Integer) testsToPrint.getOrDefault(test.name, 0);
+                    counter++;
+                    testsToPrint.put(test.name, counter);
+                }
+                jcstress.out.println("All matching tests (each with count of combinations) " + testsToPrint.size());
+                break;
+            case MATCHING_GROUPS:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    Set<String> items = (Set<String>) testsToPrint.getOrDefault(test.getTestVariant(false), new TreeSet<String>());
+                    items.add(test.name);
+                    testsToPrint.put(test.getTestVariant(false), items);
+                }
+                jcstress.out.println("All existing combinations " + testsToPrint.size());
+                break;
+            case MATCHING_IGROUPS:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    Set<String> items = (Set<String>) (testsToPrint.getOrDefault(test.name, new TreeSet<String>()));
+                    items.add(test.getTestVariant(false));
+                    testsToPrint.put(test.name, items);
+                }
+                jcstress.out.println("All matching tests" + testsToPrint.size());
+                break;
             case ALL_MATCHING:
                 for (TestConfig test : configsWithScheduler.configs) {
-                    testsToPrint.add(test.name);
+                    testsToPrint.put(test.name, null);
                 }
                 jcstress.out.println("All matching tests - " + testsToPrint.size());
                 break;
             case ALL:
                 for (String test : jcstress.getTests()) {
-                    testsToPrint.add(test);
+                    testsToPrint.put(test, null);
                 }
                 jcstress.out.println("All existing tests combinations - " + testsToPrint.size());
                 break;
             default:
                 throw new RuntimeException("Invalid option for listing: " + jcstress.opts.listingType());
         }
-        for (String test : testsToPrint) {
-            jcstress.out.println(test);
+        for (Map.Entry<String, Object> test : testsToPrint.entrySet()) {
+            if (test.getValue() == null) {
+                jcstress.out.println(test.getKey());
+            } else {
+                if (test.getValue() instanceof Integer) {
+                    jcstress.out.println(test.getValue() + " " + test.getKey());
+                } else if (test.getValue() instanceof Collection) {
+                    jcstress.out.println(test.getKey() + " " + ((Collection) test.getValue()).size());
+                    for (Object item : (Collection) test.getValue()) {
+                        jcstress.out.println("    " + item);
+                    }
+                } else {
+                    jcstress.out.println(test.getKey() + "=?=" + test.getValue());
+                }
+            }
         }
         return testsToPrint.size();
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -30,6 +30,18 @@ import java.util.TreeSet;
 
 public class TestListing {
 
+    public enum ListingTypes {
+        NONE, ALL, ALL_MATCHING, ALL_MATCHING_COMBINATIONS;
+
+        public static String toDescription() {
+            return "Optional parameter is: "
+                    + ALL + " - all tests; "
+                    + ALL_MATCHING + " all tests eligible for this system and configuration (like CPU count); "
+                    + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup." +
+                    " Defaults to " + ALL_MATCHING + " if none provided.";
+        }
+    }
+
     private final JCStress jcstress;
 
     public TestListing(JCStress jcstress) {
@@ -39,17 +51,27 @@ public class TestListing {
     public int listTests() {
         JCStress.ConfigsWithScheduler configsWithScheduler = jcstress.getConfigs();
         Set<String> testsToPrint = new TreeSet<>();
-        for (TestConfig test : configsWithScheduler.configs) {
-            if (jcstress.opts.verbosity().printAllTests()) {
-                testsToPrint.add(test.toDetailedTest());
-            } else {
-                testsToPrint.add(test.name);
-            }
-        }
-        if (jcstress.opts.verbosity().printAllTests()) {
-            jcstress.out.println("All matching tests combinations - " + testsToPrint.size());
-        } else {
-            jcstress.out.println("All matching tests - " + testsToPrint.size());
+        switch (jcstress.opts.listingType()) {
+            case ALL_MATCHING_COMBINATIONS:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    testsToPrint.add(test.toDetailedTest());
+                }
+                jcstress.out.println("All matching tests combinations - " + testsToPrint.size());
+                break;
+            case ALL_MATCHING:
+                for (TestConfig test : configsWithScheduler.configs) {
+                    testsToPrint.add(test.name);
+                }
+                jcstress.out.println("All matching tests - " + testsToPrint.size());
+                break;
+            case ALL:
+                for (String test : jcstress.getTests()) {
+                    testsToPrint.add(test);
+                }
+                jcstress.out.println("All existing tests combinations - " + testsToPrint.size());
+                break;
+            default:
+                throw new RuntimeException("Invalid option for listing: " + jcstress.opts.listingType());
         }
         for (String test : testsToPrint) {
             jcstress.out.println(test);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -35,6 +35,8 @@ import java.util.TreeSet;
 
 public class TestListing {
 
+    public static final String FLAT_JSON_VARIANTS = "jcstress.list.json.flat";
+
     public enum ListingTypes {
         NONE, ALL, ALL_MATCHING, ALL_MATCHING_COMBINATIONS,
         MATCHING_GROUPS, MATCHING_GROUPS_COUNT,

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -44,11 +44,11 @@ public class TestListing {
             return "Optional parameter is: "
                     + ALL + " all tests; "
                     + ALL_MATCHING + " all tests eligible for this system and configuration (like CPU count); "
-                    + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup."
-                    + MATCHING_GROUPS + " similar to above but the shared part is printed only once"
-                    + MATCHING_GROUPS_COUNT + " same as above, only instead of lsiting, just count is used"
-                    + MATCHING_IGROUPS + ", " + MATCHING_IGROUPS_COUNT + " same as above, only inverted"
-                    + " Defaults to " + ALL_MATCHING + " if none provided.";
+                    + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup; "
+                    + MATCHING_GROUPS + " similar to above but the shared part is printed only once; "
+                    + MATCHING_GROUPS_COUNT + " same as above, only instead of lsiting, just count is used; "
+                    + MATCHING_IGROUPS + ", " + MATCHING_IGROUPS_COUNT + " same as above, only inverted; "
+                    + "Defaults to " + ALL_MATCHING + " if none provided.";
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -42,7 +42,7 @@ public class TestListing {
 
         public static String toDescription() {
             return "Optional parameter is: "
-                    + ALL + " - all tests; "
+                    + ALL + " all tests; "
                     + ALL_MATCHING + " all tests eligible for this system and configuration (like CPU count); "
                     + ALL_MATCHING_COMBINATIONS + " all real combinations which will run in this setup."
                     + MATCHING_GROUPS + " similar to above but the shared part is printed only once"

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestListing.java
@@ -134,7 +134,7 @@ public class TestListing {
             case ALL:
             case TOTAL_ALL:
             case JSON_ALL:
-                for (String test : jcstress.getTests()) {
+                for (String test : jcstress.getTests(".*")) {
                     testsToPrint.put(test, null);
                 }
                 jcstress.out.println("All existing tests combinations - " + testsToPrint.size());

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -35,6 +35,7 @@ import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestConfig implements Serializable {
@@ -246,13 +247,12 @@ public class TestConfig implements Serializable {
     }
 
 
-    public String toDetailedTest() {
+    public String getTestVariant(boolean seed) {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
-        StringBuilder verboseOutput = new StringBuilder(name);
-        verboseOutput.append(" {")
-                .append(actorNames)
+        StringBuilder idString = new StringBuilder();
+        idString.append(actorNames)
                 .append(", spinLoopStyle: ").append(spinLoopStyle)
                 .append(", threads: ").append(threads)
                 .append(", forkId: ").append(forkId)
@@ -262,7 +262,26 @@ public class TestConfig implements Serializable {
                 .append(", strideSize: ").append(strideSize)
                 .append(", strideCount: ").append(strideCount)
                 .append(", cpuMap: ").append(cpuMap)
-                .append(", ").append(jvmArgs)
+                .append(", ").append(seed ? jvmArgs : maskSeed(jvmArgs));
+        return idString.toString();
+    }
+
+    private List<String> maskSeed(List<String> jvmArgs) {
+        List<String> argsCopy = new ArrayList<>(jvmArgs.size());
+        for (String arg : jvmArgs) {
+            if (arg.startsWith("-XX:StressSeed=")) {
+                argsCopy.add(arg.replaceAll("[0-9]+", "yyyyyyyy"));
+            } else {
+                argsCopy.add(arg);
+            }
+        }
+        return argsCopy;
+    }
+
+    public String toDetailedTest() {
+        StringBuilder verboseOutput = new StringBuilder(name);
+        verboseOutput.append(" {")
+                .append(getTestVariant(true))
                 .append("}");
         return verboseOutput.toString();
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -30,13 +30,16 @@ import org.openjdk.jcstress.os.SchedulingClass;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.os.CPUMap;
+import org.openjdk.jcstress.util.StringUtils;
 import org.openjdk.jcstress.vm.CompileMode;
 import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TestConfig implements Serializable {
     public final SpinLoopStyle spinLoopStyle;
@@ -246,23 +249,22 @@ public class TestConfig implements Serializable {
         pw.flush();
     }
 
-
-    public String getTestVariant(boolean seed) {
+    public String getTestVariant(boolean seed, boolean json) {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
         StringBuilder idString = new StringBuilder();
-        idString.append(actorNames)
-                .append(", spinLoopStyle: ").append(spinLoopStyle)
-                .append(", threads: ").append(threads)
-                .append(", forkId: ").append(forkId)
-                .append(", maxFootprintMB: ").append(maxFootprintMB)
-                .append(", compileMode: ").append(compileMode)
-                .append(", shClass: ").append(shClass)
-                .append(", strideSize: ").append(strideSize)
-                .append(", strideCount: ").append(strideCount)
-                .append(", cpuMap: ").append(cpuMap)
-                .append(", ").append(seed ? jvmArgs : maskSeed(jvmArgs));
+        idString.append(StringUtils.fieldToString("actorNames", json, actorNames))
+                .append(", ").append(StringUtils.fieldToString("spinLoopStyle", json, spinLoopStyle))
+                .append(", ").append(StringUtils.fieldToString("threads", json, threads))
+                .append(", ").append(StringUtils.fieldToString("forkId", json, forkId))
+                .append(", ").append(StringUtils.fieldToString("maxFootprintMB", json, maxFootprintMB))
+                .append(", ").append(StringUtils.fieldToString("compileMode", json, compileMode))
+                .append(", ").append(StringUtils.fieldToString("shClass", json, shClass))
+                .append(", ").append(StringUtils.fieldToString("strideSize", json, strideSize))
+                .append(", ").append(StringUtils.fieldToString("strideCount", json, strideCount))
+                .append(", ").append(StringUtils.fieldToString("cpuMap", json, cpuMap))
+                .append(", ").append(StringUtils.fieldToString("jvmArgs", json, (seed ? jvmArgs : maskSeed(jvmArgs))));
         return idString.toString();
     }
 
@@ -278,11 +280,23 @@ public class TestConfig implements Serializable {
         return argsCopy;
     }
 
-    public String toDetailedTest() {
-        StringBuilder verboseOutput = new StringBuilder(name);
-        verboseOutput.append(" {")
-                .append(getTestVariant(true))
-                .append("}");
+    public String toDetailedTest(boolean json, boolean showName, boolean seed, boolean keepBrackets) {
+        StringBuilder verboseOutput = showName ? new StringBuilder(StringUtils.fieldToString("name", json, false, name)) : new StringBuilder();
+        if (json) {
+            if (showName) {
+                verboseOutput.append(", ");
+            }
+            verboseOutput.append("\"metadata\": ");
+        } else {
+            if (showName) {
+                verboseOutput.append(" ");
+            }
+        }
+        if (keepBrackets) {
+            verboseOutput.append("{").append(getTestVariant(seed, json)).append("}");
+        } else {
+            verboseOutput.append(getTestVariant(seed, json));
+        }
         return verboseOutput.toString();
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class StringUtils {
 
@@ -190,5 +191,54 @@ public class StringUtils {
             }
         }
         return result;
+    }
+
+   public static String fieldToString(String name, boolean json, Collection<? extends Object> field) {
+        String value;
+        if (json) {
+            value = "\"" + (field.stream().map( a -> String.valueOf(a)).collect(Collectors.joining("\",\""))) + "\"";
+        } else {
+            value = field.toString();
+        }
+        return fieldToStringImpl(name, json, false, value, true);
+    }
+
+    public static String fieldToString(String name, boolean json, Object field) {
+        return fieldToString(name, json, true, String.valueOf(field));
+    }
+
+    public static String fieldToString(String name, boolean json, boolean showName, Object field) {
+        return fieldToStringImpl(name, json, showName, String.valueOf(field), false);
+    }
+
+    private static String fieldToStringImpl(String name, boolean json, boolean showName, String field, boolean arrayQuotes) {
+        String finalForm;
+        if (showName || json) {
+            finalForm = key(json, name);
+        } else {
+            finalForm = "";
+        }
+        if (json) {
+            if (arrayQuotes) {
+                return finalForm + "[" + field + "]";
+            } else {
+                if (field.chars().allMatch( Character::isDigit )) {
+                    //all known usages use only int as numbers
+                    return finalForm + field;
+                } else {
+                    return finalForm + "\"" + field + "\"";
+                }
+            }
+        } else {
+            return finalForm + field;
+        }
+    }
+
+    private static String key(boolean json, String title) {
+        if (json) {
+            return "\"" + title + "\": ";
+        } else {
+            return title + ": ";
+        }
     }
 }


### PR DESCRIPTION
This is still WIP, but already on row what [CODETOOLS-7903774](https://bugs.openjdk.org/browse/CODETOOLS-7903774) suggested.

It will be finished once all desired output combinations are included, but already now is doing the usage of listing much more comfortable and code readable.

From:
```
`TESTS` - as introduced by https://github.com/openjdk/jcstress/pull/149
`COMBINATIONS` - as introduced in https://github.com/openjdk/jcstress/pull/149 verbose mode (thus surpassing the `-v` impact
`ALL_TESTS` - all tests as it was before https://github.com/openjdk/jcstress/pull/149
`COMBINATIONS_GROUPED ` - as suggested in https://github.com/openjdk/jcstress/pull/149#discussion_r1668678910
`COMBINATIONS_JSON` same as combinations, but a valid json
`COMBINATIONS_GROUPS` same as COMBINATIONS_GROUPED only instead of enumeration in each group, only count of members will be printed 
```

* TESTS are already implemented as ALL_MATCHING
* COMBINATIONS as ALL_MATCHING_COMBINATIONS
* ALL_TESTS as ALL

COMBINATIONS_GROUPED, and COMBINATIONS_GROUPS are under development.
The _JSON variants are tobe decided, but ability to JQL it sounds nice.

Suggestion to better names welcomed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903774](https://bugs.openjdk.org/browse/CODETOOLS-7903774): make all tests combinations printing nicer and/or configurable (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jcstress.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/153.diff">https://git.openjdk.org/jcstress/pull/153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/153#issuecomment-2476930218)
</details>
