### PR TITLE
7903754: jcstress: Implement fail-on-error run option 

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -70,7 +70,7 @@ public class JCStress {
         FailFastKiller failFastKiller = null;
         TestResultCollector mux;
         if (opts.isFailFast()) {
-            failFastKiller = new FailFastKiller(opts, new PrintWriter(out, true), config.configs.size());
+            failFastKiller = new FailFastKiller(opts, new PrintWriter(out, true), config.configs);
             mux = MuxCollector.of(printer, diskCollector, failFastKiller);
         } else {
             mux = MuxCollector.of(printer, diskCollector);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -28,6 +28,7 @@ import org.openjdk.jcstress.infra.TestInfo;
 import org.openjdk.jcstress.infra.collectors.*;
 import org.openjdk.jcstress.infra.grading.ConsoleReportPrinter;
 import org.openjdk.jcstress.infra.grading.ExceptionReportPrinter;
+import org.openjdk.jcstress.infra.grading.FailFastKiller;
 import org.openjdk.jcstress.infra.grading.TextReportPrinter;
 import org.openjdk.jcstress.infra.grading.HTMLReportPrinter;
 import org.openjdk.jcstress.infra.runners.TestConfig;
@@ -66,11 +67,21 @@ public class JCStress {
 
         ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), config.configs.size(), timeBudget);
         DiskWriteCollector diskCollector = new DiskWriteCollector(opts.getResultFile());
-        TestResultCollector mux = MuxCollector.of(printer, diskCollector);
+        FailFastKiller failFastKiller = null;
+        TestResultCollector mux;
+        if (opts.isFailFast()) {
+            failFastKiller = new FailFastKiller(opts, new PrintWriter(out, true), config.configs.size());
+            mux = MuxCollector.of(printer, diskCollector, failFastKiller);
+        } else {
+            mux = MuxCollector.of(printer, diskCollector);
+        }
         SerializedBufferCollector sink = new SerializedBufferCollector(mux);
 
         TestExecutor executor = new TestExecutor(opts.verbosity(), sink, config.scheduler, timeBudget);
         printer.setExecutor(executor);
+        if (failFastKiller!=null) {
+            failFastKiller.setExecutor(executor);
+        }
 
         executor.runAll(config.configs);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -69,7 +69,7 @@ public class JCStress {
         DiskWriteCollector diskCollector = new DiskWriteCollector(opts.getResultFile());
         FailFastKiller failFastKiller = null;
         TestResultCollector mux;
-        if (opts.isFailFast()) {
+        if (opts.isFailOnError()) {
             failFastKiller = new FailFastKiller(opts, new PrintWriter(out, true), config.configs);
             mux = MuxCollector.of(printer, diskCollector, failFastKiller);
         } else {
@@ -79,7 +79,7 @@ public class JCStress {
 
         TestExecutor executor = new TestExecutor(opts.verbosity(), sink, config.scheduler, timeBudget);
         printer.setExecutor(executor);
-        if (failFastKiller!=null) {
+        if (failFastKiller != null) {
             failFastKiller.setExecutor(executor);
         }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -434,7 +434,7 @@ public class Options {
 
     private void checkFailFast() {
         if (failFastVariants!=null && failFastTests != null) {
-            throw new IllegalArgumentException("Both " + FAIL_FAST_TESTS + " and " + FAIL_FAST_VARIANTS + " was declared, thatr is illegal");
+            throw new IllegalArgumentException("Both " + FAIL_FAST_TESTS + " and " + FAIL_FAST_VARIANTS + " was declared, that is illegal");
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -66,6 +66,7 @@ public class TestExecutor {
     private final ExecutorService supportTasks;
 
     private final TimeBudget timeBudget;
+    private boolean diedFast = false;
 
     public TestExecutor(Verbosity verbosity, TestResultCollector sink, Scheduler scheduler, TimeBudget tb) throws IOException {
         this.verbosity = verbosity;
@@ -142,7 +143,6 @@ public class TestExecutor {
         }
 
         while (!byScl.isEmpty()) {
-
             // Roll over the scheduling classes and try to greedily cram most
             // of the tasks for it. This exits when no scheduling classes can fit
             // the current state of the machine.
@@ -167,8 +167,17 @@ public class TestExecutor {
             while (!processReadyVMs()) {
                 awaitNotification();
             }
+            if (diedFast) {
+                System.err.println("fail1");
+                cleanup();
+                return;
+            }
         }
 
+        cleanup();
+    }
+
+    private void cleanup() {
         // Wait until all threads are done, which means everything got processed
         while (!vmByToken.isEmpty()) {
             while (!processReadyVMs()) {
@@ -213,6 +222,10 @@ public class TestExecutor {
 
     public int getJVMsFinishing() {
         return jvmsFinishing.get();
+    }
+
+    public void setDiedFast() {
+        diedFast=true;
     }
 
     private class VM {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -168,7 +168,6 @@ public class TestExecutor {
                 awaitNotification();
             }
             if (diedFast) {
-                System.err.println("fail1");
                 cleanup();
                 return;
             }
@@ -226,6 +225,10 @@ public class TestExecutor {
 
     public void setDiedFast() {
         diedFast=true;
+    }
+
+    public boolean isDiedFast() {
+        return diedFast;
     }
 
     private class VM {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -39,7 +39,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
 
 /**
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
@@ -64,9 +63,7 @@ public class TestResult implements Serializable {
     }
 
     public TestResult(DataInputStream dis) throws IOException {
-        //status = Status.values()[dis.readInt()];
-        dis.readInt();
-        status = Status.values()[new Random().nextInt(6)];
+        status = Status.values()[dis.readInt()];
         states = new Counter<>(dis);
         messages = new ArrayList<>();
         {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 /**
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
@@ -63,7 +64,9 @@ public class TestResult implements Serializable {
     }
 
     public TestResult(DataInputStream dis) throws IOException {
-        status = Status.values()[dis.readInt()];
+        //status = Status.values()[dis.readInt()];
+        dis.readInt();
+        status = Status.values()[new Random().nextInt(6)];
         states = new Counter<>(dis);
         messages = new ArrayList<>();
         {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -188,9 +188,9 @@ public class ConsoleReportPrinter extends CountingResultCollector {
         clearStatusLine();
         printStatusLine();
         if (executor.isDiedFast()) {
-            System.out.println("****************************************************");
-            System.out.println("To much failures occurred. Failing fast as requested");
-            System.out.println("****************************************************");
+            output.println("****************************************************");
+            output.println("To much failures occurred. Failing fast as requested");
+            output.println("****************************************************");
         }
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -187,6 +187,11 @@ public class ConsoleReportPrinter extends CountingResultCollector {
     public void printFinishLine() {
         clearStatusLine();
         printStatusLine();
+        if (executor.isDiedFast()) {
+            System.out.println("****************************************************");
+            System.out.println("To much failures occurred. Failing fast as requested");
+            System.out.println("****************************************************");
+        }
     }
 
     private String computeSpeed() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ConsoleReportPrinter.java
@@ -29,7 +29,6 @@ import org.openjdk.jcstress.TestExecutor;
 import org.openjdk.jcstress.TimeBudget;
 import org.openjdk.jcstress.Verbosity;
 import org.openjdk.jcstress.infra.collectors.TestResult;
-import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
@@ -41,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
  */
-public class ConsoleReportPrinter implements TestResultCollector {
+public class ConsoleReportPrinter extends CountingResultCollector {
 
     private static final Integer PRINT_INTERVAL_MS = Integer.getInteger("jcstress.console.printIntervalMs");
 
@@ -62,10 +61,6 @@ public class ConsoleReportPrinter implements TestResultCollector {
     private boolean progressFirstLine;
     private final int[] progressLen;
 
-    private long passed;
-    private long failed;
-    private long softErrors;
-    private long hardErrors;
     private TestExecutor executor;
     private final int totalCpuCount;
 
@@ -103,35 +98,11 @@ public class ConsoleReportPrinter implements TestResultCollector {
     }
 
     private void printResult(TestResult r) {
-        TestGrading grading = r.grading();
-
-        boolean inHardError = false;
-        switch (r.status()) {
-            case TIMEOUT_ERROR:
-            case CHECK_TEST_ERROR:
-            case TEST_ERROR:
-            case VM_ERROR:
-                hardErrors++;
-                inHardError = true;
-                break;
-            case API_MISMATCH:
-                softErrors++;
-                break;
-            case NORMAL:
-                if (grading.isPassed) {
-                    passed++;
-                } else {
-                    failed++;
-                }
-                break;
-            default:
-                throw new IllegalStateException("Illegal status: " + r.status());
-        }
-
+        boolean inHardError = countResult(r);
         boolean shouldPrintResults =
                 inHardError ||
-                !grading.isPassed ||
-                grading.hasInteresting ||
+                !r.grading().isPassed ||
+                r.grading().hasInteresting ||
                 verbosity.printAllTests();
 
         boolean shouldPrintStatusLine =

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/CountingResultCollector.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/CountingResultCollector.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.grading;
+
+import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.collectors.TestResultCollector;
+
+
+
+public abstract class  CountingResultCollector implements TestResultCollector {
+
+    protected long total;
+    protected long passed;
+    protected long failed;
+    protected long softErrors;
+    protected long hardErrors;
+
+    protected boolean countResult(TestResult r) {
+        TestGrading grading = r.grading();
+        total ++;
+        boolean inHardError = false;
+        switch (r.status()) {
+            case TIMEOUT_ERROR:
+            case CHECK_TEST_ERROR:
+            case TEST_ERROR:
+            case VM_ERROR:
+                hardErrors++;
+                inHardError = true;
+                break;
+            case API_MISMATCH:
+                softErrors++;
+                break;
+            case NORMAL:
+                if (grading.isPassed) {
+                    passed++;
+                } else {
+                    failed++;
+                }
+                break;
+            default:
+                throw new IllegalStateException("Illegal status: " + r.status());
+        }
+        return inHardError;
+    }
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -136,7 +136,7 @@ public class FailFastKiller extends CountingResultCollector {
             if (isFailFastAllVariants) {
                 totalFinishedUpToNow = passed + failed + softErrors + hardErrors;
             } else {
-                totalFinishedUpToNow = tests.values().stream().filter(a -> a <= 0).collect(Collectors.toList()).size();
+                totalFinishedUpToNow = tests.values().stream().filter(a -> a <= 0).collect(Collectors.counting());
             }
             double currentAbsoluteThreshold = (relativeThreshold * totalFinishedUpToNow) / 100d;
             //there must be enough finished to get to some reasonable numbers

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,20 +27,15 @@ package org.openjdk.jcstress.infra.grading;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.TestExecutor;
 import org.openjdk.jcstress.infra.collectors.TestResult;
-import org.openjdk.jcstress.infra.collectors.TestResultCollector;
 
 import java.io.PrintWriter;
 
 
-public class FailFastKiller implements TestResultCollector {
+public class FailFastKiller extends CountingResultCollector {
 
     private final PrintWriter output;
     private final long expectedResults;
 
-    private long passed;
-    private long failed;
-    private long softErrors;
-    private long hardErrors;
     private TestExecutor executor;
     private int numericDeadline;
 
@@ -65,29 +60,7 @@ public class FailFastKiller implements TestResultCollector {
 
     private void addResult(TestResult r) {
         TestGrading grading = r.grading();
-
-        boolean inHardError = false;
-        switch (r.status()) {
-            case TIMEOUT_ERROR:
-            case CHECK_TEST_ERROR:
-            case TEST_ERROR:
-            case VM_ERROR:
-                hardErrors++;
-                inHardError = true;
-                break;
-            case API_MISMATCH:
-                softErrors++;
-                break;
-            case NORMAL:
-                if (grading.isPassed) {
-                    passed++;
-                } else {
-                    failed++;
-                }
-                break;
-            default:
-                throw new IllegalStateException("Illegal status: " + r.status());
-        }
+        countResult(r);
         verifyState();
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -140,7 +140,7 @@ public class FailFastKiller extends CountingResultCollector {
             }
             double currentAbsoluteThreshold = (relativeThreshold * totalFinishedUpToNow) / 100d;
             //there must be enough finished to get to some reasonable numbers
-            if (currentAbsoluteThreshold > 1 && totalFinishedUpToNow > currentAbsoluteThreshold) {
+            if (currentAbsoluteThreshold > 1 && totalFailed > currentAbsoluteThreshold) {
                 executor.setDiedFast();
             }
         } else {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.grading;
+
+import org.openjdk.jcstress.Options;
+import org.openjdk.jcstress.TestExecutor;
+import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.collectors.TestResultCollector;
+
+import java.io.PrintWriter;
+
+
+public class FailFastKiller implements TestResultCollector {
+
+    private final PrintWriter output;
+    private final long expectedResults;
+
+    private long passed;
+    private long failed;
+    private long softErrors;
+    private long hardErrors;
+    private TestExecutor executor;
+    private int numericDeadline;
+
+
+    public FailFastKiller(Options opts, PrintWriter pw, long expectedResults) {
+        this.output = pw;
+        this.expectedResults = expectedResults;
+        output.println("  FailFast attached as:");
+        if (opts.isFailFastAllVariants()) {
+            output.println("    all variants, " + opts.getFailFast());
+        } else {
+            output.println("    whole tests, " + opts.getFailFast());
+        }
+        this.numericDeadline = Integer.valueOf(opts.getFailFast());
+        output.println();
+    }
+
+    @Override
+    public synchronized void add(TestResult r) {
+        addResult(r);
+    }
+
+    private void addResult(TestResult r) {
+        TestGrading grading = r.grading();
+
+        boolean inHardError = false;
+        switch (r.status()) {
+            case TIMEOUT_ERROR:
+            case CHECK_TEST_ERROR:
+            case TEST_ERROR:
+            case VM_ERROR:
+                hardErrors++;
+                inHardError = true;
+                break;
+            case API_MISMATCH:
+                softErrors++;
+                break;
+            case NORMAL:
+                if (grading.isPassed) {
+                    passed++;
+                } else {
+                    failed++;
+                }
+                break;
+            default:
+                throw new IllegalStateException("Illegal status: " + r.status());
+        }
+        verifyState();
+    }
+
+    private void verifyState() {
+        String l4 = String.format("(Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
+                expectedResults, passed, failed, softErrors, hardErrors);
+        //output.println(l4);
+        //output.flush();
+        if (passed+failed+softErrors+hardErrors > numericDeadline) {
+            executor.setDiedFast();
+        }
+    }
+
+    public void setExecutor(TestExecutor executor) {
+        this.executor = executor;
+    }
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -131,6 +131,9 @@ public class FailFastKiller extends CountingResultCollector {
 
     private void verifyState(TestResult r) {
         long totalFailed = failed + hardErrors;
+        if (System.getProperty("jcstress.failfast.countsoft") != null) {
+            totalFailed += softErrors;
+        }
         if (superRelative) {
             double totalFinishedUpToNow;
             if (isFailFastAllVariants) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -27,30 +27,88 @@ package org.openjdk.jcstress.infra.grading;
 import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.TestExecutor;
 import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.TestConfig;
 
 import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 public class FailFastKiller extends CountingResultCollector {
 
     private final PrintWriter output;
-    private final long expectedResults;
+    private final String originalValue;
+    private final Map<String, Integer> tests;
+    private final Set<String> failures = new HashSet<>();
+    private final List<TestConfig> variants;
+    private final boolean isFailFastAllVariants;
+    private final double userValue;
+    private final boolean relative;
+    private final boolean superRelative;
 
     private TestExecutor executor;
-    private int numericDeadline;
+    private double absoluteThreshold = 1;
+    private double relativeThreshold = 1;
+    private int usedTotal = -1;
 
 
-    public FailFastKiller(Options opts, PrintWriter pw, long expectedResults) {
+    public FailFastKiller(Options opts, PrintWriter pw, List<TestConfig> finalVariants) {
         this.output = pw;
-        this.expectedResults = expectedResults;
         output.println("  FailFast attached as:");
-        if (opts.isFailFastAllVariants()) {
-            output.println("    all variants, " + opts.getFailFast());
+        this.originalValue = opts.getFailFast();
+        this.userValue = Double.valueOf(originalValue.replaceAll("%*", ""));
+        this.relative = originalValue.endsWith("%");
+        this.superRelative = originalValue.endsWith("%%");
+        this.isFailFastAllVariants = opts.isFailFastAllVariants();
+        this.variants = Collections.unmodifiableList(finalVariants);
+        this.tests = groupVariants(finalVariants);
+        if (isFailFastAllVariants) {
+            output.println("    all variants, " + originalValue);
+            usedTotal = variants.size();
         } else {
-            output.println("    whole tests, " + opts.getFailFast());
+            output.println("    whole tests, " + originalValue);
+            usedTotal = tests.size();
         }
-        this.numericDeadline = Integer.valueOf(opts.getFailFast());
+        if (superRelative) {
+            relativeThreshold = userValue;
+            absoluteThreshold = -1;
+            output.println("    The suite will terminate once failure rate reaches " + getRelativeThresholdNice()
+                    + "% of *currently* finished number of tests/variants");
+        } else {
+            if (relative) {
+                relativeThreshold = userValue;
+                if (isFailFastAllVariants) {
+                    absoluteThreshold = (relativeThreshold * (double) variants.size()) / 100d;
+                } else {
+                    absoluteThreshold = (relativeThreshold * (double) tests.size()) / 100d;
+                }
+            } else {
+                absoluteThreshold = (long) userValue;
+                if (isFailFastAllVariants) {
+                    relativeThreshold = (absoluteThreshold * 100d) / (double) variants.size();
+                } else {
+                    relativeThreshold = (absoluteThreshold * 100d) / (double) tests.size();
+                }
+            }
+            output.println("    The suite will terminate once failure rate reaches " + getRelativeThresholdNice() + "% ("
+                    + getAbsoluteThresholdNice() + ") of total tests/variants (" + usedTotal + ")");
+        }
         output.println();
+    }
+
+    private static Map<String, Integer> groupVariants(List<TestConfig> finalVariants) {
+        Map<String, Integer> tests = new HashMap<>();
+        for (TestConfig testVariant : finalVariants) {
+            int counter = tests.getOrDefault(testVariant.name, 0);
+            counter++;
+            tests.put(testVariant.name, counter);
+        }
+        return tests;
     }
 
     @Override
@@ -59,22 +117,56 @@ public class FailFastKiller extends CountingResultCollector {
     }
 
     private void addResult(TestResult r) {
-        TestGrading grading = r.grading();
+        int groupCounter = tests.get(r.getName());
+        //we are counting each group down, so we can assure that the group is finished
+        tests.put(r.getName(), groupCounter-1);
+        long wasFailed = hardErrors + failed;
         countResult(r);
-        verifyState();
+        long isFailed = hardErrors + failed;
+        if (isFailed > wasFailed) {
+            failures.add(r.getName());
+        }
+        verifyState(r);
     }
 
-    private void verifyState() {
-        String l4 = String.format("(Results: %d planned; %d passed, %d failed, %d soft errs, %d hard errs)",
-                expectedResults, passed, failed, softErrors, hardErrors);
-        //output.println(l4);
-        //output.flush();
-        if (passed+failed+softErrors+hardErrors > numericDeadline) {
-            executor.setDiedFast();
+    private void verifyState(TestResult r) {
+        long totalFailed = failed + hardErrors;
+        if (superRelative) {
+            double totalFinishedUpToNow;
+            if (isFailFastAllVariants) {
+                totalFinishedUpToNow = passed + failed + softErrors + hardErrors;
+            } else {
+                totalFinishedUpToNow = tests.values().stream().filter(a -> a <= 0).collect(Collectors.toList()).size();
+            }
+            double currentAbsoluteThreshold = (relativeThreshold * totalFinishedUpToNow) / 100d;
+            //there must be enough finished to get to some reasonable numbers
+            if (currentAbsoluteThreshold > 1 && totalFinishedUpToNow > currentAbsoluteThreshold) {
+                executor.setDiedFast();
+            }
+        } else {
+            if (isFailFastAllVariants) {
+                if (totalFailed > absoluteThreshold) {
+                    executor.setDiedFast();
+                }
+            } else {
+                //we have to ensure, that all tests in current group finished
+                if (failures.size() > absoluteThreshold && tests.get(r.getName()) <= 0) {
+                    executor.setDiedFast();
+                }
+            }
         }
     }
 
     public void setExecutor(TestExecutor executor) {
         this.executor = executor;
     }
+
+    private String getAbsoluteThresholdNice() {
+        return String.format("%.0f", absoluteThreshold);
+    }
+
+    private String getRelativeThresholdNice() {
+        return String.format("%.2f", relativeThreshold);
+    }
+
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/FailFastKiller.java
@@ -32,72 +32,50 @@ import org.openjdk.jcstress.infra.runners.TestConfig;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 
 
 public class FailFastKiller extends CountingResultCollector {
 
-    private final PrintWriter output;
-    private final String originalValue;
+    private static final String INCLUDE_SOFT_ERRORS = "jcstress.foe.countsoft";
+    private static final String BREAK_IN_GROUP = "jcstress.foe.breakgroup";
+    private static final String LIMIT = "jcstress.foe.limit";
+
     private final Map<String, Integer> tests;
-    private final Set<String> failures = new HashSet<>();
-    private final List<TestConfig> variants;
-    private final boolean isFailFastAllVariants;
-    private final double userValue;
-    private final boolean relative;
-    private final boolean superRelative;
 
     private TestExecutor executor;
-    private double absoluteThreshold = 1;
-    private double relativeThreshold = 1;
-    private int usedTotal = -1;
+    private final double absoluteThreshold;
+    private final double relativeThreshold;
+
+    private final boolean breakInGroup;
+    private final boolean includeSoftErrors;
 
 
-    public FailFastKiller(Options opts, PrintWriter pw, List<TestConfig> finalVariants) {
-        this.output = pw;
-        output.println("  FailFast attached as:");
-        this.originalValue = opts.getFailFast();
-        this.userValue = Double.valueOf(originalValue.replaceAll("%*", ""));
-        this.relative = originalValue.endsWith("%");
-        this.superRelative = originalValue.endsWith("%%");
-        this.isFailFastAllVariants = opts.isFailFastAllVariants();
-        this.variants = Collections.unmodifiableList(finalVariants);
+    public FailFastKiller(Options opts, PrintWriter output, List<TestConfig> finalVariants) {
+        output.println("  Fail-on-error enabled as:");
+        String originalValue = System.getProperty(LIMIT, "1");
+        breakInGroup = Boolean.parseBoolean(System.getProperty(BREAK_IN_GROUP, "true"));
+        includeSoftErrors = Boolean.parseBoolean(System.getProperty(INCLUDE_SOFT_ERRORS, "false"));
+        double userValue = Double.parseDouble(originalValue.replaceAll("%*", ""));
+        boolean relative = originalValue.endsWith("%");
+        List<TestConfig> variants = Collections.unmodifiableList(finalVariants);
         this.tests = groupVariants(finalVariants);
-        if (isFailFastAllVariants) {
-            output.println("    all variants, " + originalValue);
-            usedTotal = variants.size();
-        } else {
-            output.println("    whole tests, " + originalValue);
-            usedTotal = tests.size();
+        output.println("    all tests, " + originalValue);
+        output.println("    break in group: " + breakInGroup);
+        if (breakInGroup && variants.size() < 1000) {
+            output.println("       Warning, with lower number of tests and high concurrency, the whole suite may finish before the condition is met.");
         }
-        if (superRelative) {
+        output.println("    include soft errors: " + includeSoftErrors);
+        if (relative) {
             relativeThreshold = userValue;
-            absoluteThreshold = -1;
-            output.println("    The suite will terminate once failure rate reaches " + getRelativeThresholdNice()
-                    + "% of *currently* finished number of tests/variants");
+            absoluteThreshold = (relativeThreshold * (double) variants.size()) / 100d;
         } else {
-            if (relative) {
-                relativeThreshold = userValue;
-                if (isFailFastAllVariants) {
-                    absoluteThreshold = (relativeThreshold * (double) variants.size()) / 100d;
-                } else {
-                    absoluteThreshold = (relativeThreshold * (double) tests.size()) / 100d;
-                }
-            } else {
-                absoluteThreshold = (long) userValue;
-                if (isFailFastAllVariants) {
-                    relativeThreshold = (absoluteThreshold * 100d) / (double) variants.size();
-                } else {
-                    relativeThreshold = (absoluteThreshold * 100d) / (double) tests.size();
-                }
-            }
-            output.println("    The suite will terminate once failure rate reaches " + getRelativeThresholdNice() + "% ("
-                    + getAbsoluteThresholdNice() + ") of total tests/variants (" + usedTotal + ")");
+            absoluteThreshold = (long) userValue;
+            relativeThreshold = (absoluteThreshold * 100d) / (double) variants.size();
         }
+        output.println("    The suite will terminate once failure rate reaches " + getRelativeThresholdNice() + "% (" + getAbsoluteThresholdNice() + ") of total tests (" + variants.size() + ")");
         output.println();
     }
 
@@ -120,42 +98,22 @@ public class FailFastKiller extends CountingResultCollector {
         int groupCounter = tests.get(r.getName());
         //we are counting each group down, so we can assure that the group is finished
         tests.put(r.getName(), groupCounter-1);
-        long wasFailed = hardErrors + failed;
         countResult(r);
-        long isFailed = hardErrors + failed;
-        if (isFailed > wasFailed) {
-            failures.add(r.getName());
-        }
         verifyState(r);
     }
 
     private void verifyState(TestResult r) {
         long totalFailed = failed + hardErrors;
-        if (System.getProperty("jcstress.failfast.countsoft") != null) {
+        if (includeSoftErrors) {
             totalFailed += softErrors;
         }
-        if (superRelative) {
-            double totalFinishedUpToNow;
-            if (isFailFastAllVariants) {
-                totalFinishedUpToNow = passed + failed + softErrors + hardErrors;
-            } else {
-                totalFinishedUpToNow = tests.values().stream().filter(a -> a <= 0).collect(Collectors.counting());
-            }
-            double currentAbsoluteThreshold = (relativeThreshold * totalFinishedUpToNow) / 100d;
-            //there must be enough finished to get to some reasonable numbers
-            if (currentAbsoluteThreshold > 1 && totalFailed > currentAbsoluteThreshold) {
+        if (breakInGroup) {
+            if (totalFailed >= absoluteThreshold) {
                 executor.setDiedFast();
             }
         } else {
-            if (isFailFastAllVariants) {
-                if (totalFailed > absoluteThreshold) {
-                    executor.setDiedFast();
-                }
-            } else {
-                //we have to ensure, that all tests in current group finished
-                if (failures.size() > absoluteThreshold && tests.get(r.getName()) <= 0) {
-                    executor.setDiedFast();
-                }
+            if (totalFailed > absoluteThreshold && tests.get(r.getName()) <= 0) {
+                executor.setDiedFast();
             }
         }
     }


### PR DESCRIPTION
Initial PoC

It currently show how to set up argument, and how the framework will be terminated. Feedback welcomed.  Should be finished soon

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903754](https://bugs.openjdk.org/browse/CODETOOLS-7903754): jcstress: Implement fail-on-error run option (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/jcstress.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/157.diff">https://git.openjdk.org/jcstress/pull/157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/157#issuecomment-2575481604)
</details>
