### PR TITLE
7903891: jcstress: Switch to latest runner versions

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         build-java: [17, 21]
         run-java: [8, 11, 17, 21]
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     name: Build JDK ${{ matrix.build-java }}, run JDK ${{ matrix.run-java }}, ${{ matrix.os }}
 


### PR DESCRIPTION
We always playing the catchup game with runners. Let's just default to latest runners for every OS flavor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903891](https://bugs.openjdk.org/browse/CODETOOLS-7903891): jcstress: Switch to latest runner versions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/154/head:pull/154` \
`$ git checkout pull/154`

Update a local copy of the PR: \
`$ git checkout pull/154` \
`$ git pull https://git.openjdk.org/jcstress.git pull/154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 154`

View PR using the GUI difftool: \
`$ git pr show -t 154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/154.diff">https://git.openjdk.org/jcstress/pull/154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/154#issuecomment-2508466480)
</details>
