### PR TITLE
7903819: jcstress do not print structuralised results

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -160,8 +160,8 @@ public class JCStress {
 
         new TextReportPrinter(opts.verbosity(), collector).work();
         new HTMLReportPrinter(opts.getResultDest(), collector, out).work();
-        new XMLReportPrinter(opts.getResultDest(), collector, out, false, XMLReportPrinter.isErrorAsFailure(), XMLReportPrinter.isTestsuiteUsed()).work();
-        new XMLReportPrinter(opts.getResultDest(), collector, out, true, XMLReportPrinter.isErrorAsFailure(), XMLReportPrinter.isTestsuiteUsed()).work();
+        new XMLReportPrinter(opts.getResultDest(), collector, out, false).work();
+        new XMLReportPrinter(opts.getResultDest(), collector, out, true).work();
         new ExceptionReportPrinter(collector).work();
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -30,6 +30,7 @@ import org.openjdk.jcstress.infra.grading.ConsoleReportPrinter;
 import org.openjdk.jcstress.infra.grading.ExceptionReportPrinter;
 import org.openjdk.jcstress.infra.grading.TextReportPrinter;
 import org.openjdk.jcstress.infra.grading.HTMLReportPrinter;
+import org.openjdk.jcstress.infra.grading.XMLReportPrinter;
 import org.openjdk.jcstress.infra.runners.TestConfig;
 import org.openjdk.jcstress.infra.runners.TestList;
 import org.openjdk.jcstress.os.*;
@@ -157,10 +158,13 @@ public class JCStress {
         drc.dump();
         drc.close();
 
-        new TextReportPrinter(opts, collector).work();
-        new HTMLReportPrinter(opts, collector, out).work();
+        new TextReportPrinter(opts.verbosity(), collector).work();
+        new HTMLReportPrinter(opts.getResultDest(), collector, out).work();
+        new XMLReportPrinter(opts.getResultDest(), collector, out, false, XMLReportPrinter.isErrorAsFailure(), XMLReportPrinter.isTestsuiteUsed()).work();
+        new XMLReportPrinter(opts.getResultDest(), collector, out, true, XMLReportPrinter.isErrorAsFailure(), XMLReportPrinter.isTestsuiteUsed()).work();
         new ExceptionReportPrinter(collector).work();
     }
+
 
     private SortedSet<Integer> computeActorCounts(Set<String> tests) {
         SortedSet<Integer> counts = new TreeSet<>();
@@ -252,7 +256,7 @@ public class JCStress {
         Set<String> testsToPrint = new TreeSet<>();
         for (TestConfig test : configsWithScheduler.configs) {
             if (opts.verbosity().printAllTests()) {
-                testsToPrint.add(test.toDetailedTest());
+                testsToPrint.add(test.toDetailedTest(true));
             } else {
                 testsToPrint.add(test.name);
             }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -160,8 +160,12 @@ public class JCStress {
 
         new TextReportPrinter(opts.verbosity(), collector).work();
         new HTMLReportPrinter(opts.getResultDest(), collector, out).work();
-        new XMLReportPrinter(opts.getResultDest(), collector, out, false).work();
-        new XMLReportPrinter(opts.getResultDest(), collector, out, true).work();
+        if (XMLReportPrinter.getSparse(out)!=null) {
+            new XMLReportPrinter(opts.getResultDest(), collector, out, XMLReportPrinter.getSparse(out)).work();
+        } else {
+            new XMLReportPrinter(opts.getResultDest(), collector, out, false).work();
+            new XMLReportPrinter(opts.getResultDest(), collector, out, true).work();
+        }
         new ExceptionReportPrinter(collector).work();
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -39,7 +39,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
 
 /**
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
@@ -55,29 +54,15 @@ public class TestResult implements Serializable {
     private final List<String> vmErr;
     private transient TestGrading grading;
 
-    private static final Random r = new Random();
-    private final int failer;
-
     public TestResult(Status status) {
-        failer = r.nextInt(7);
-        switch (failer) {
-            case 0:  this.status=Status.TEST_ERROR; break;
-            case 1:  this.status=Status.NORMAL; break;
-            case 2:  this.status=Status.CHECK_TEST_ERROR; break;
-            case 3:  this.status=Status.API_MISMATCH; break;
-            case 4:  this.status=Status.TIMEOUT_ERROR; break;
-            case 5:  this.status=Status.VM_ERROR; break;
-            default: this.status = status;
-        }
+        this.status = status;
         this.states = new Counter<>();
         this.messages = new ArrayList<>();
         this.vmOut = new ArrayList<>();
         this.vmErr = new ArrayList<>();
-        fakeOutputs();
     }
 
     public TestResult(DataInputStream dis) throws IOException {
-        failer=10;
         status = Status.values()[dis.readInt()];
         states = new Counter<>(dis);
         messages = new ArrayList<>();
@@ -101,16 +86,6 @@ public class TestResult implements Serializable {
                 vmErr.add(dis.readUTF());
             }
         }
-        fakeOutputs();
-    }
-
-    private void fakeOutputs() {
-        messages.add("messages1");
-        messages.add("messages2");
-        vmOut.add("out1");
-        vmOut.add("out2");
-        vmErr.add("err1");
-        vmErr.add("err2");
     }
 
     public void write(DataOutputStream dos) throws IOException {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/collectors/TestResult.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 /**
  * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
@@ -54,15 +55,29 @@ public class TestResult implements Serializable {
     private final List<String> vmErr;
     private transient TestGrading grading;
 
+    private static final Random r = new Random();
+    private final int failer;
+
     public TestResult(Status status) {
-        this.status = status;
+        failer = r.nextInt(7);
+        switch (failer) {
+            case 0:  this.status=Status.TEST_ERROR; break;
+            case 1:  this.status=Status.NORMAL; break;
+            case 2:  this.status=Status.CHECK_TEST_ERROR; break;
+            case 3:  this.status=Status.API_MISMATCH; break;
+            case 4:  this.status=Status.TIMEOUT_ERROR; break;
+            case 5:  this.status=Status.VM_ERROR; break;
+            default: this.status = status;
+        }
         this.states = new Counter<>();
         this.messages = new ArrayList<>();
         this.vmOut = new ArrayList<>();
         this.vmErr = new ArrayList<>();
+        fakeOutputs();
     }
 
     public TestResult(DataInputStream dis) throws IOException {
+        failer=10;
         status = Status.values()[dis.readInt()];
         states = new Counter<>(dis);
         messages = new ArrayList<>();
@@ -86,6 +101,16 @@ public class TestResult implements Serializable {
                 vmErr.add(dis.readUTF());
             }
         }
+        fakeOutputs();
+    }
+
+    private void fakeOutputs() {
+        messages.add("messages1");
+        messages.add("messages2");
+        vmOut.add("out1");
+        vmOut.add("out2");
+        vmErr.add("err1");
+        vmErr.add("err2");
     }
 
     public void write(DataOutputStream dos) throws IOException {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -64,7 +64,7 @@ public class HTMLReportPrinter {
         out.println("  HTML report generated at " + dir.getAbsolutePath() + File.separator + getMainFileName());
     }
 
-    public String getMainFileName() {
+    private String getMainFileName() {
         return "index.html";
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -174,7 +174,7 @@ public class HTMLReportPrinter {
         emitTestReports(ReportUtils.byName(collector.getTestResults()));
     }
 
-    private SortedMap<String, String> getEnv(List<TestResult> ts) {
+    static SortedMap<String, String> getEnv(List<TestResult> ts) {
         SortedMap<String, String> env = new TreeMap<>();
         for (TestResult result : ts) {
             if (result != null) {
@@ -356,10 +356,7 @@ public class HTMLReportPrinter {
         }
 
         List<TestResult> sorted = new ArrayList<>(results);
-        sorted.sort(Comparator
-                .comparing((TestResult t) -> t.getConfig().getCompileMode())
-                .thenComparing((TestResult t) -> t.getConfig().getSchedulingClass().toString())
-                .thenComparing((TestResult t) -> StringUtils.join(t.getConfig().jvmArgs, ",")));
+        resultsOrder(sorted);
 
         o.println("<h3>Environment</h3>");
         o.println("<table>");
@@ -493,6 +490,13 @@ public class HTMLReportPrinter {
         }
 
         printFooter(o);
+    }
+
+    static void resultsOrder(List<TestResult> sorted) {
+        sorted.sort(Comparator
+                .comparing((TestResult t) -> t.getConfig().getCompileMode())
+                .thenComparing((TestResult t) -> t.getConfig().getSchedulingClass().toString())
+                .thenComparing((TestResult t) -> StringUtils.join(t.getConfig().jvmArgs, ",")));
     }
 
     private void resultHeader(PrintWriter o, TestResult r) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/HTMLReportPrinter.java
@@ -25,7 +25,6 @@
 package org.openjdk.jcstress.infra.grading;
 
 
-import org.openjdk.jcstress.Options;
 import org.openjdk.jcstress.annotations.Expect;
 import org.openjdk.jcstress.infra.Status;
 import org.openjdk.jcstress.infra.TestInfo;
@@ -57,19 +56,23 @@ public class HTMLReportPrinter {
     private final InProcessCollector collector;
     private int cellStyle = 1;
 
-    public HTMLReportPrinter(Options opts, InProcessCollector collector, PrintStream out) {
+    public HTMLReportPrinter(String resultDir, InProcessCollector collector, PrintStream out) {
         this.collector = collector;
-        this.resultDir = opts.getResultDest();
+        this.resultDir = resultDir;
         File dir = new File(resultDir);
         dir.mkdirs();
-        out.println("  HTML report generated at " + dir.getAbsolutePath() + File.separator + "index.html");
+        out.println("  HTML report generated at " + dir.getAbsolutePath() + File.separator + getMainFileName());
+    }
+
+    public String getMainFileName() {
+        return "index.html";
     }
 
     public void work() throws FileNotFoundException {
         List<TestResult> byName = ReportUtils.mergedByName(collector.getTestResults());
         Collections.sort(byName, Comparator.comparing(TestResult::getName));
 
-        PrintWriter output = new PrintWriter(resultDir + "/index.html");
+        PrintWriter output = new PrintWriter(resultDir + File.separator + getMainFileName());
 
         printHeader(output);
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -84,6 +84,13 @@ public class ReportUtils {
         }
         return result;
     }
+    public static Multimap<String, TestResult> byDetailedName(Collection<TestResult> src) {
+        Multimap<String, TestResult> result = new HashMultimap<>();
+        for (TestResult r : mergedByConfig(src)) {
+            result.put(r.getConfig().toDetailedTest(false), r);
+        }
+        return result;
+    }
 
     private static TestResult merged(TestConfig config, Collection<TestResult> mergeable) {
         Counter<String> counter = new Counter<>();

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/TextReportPrinter.java
@@ -48,10 +48,10 @@ public class TextReportPrinter {
     private final PrintWriter pw;
     private final Set<TestResult> emittedTests;
 
-    public TextReportPrinter(Options opts, InProcessCollector collector) {
+    public TextReportPrinter(Verbosity verbosity, InProcessCollector collector) {
         this.collector = collector;
         this.pw = new PrintWriter(System.out, true);
-        this.verbosity = opts.verbosity();
+        this.verbosity = verbosity;
         this.emittedTests = new HashSet<>();
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -181,14 +181,6 @@ public class XMLReportPrinter {
         }
     }
 
-    private static String getRoughCount(TestResult r) {
-        long sum = r.getTotalCount();
-        if (sum > 10) {
-            return "10^" + (int) Math.floor(Math.log10(sum));
-        } else {
-            return String.valueOf(sum);
-        }
-    }
 
     private static void printSeed(PrintWriter o, TestResult r) {
         if (r.getConfig().getSeed() != null) {
@@ -567,6 +559,15 @@ public class XMLReportPrinter {
     /// /// /////////candidates to remove
     /// /// /////////candidates to remove
     /// /// /////////candidates to remove
+
+    private static String getRoughCount(TestResult r) {
+        long sum = r.getTotalCount();
+        if (sum > 10) {
+            return "10^" + (int) Math.floor(Math.log10(sum));
+        } else {
+            return String.valueOf(sum);
+        }
+    }
 
     private void printXTests(List<TestResult> byName,
                              PrintWriter output,

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -76,9 +76,9 @@ public class XMLReportPrinter {
     }
 
     //how to deal with sofrt errors like api mishmash or similar
-    public static final String SOFT_ERROR_AS = "jcstress.report.xml.softErrorAs"; //pass/fail/skip defaults to skip
+    public static final String SOFT_ERROR_AS = "jcstress.report.xml.softErrorAs"; //pass/fail/skip/error defaults to skip
     //how to deal with hard errors. Those may be timout, but also segfaulting vm
-    public static final String HARD_ERROR_AS = "jcstress.report.xml.hardErrorAs"; //pass/fail defaults to fail
+    public static final String HARD_ERROR_AS = "jcstress.report.xml.hardErrorAs"; //pass/fail/skip/error defaults to fail
     //only for full (non-saprse) output, will wrap each family by its <testsuite name>
     public static final String USE_TESTSUITES = "jcstress.report.xml.sparse.testsuites";
     //in case of sued testsuiotes, will not replicate the name of suite in test name.
@@ -90,11 +90,11 @@ public class XMLReportPrinter {
     //this is for tools,m which do nto show stdout/err properly
     //also it is saving a bit of space, but is loosing the granularity
     public static final String STDOUTERR_TO_FAILURE = "jcstress.report.xml.souterr2failure";
-    //vill validate final xmls
+    //will validate final xmls
     public static final String VALIDATE = "jcstress.report.xml.validate";
     //will keep non standart (but widelyused) elements uncomment
     public static final String UNCOMMENT_NONSTANDART = "jcstress.report.xml.nonstandart";
-    //by default both reprots are printed. By setting it to true or false, wil linclude only sparse ot full
+    //by default both reports are printed. By setting it to true or false, will include only sparse ot full
     public static final String SPARSE = "jcstress.report.xml.sparse"; //true/false/null
 
     private final String resultDir;
@@ -637,7 +637,7 @@ public class XMLReportPrinter {
 
     public static JunitResult testsToJunitResult(Collection<TestResult> results) {
         boolean hadError = false;
-        int coutSkipped = 0;
+        int countSkipped = 0;
         for (TestResult result : results) {
             if (testToJunitResult(result) == JunitResult.failure) {
                 //if there was failure in sub set, return whole group as failure
@@ -647,7 +647,7 @@ public class XMLReportPrinter {
                 hadError = true;
             }
             if (testToJunitResult(result) == JunitResult.skipped) {
-                coutSkipped++;
+                countSkipped++;
             }
         }
         //no failure, bute errors presented
@@ -655,7 +655,7 @@ public class XMLReportPrinter {
             return JunitResult.error;
         }
         //no failure, no error, was all skipped?
-        if (coutSkipped == results.size()) {
+        if (countSkipped == results.size()) {
             return JunitResult.skipped;
         }
         return JunitResult.pass;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.infra.grading;
+
+
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.infra.Status;
+import org.openjdk.jcstress.infra.TestInfo;
+import org.openjdk.jcstress.infra.collectors.InProcessCollector;
+import org.openjdk.jcstress.infra.collectors.TestResult;
+import org.openjdk.jcstress.infra.runners.TestConfig;
+import org.openjdk.jcstress.infra.runners.TestList;
+import org.openjdk.jcstress.os.SchedulingClass;
+import org.openjdk.jcstress.util.Multimap;
+import org.openjdk.jcstress.util.StringUtils;
+import org.openjdk.jcstress.vm.CompileMode;
+
+import java.awt.Color;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+
+/**
+ * Prints HTML reports.
+ *
+ * @author Aleksey Shipilev (aleksey.shipilev@oracle.com)
+ */
+public class XMLReportPrinter {
+
+    public static final String ERROR_AS_FAILURE = "jcstress.xml.error2failure";
+    public static final String USE_TESTSUITES = "jcstress.xml.testsuites";
+    private final String resultDir;
+    private final InProcessCollector collector;
+    private final boolean sparse;
+    private final boolean errorAsFailure;
+    private final boolean useTestsuites;
+
+
+    public static boolean isErrorAsFailure() {
+        return "true".equals(System.getProperty(XMLReportPrinter.ERROR_AS_FAILURE));
+    }
+
+    public static boolean isTestsuiteUsed() {
+        return "true".equals(System.getProperty(XMLReportPrinter.USE_TESTSUITES));
+    }
+
+    public XMLReportPrinter(String resultDir, InProcessCollector collector, PrintStream out, boolean sparse, boolean errorAsFailure, boolean useTestsuites) {
+        //sparse true -ALL_MATCHING
+        //sparse false - as ALL_MATCHING_COMBINATIONS
+        //jednou smichat, jednou ne. Varovani kolik jich bude
+        //-xml true/false, defaults to sparse
+        this.collector = collector;
+        this.resultDir = resultDir;
+        this.sparse = sparse;
+        this.errorAsFailure = errorAsFailure;
+        this.useTestsuites = useTestsuites;
+        File dir = new File(resultDir);
+        dir.mkdirs();
+        out.println("  " + getSparseString() + " XML report generated at " + dir.getAbsolutePath() + File.separator + getMainFileName() + ". " + ERROR_AS_FAILURE + "=" + errorAsFailure + ", " + USE_TESTSUITES + "=" + useTestsuites);
+    }
+
+    public String getMainFileName() {
+        return "junit-" + getSparseString() + ".xml";
+    }
+
+    private String getSparseString() {
+        return sparse ? "sparse" : "full";
+    }
+
+    public void work() throws FileNotFoundException {
+        List<TestResult> byName = sparse ? ReportUtils.mergedByName(collector.getTestResults()) : new ArrayList<>(collector.getTestResults());
+        Collections.sort(byName, Comparator.comparing(TestResult::getName));
+
+        PrintWriter output = new PrintWriter(resultDir + File.separator + getMainFileName());
+
+        {
+            int passedCount = 0;
+            int failedCount = 0;
+            int sanityFailedCount = 0;
+            for (TestResult result : byName) {
+                if (result.status() == Status.NORMAL) {
+                    if (result.grading().isPassed) {
+                        passedCount++;
+                    } else {
+                        failedCount++;
+                    }
+                } else {
+                    if (result.status() == Status.API_MISMATCH) {
+                        sanityFailedCount++;
+                    } else {
+                        failedCount++;
+                    }
+                }
+            }
+
+            int totalCount = passedCount + failedCount + sanityFailedCount;
+
+            output.println("<?xml version='1.0' encoding='UTF-8'?>");
+            output.println("<testsuite name='jcstress'" +
+                    " tests='" + totalCount + "'" +
+                    " failures='" + failedCount + "'" +
+                    " errors='" + 0/*fixme*/ + "'" +
+                    " skipped='" + sanityFailedCount + "' " +
+                    " time='" + 0/*fixme*/ + "'" +
+                    " timestamp='" + new Date().toString() + ">");
+
+        }
+        {
+            SortedMap<String, String> env = getEnv(byName);
+
+            output.println("  <properties>");
+            for (Map.Entry<String, String> entry : env.entrySet()) {
+                output.println("    <property name='"+entry.getKey()+"' value='"+entry.getValue()+"' />");
+            }
+            output.println("    <property name='sparse' value='"+sparse+"' />");
+            output.println("    <property name='"+useTestsuites+"' value='"+isTestsuiteUsed()+"' />");
+            output.println("    <property name='"+errorAsFailure+"' value='"+isErrorAsFailure()+"' />");
+            output.println("  </properties>");
+        }
+
+        output.println("<!--");
+        printXTests(byName, output,
+                "FAILED tests",
+                "Strong asserts were violated. Correct implementations should have no assert failures here.",
+                r -> r.status() == Status.NORMAL && !r.grading().isPassed);
+
+        printXTests(byName, output,
+                "ERROR tests",
+                "Tests break for some reason, other than failing the assert. Correct implementations should have none.",
+                r -> r.status() != Status.NORMAL && r.status() != Status.API_MISMATCH);
+
+        printXTests(byName, output,
+                "INTERESTING tests",
+                "Some interesting behaviors observed. This is for the plain curiosity.",
+                r -> r.status() == Status.NORMAL && r.grading().hasInteresting);
+        output.println("-->");
+
+        printXTests(byName, output,
+                "All tests",
+                "",
+                r -> true);
+        emitTestReports(ReportUtils.byName(collector.getTestResults()), output);
+        output.close();
+    }
+
+    private SortedMap<String, String> getEnv(List<TestResult> ts) {
+        SortedMap<String, String> env = new TreeMap<>();
+        for (TestResult result : ts) {
+            if (result != null) {
+                for (Map.Entry<String, String> kv : result.getEnv().entries().entrySet()) {
+                    String key = kv.getKey();
+                    String value = kv.getValue();
+                    String lastV = env.get(key);
+                    if (lastV == null) {
+                        env.put(key, value);
+                    } else {
+                        // Some VMs have these keys pre-populated with the command line,
+                        // which can have port definitions, PIDs, etc, and naturally
+                        // clash from launch to launch.
+                        if (key.equals("cmdLine")) continue;
+                        if (key.equals("launcher")) continue;
+
+                        if (!lastV.equalsIgnoreCase(value)) {
+                            System.err.println("Mismatched environment for key = " + key + ", was = " + lastV + ", now = " + value);
+                        }
+                    }
+                }
+            }
+        }
+        return env;
+    }
+
+
+
+    private void printXTests(List<TestResult> byName,
+                             PrintWriter output,
+                             String header,
+                             String subheader,
+                             Predicate<TestResult> filterResults) {
+        output.println("*** " + header + " ***");
+        output.println("" + subheader + "");
+        boolean hadAnyTests = false;
+        for (TestResult result : byName) {
+            if (filterResults.test(result)) {
+                if (result.status() == Status.NORMAL) {
+                    emitTest(output, result);
+                } else {
+                    emitTestFailure(output, result);
+                }
+                hadAnyTests = true;
+            }
+        }
+        if (!hadAnyTests) {
+            output.println("None!");
+        }
+    }
+
+    public void emitTest(PrintWriter output, TestResult result) {
+        TestGrading grading = result.grading();
+        if (grading.isPassed) {
+            output.println("  Passed - " + StringUtils.chunkName(result.getName()) + " " +getRoughCount(result));
+        } else {
+            output.println("  FAILED - " + StringUtils.chunkName(result.getName()) + " " +getRoughCount(result));
+        }
+
+        if (grading.hasInteresting) {
+            output.println("    was interesting");
+        }
+    }
+
+    public void emitTestFailure(PrintWriter output, TestResult result) {
+        output.println("   FAILED - " + StringUtils.chunkName(result.getName()) + " " +getRoughCount(result));
+        switch (result.status()) {
+            case API_MISMATCH:
+                output.println("      API MISMATCH - Sanity check failed, API mismatch?");
+                break;
+            case TEST_ERROR:
+            case CHECK_TEST_ERROR:
+                output.println("      ERROR - Error while running the test");
+                break;
+            case TIMEOUT_ERROR:
+                output.println("      ERROR - Timeout while running the test");
+                break;
+            case VM_ERROR:
+                output.println("      VM ERROR - Error running the VM");
+                break;
+        }
+    }
+
+    public static String getRoughCount(TestResult r) {
+        long sum = r.getTotalCount();
+        if (sum > 10) {
+            return "10^" + (int) Math.floor(Math.log10(sum));
+        } else {
+            return String.valueOf(sum);
+        }
+    }
+
+    private void emitTestReports(Multimap<String, TestResult> multiByName, PrintWriter local) {
+        multiByName.keys().parallelStream().forEach(name -> {
+            TestInfo test = TestList.getInfo(name);
+            local.println(resultDir + "/" + name + ".html would be...");
+            emitTestReport(local, multiByName.get(name), test);
+            local.close();
+        });
+    }
+
+    public void emitTestReport(PrintWriter o, Collection<TestResult> results, TestInfo test) {
+        o.println("subtests of: " + test.name());
+        o.println("  Description and references:");
+        o.println("  * " + test.description() + "");
+        for (String ref : test.refs()) {
+            o.println("    " + ref);
+        }
+
+        List<TestResult> sorted = new ArrayList<>(results);
+        sorted.sort(Comparator
+                .comparing((TestResult t) -> t.getConfig().getCompileMode())
+                .thenComparing((TestResult t) -> t.getConfig().getSchedulingClass().toString())
+                .thenComparing((TestResult t) -> StringUtils.join(t.getConfig().jvmArgs, ",")));
+
+
+        o.println("<properties>");
+        for (Map.Entry<String, String> entry : getEnv(sorted).entrySet()) {
+            o.println("<property  name='" + entry.getKey() + "' value=" + entry.getValue() + "' />");
+        }
+        o.println("</properties>");
+
+        Set<String> keys = new TreeSet<>();
+        for (TestResult r : sorted) {
+            keys.addAll(r.getStateKeys());
+        }
+
+// fixme use later? Defiitley ther emust be for (String key : keys) {for (TestResult r : sorted) {}} of results
+//                GradingResult c = r.grading().gradingResults.get(key);
+//                    o.println("<td>" + c.expect + "</td>");
+//                    o.println("<td>" + c.description + "</td>");
+
+
+
+        for (TestResult r : sorted) {
+            String color = ReportUtils.statusToPassed(r) ? "green" : "red";
+            String label = ReportUtils.statusToLabel(r);
+            o.println(color + " " + label + " " + r.getConfig().toDetailedTest(false)); //TODO, keep using  the seed shading
+// this is that multiplication. Probably just span it to failure if any?
+//            for (String key : keys) {
+//                GradingResult c = r.grading().gradingResults.get(key);
+//                if (c != null) {
+//                    o.println("<td align='right' width='" + 100D / keys.size() + "%' bgColor=" + selectHTMLColor(c.expect, c.count == 0) + ">" + c.count + "</td>");
+//                } else {
+//                    o.println("<td align='right' width='" + 100D / keys.size() + "%' bgColor=" + selectHTMLColor(Expect.ACCEPTABLE, true) + ">0</td>");
+//                }
+//            }
+        }
+
+
+        o.println("<h3>Messages</h3>");
+
+        for (TestResult r : sorted) {
+            if (!r.getMessages().isEmpty()) {
+                resultHeader(o, r);
+                o.println("<pre>");
+                for (String data : r.getMessages()) {
+                    o.println(data);
+                }
+                o.println("</pre>");
+                o.println();
+            }
+        }
+
+        o.println("<h3>VM Output Streams</h3>");
+
+        for (TestResult r : sorted) {
+            if (!r.getVmOut().isEmpty()) {
+                resultHeader(o, r);
+                o.println("<pre>");
+                for (String data : r.getVmOut()) {
+                    o.println(data);
+                }
+                o.println("</pre>");
+                o.println();
+            }
+        }
+
+        o.println("<h3>VM Error Streams</h3>");
+
+        for (TestResult r : sorted) {
+            if (!r.getVmErr().isEmpty()) {
+                resultHeader(o, r);
+                o.println("<pre>");
+                for (String data : r.getVmErr()) {
+                    o.println(data);
+                }
+                o.println("</pre>");
+                o.println();
+            }
+        }
+
+    }
+
+    private void resultHeader(PrintWriter o, TestResult r) {
+        TestConfig cfg = r.getConfig();
+        o.println("<p><b>");
+        o.println("<pre>" + CompileMode.description(cfg.compileMode, cfg.actorNames) + "</pre>");
+        o.println("<pre>" + SchedulingClass.description(cfg.shClass, cfg.actorNames) + "</pre>");
+        o.println("");
+        if (!cfg.jvmArgs.isEmpty()) {
+            o.println("<pre>" + cfg.jvmArgs + "</pre>");
+        }
+        o.println("</b></p>");
+    }
+
+    public String selectHTMLColor(Expect type, boolean isZero) {
+        String rgb = Integer.toHexString(selectColor(type, isZero).getRGB());
+        return "#" + rgb.substring(2);
+    }
+
+    public Color selectColor(Expect type, boolean isZero) {
+        switch (type) {
+            case ACCEPTABLE:
+                return isZero ? Color.LIGHT_GRAY : Color.GREEN;
+            case FORBIDDEN:
+                return isZero ? Color.LIGHT_GRAY : Color.RED;
+            case ACCEPTABLE_INTERESTING:
+                return isZero ? Color.LIGHT_GRAY : Color.CYAN;
+            case UNKNOWN:
+                return Color.RED;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -272,15 +272,7 @@ public class XMLReportPrinter {
 
             output.println("  <properties>");
             printBaseProperties(byName, output);
-            output.println("    <property name='sparse' value='" + sparse + "' />");
-            output.println("    <property name='" + USE_TESTSUITES + "' value='" + isTestsuiteUsed() + "' />");
-            output.println("    <property name='" + TESTSUITES_STRIPNAMES + "' value='" + isStripNames() + "' />");
-            output.println("    <property name='" + SOFT_ERROR_AS + "' value='" + getSoftErrorAs() + "' />");
-            output.println("    <property name='" + HARD_ERROR_AS + "' value='" + getHardErrorAs() + "' />");
-            output.println("    <property name='" + DUPLICATE_PROPERTIES + "' value='" + isDuplicateProperties() + "' />");
-            output.println("    <property name='" + NO_COMMENTS + "' value='" + isNoComments() + "' />");
-            output.println("    <property name='" + STDOUTERR_TO_FAILURE + "' value='" + isStdoutErrToFailure() + "' />");
-            output.println("    <property name='" + SPARSE + "' value='" + Objects.toString(getSparse(null)) + "' />");
+            printXmlReporterProperties(output);
             output.println("  </properties>");
         }
 // we have create dsummary, lets try to prnit the rest from merged info
@@ -311,6 +303,18 @@ public class XMLReportPrinter {
         if (isValidate()) {
             validate(filePath);
         }
+    }
+
+    private void printXmlReporterProperties(PrintWriter output) {
+        output.println("    <property name='sparse' value='" + sparse + "' />");
+        output.println("    <property name='" + USE_TESTSUITES + "' value='" + isTestsuiteUsed() + "' />");
+        output.println("    <property name='" + TESTSUITES_STRIPNAMES + "' value='" + isStripNames() + "' />");
+        output.println("    <property name='" + SOFT_ERROR_AS + "' value='" + getSoftErrorAs() + "' />");
+        output.println("    <property name='" + HARD_ERROR_AS + "' value='" + getHardErrorAs() + "' />");
+        output.println("    <property name='" + DUPLICATE_PROPERTIES + "' value='" + isDuplicateProperties() + "' />");
+        output.println("    <property name='" + NO_COMMENTS + "' value='" + isNoComments() + "' />");
+        output.println("    <property name='" + STDOUTERR_TO_FAILURE + "' value='" + isStdoutErrToFailure() + "' />");
+        output.println("    <property name='" + SPARSE + "' value='" + Objects.toString(getSparse(null)) + "' />");
     }
 
     private void emitTestReports(Multimap<String, TestResult> multiByName, PrintWriter local) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -340,7 +340,7 @@ public class XMLReportPrinter {
         if (sparse) {
             List<TestResult> sorted = new ArrayList<>(results);
             HTMLReportPrinter.resultsOrder(sorted);
-            outw.println("  <testcase class='jcstress' name='" + test.name() + "' time='" + getTime(results, false) + "'>");
+            outw.println("  " + getOpenTestcase(results, test.name()));
             printPropertiesPerTest(outw, test, null, sorted);
             printMainTestBody(outw, sorted, true);
             outw.println("</testcase>");
@@ -356,7 +356,7 @@ public class XMLReportPrinter {
                 if (isTestsuiteUsed() && isStripNames()) {
                     testName = r.getConfig().getTestVariant(false);
                 }
-                outw.println("  <testcase class='jcstress' name='" + testName + "' time='" + getTime(Arrays.asList(r), false) + "'>");
+                outw.println("  " + getOpenTestcase(Arrays.asList(r),testName));
                 printPropertiesPerTest(outw, test, r, sorted);
                 printMainTestBody(outw, Arrays.asList(r), null);
                 outw.println("</testcase>");
@@ -366,6 +366,10 @@ public class XMLReportPrinter {
             }
         }
 
+    }
+
+    private static String getOpenTestcase(Collection<TestResult> results, String test) {
+        return "<testcase classname='jcstress' name='" + test + "' time='" + getTime(results, false) + "'>";
     }
 
     private static String getTime(Collection<TestResult> results, boolean toNicestring) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -174,7 +174,11 @@ public class XMLReportPrinter {
                 "All tests",
                 "",
                 r -> true);
-        emitTestReports(ReportUtils.byName(collector.getTestResults()), output);
+        if (sparse) {
+            emitTestReports(ReportUtils.byName(collector.getTestResults()), output);
+        } else {
+            emitTestReports(ReportUtils.byDetailedName(collector.getTestResults()), output);
+        }
         output.close();
     }
 
@@ -272,8 +276,8 @@ public class XMLReportPrinter {
     }
 
     private void emitTestReports(Multimap<String, TestResult> multiByName, PrintWriter local) {
-        multiByName.keys().parallelStream().forEach(name -> {
-            TestInfo test = TestList.getInfo(name);
+        multiByName.keys().stream().forEach(name -> {
+            TestInfo test = TestList.getInfo(name.split(" ")[0]);
             local.println(resultDir + "/" + name + ".html would be...");
             emitTestReport(local, multiByName.get(name), test);
             local.close();
@@ -383,11 +387,6 @@ public class XMLReportPrinter {
             o.println("<pre>" + cfg.jvmArgs + "</pre>");
         }
         o.println("</b></p>");
-    }
-
-    public String selectHTMLColor(Expect type, boolean isZero) {
-        String rgb = Integer.toHexString(selectColor(type, isZero).getRGB());
-        return "#" + rgb.substring(2);
     }
 
     public Color selectColor(Expect type, boolean isZero) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -92,8 +92,8 @@ public class XMLReportPrinter {
     public static final String STDOUTERR_TO_FAILURE = "jcstress.report.xml.souterr2failure";
     //vill validate final xmls
     public static final String VALIDATE = "jcstress.report.xml.validate";
-    //will nto include comments (if any)
-    public static final String NO_COMMENTS = "jcstress.report.xml.nocomments";
+    //will keep non standart (but widelyused) elements uncomment
+    public static final String UNCOMMENT_NONSTANDART = "jcstress.report.xml.nonstandart";
     //by default both reprots are printed. By setting it to true or false, wil linclude only sparse ot full
     public static final String SPARSE = "jcstress.report.xml.sparse"; //true/false/null
 
@@ -168,7 +168,7 @@ public class XMLReportPrinter {
     }
 
     private static boolean isNoComments() {
-        return System.getProperty(XMLReportPrinter.NO_COMMENTS) != null;
+        return System.getProperty(XMLReportPrinter.UNCOMMENT_NONSTANDART) != null;
     }
 
     private static String printProperty(String key, boolean value) {
@@ -322,7 +322,7 @@ public class XMLReportPrinter {
         output.println("    " + printProperty(SOFT_ERROR_AS, getSoftErrorAs().toString()));
         output.println("    " + printProperty(HARD_ERROR_AS, getHardErrorAs().toString()));
         output.println("    " + printProperty(DUPLICATE_PROPERTIES, isDuplicateProperties()));
-        output.println("    " + printProperty(NO_COMMENTS, isNoComments()));
+        output.println("    " + printProperty(UNCOMMENT_NONSTANDART, isNoComments()));
         output.println("    " + printProperty(STDOUTERR_TO_FAILURE, isStdoutErrToFailure()));
         output.println("    " + printProperty(SPARSE, Objects.toString(getSparse(null))));
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -94,7 +94,7 @@ public class XMLReportPrinter {
         out.println("  " + getSparseString() + " XML report generated at " + dir.getAbsolutePath() + File.separator + getMainFileName() + ". " + ERROR_AS_FAILURE + "=" + errorAsFailure + ", " + USE_TESTSUITES + "=" + useTestsuites);
     }
 
-    public String getMainFileName() {
+    private String getMainFileName() {
         return "junit-" + getSparseString() + ".xml";
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -79,6 +79,7 @@ public class XMLReportPrinter {
     public static final String USE_TESTSUITES = "jcstress.report.xml.sparse.testsuites";
     public static final String TESTSUITES_STRIPNAMES = "jcstress.report.xml.sparse.stripNames";
     public static final String DUPLICATE_PROPERTIES = "jcstress.report.xml.properties.dupliate";
+    public static final String STDOUTERR_TO_FAILURE = "jcstress.report.xml.souterr2failure";
     public static final String VALIDATE = "jcstress.report.xml.validate";
     public static final String NO_COMMENTS = "jcstress.report.xml.nocomments";
     public static final String SPARSE = "jcstress.report.xml.sparse";
@@ -132,6 +133,10 @@ public class XMLReportPrinter {
 
     private static boolean isTestsuiteUsed() {
         return System.getProperty(XMLReportPrinter.USE_TESTSUITES) != null;
+    }
+
+    private static boolean isStdoutErrToFailure() {
+        return System.getProperty(XMLReportPrinter.STDOUTERR_TO_FAILURE) != null;
     }
 
     private static boolean isStripNames() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -196,10 +196,18 @@ public class XMLReportPrinter {
 
     private static String getSeed(TestResult r) {
         if (r.getConfig().getSeed() != null) {
-            return ("          " + printProperty("seed", r.getConfig().getSeed()) + "\n");
+            return ("          " + printProperty("seed", getCleanSeed(r)) + "\n");
         } else {
             return null;
         }
+    }
+
+    private static String getCleanSeed(TestResult r) {
+        String[] args = r.getConfig().getSeed().split("=");
+        if (args.length>1) {
+            return args[1];
+        }
+        return args[0];
     }
 
     private static String getRefs(TestInfo test) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -34,10 +34,7 @@ import org.openjdk.jcstress.infra.runners.TestList;
 import org.openjdk.jcstress.os.SchedulingClass;
 import org.openjdk.jcstress.util.Multimap;
 import org.openjdk.jcstress.vm.CompileMode;
-import org.w3c.dom.CDATASection;
-import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -45,12 +42,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -59,7 +50,6 @@ import javax.xml.validation.Validator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.net.InetAddress;
@@ -688,42 +678,4 @@ public class XMLReportPrinter {
                 throw new IllegalStateException("Illegal status: " + result.status());
         }
     }
-
-    public static void main(String... args) throws ParserConfigurationException, TransformerException {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-
-        Document doc = docBuilder.newDocument();
-        Comment comment1 = doc.createComment("passed 4");
-        doc.appendChild(comment1);
-        Element testsuite = doc.createElement("testsuite");
-        testsuite.setAttribute("failed", "5");
-        testsuite.setAttribute("total", "10");
-        testsuite.setAttribute("error", "8");
-        testsuite.setAttribute("skipped", "9");
-        doc.appendChild(testsuite);
-        Comment comment2 = doc.createComment("passed 5");
-        testsuite.appendChild(comment2);
-        Element testcase = doc.createElement("testcase");
-        testsuite.appendChild(testcase);
-        testcase.setAttribute("classname", "jcstress");
-        testcase.setAttribute("name", "org.openjdk.jcstress.tests.copy.manual.objects.plain.StringTest");
-        Element failure = doc.createElement("failure");
-        CDATASection cdataSection = doc.createCDATASection("more\nlines\nhere");
-        failure.appendChild(cdataSection);
-        testcase.appendChild(failure);
-        writeXml(doc, System.out);
-
-    }
-
-    // write doc to output stream
-    private static void writeXml(Document doc, OutputStream output) throws TransformerException {
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-        DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(output);
-        transformer.transform(source, result);
-    }
-
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/XMLReportPrinter.java
@@ -148,8 +148,8 @@ public class XMLReportPrinter {
                 output.println("    <property name='"+entry.getKey()+"' value='"+entry.getValue()+"' />");
             }
             output.println("    <property name='sparse' value='"+sparse+"' />");
-            output.println("    <property name='"+useTestsuites+"' value='"+isTestsuiteUsed()+"' />");
-            output.println("    <property name='"+errorAsFailure+"' value='"+isErrorAsFailure()+"' />");
+            output.println("    <property name='"+USE_TESTSUITES+"' value='"+isTestsuiteUsed()+"' />");
+            output.println("    <property name='"+ERROR_AS_FAILURE+"' value='"+isErrorAsFailure()+"' />");
             output.println("  </properties>");
         }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -35,6 +35,7 @@ import org.openjdk.jcstress.vm.VMSupport;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestConfig implements Serializable {
@@ -246,13 +247,12 @@ public class TestConfig implements Serializable {
     }
 
 
-    public String toDetailedTest() {
+    public String getTestVariant(boolean seed) {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
-        StringBuilder verboseOutput = new StringBuilder(name);
-        verboseOutput.append(" {")
-                .append(actorNames)
+        StringBuilder idString = new StringBuilder();
+        idString.append(actorNames)
                 .append(", spinLoopStyle: ").append(spinLoopStyle)
                 .append(", threads: ").append(threads)
                 .append(", forkId: ").append(forkId)
@@ -262,7 +262,26 @@ public class TestConfig implements Serializable {
                 .append(", strideSize: ").append(strideSize)
                 .append(", strideCount: ").append(strideCount)
                 .append(", cpuMap: ").append(cpuMap)
-                .append(", ").append(jvmArgs)
+                .append(", ").append(seed ? jvmArgs : maskSeed(jvmArgs));
+        return idString.toString();
+    }
+
+    private List<String> maskSeed(List<String> jvmArgs) {
+        List<String> argsCopy = new ArrayList<>(jvmArgs.size());
+        for (String arg : jvmArgs) {
+            if (arg.startsWith("-XX:StressSeed=")) {
+                argsCopy.add(arg.replaceAll("[0-9]+", "yyyyyyyy"));
+            } else {
+                argsCopy.add(arg);
+            }
+        }
+        return argsCopy;
+    }
+
+    public String toDetailedTest(boolean seed) {
+        StringBuilder verboseOutput = new StringBuilder(name);
+        verboseOutput.append(" {")
+                .append(getTestVariant(seed))
                 .append("}");
         return verboseOutput.toString();
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -247,7 +247,7 @@ public class TestConfig implements Serializable {
     }
 
 
-    public String getTestVariant(boolean seed) {
+    public String getTestVariant(boolean keepSeed) {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
@@ -262,7 +262,7 @@ public class TestConfig implements Serializable {
                 .append(", shClass: ").append(shClass)
                 .append(", strideSize: ").append(strideSize)
                 .append(", strideCount: ").append(strideCount)
-                .append(", ").append(seed ? jvmArgs : maskSeed(jvmArgs));
+                .append(", ").append(keepSeed ? jvmArgs : maskSeed(jvmArgs));
         return idString.toString();
     }
 
@@ -278,10 +278,10 @@ public class TestConfig implements Serializable {
         return argsCopy;
     }
 
-    public String toDetailedTest(boolean seed) {
+    public String toDetailedTest(boolean keepSeed) {
         StringBuilder verboseOutput = new StringBuilder(name);
         verboseOutput.append(" {")
-                .append(getTestVariant(seed))
+                .append(getTestVariant(keepSeed))
                 .append("}");
         return verboseOutput.toString();
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -262,7 +262,7 @@ public class TestConfig implements Serializable {
                 .append(", shClass: ").append(shClass)
                 .append(", strideSize: ").append(strideSize)
                 .append(", strideCount: ").append(strideCount)
-                .append(", ").append(keepSeed ? jvmArgs : maskSeed(jvmArgs));
+                .append(", ").append(keepSeed ? jvmArgs : maskSeed(jvmArgs)); //this is intentionally last to keep remaining prefix easily searchable
         return idString.toString();
     }
 
@@ -276,6 +276,15 @@ public class TestConfig implements Serializable {
             }
         }
         return argsCopy;
+    }
+
+    public String getSeed() {
+        for (String arg : jvmArgs) {
+            if (arg.startsWith("-XX:StressSeed=")) {
+                return arg;
+            }
+        }
+        return null;
     }
 
     public String toDetailedTest(boolean keepSeed) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/runners/TestConfig.java
@@ -251,6 +251,7 @@ public class TestConfig implements Serializable {
         //binaryName have correct $ instead of . in name; omitted
         //generatedRunnerName name with suffix (usually _Test_jcstress) omitted
         //super.toString() as TestConfig@hash - omitted
+        //cpumap - null in listing, no reasonable toString method => omitted
         StringBuilder idString = new StringBuilder();
         idString.append(actorNames)
                 .append(", spinLoopStyle: ").append(spinLoopStyle)
@@ -261,7 +262,6 @@ public class TestConfig implements Serializable {
                 .append(", shClass: ").append(shClass)
                 .append(", strideSize: ").append(strideSize)
                 .append(", strideCount: ").append(strideCount)
-                .append(", cpuMap: ").append(cpuMap)
                 .append(", ").append(seed ? jvmArgs : maskSeed(jvmArgs));
         return idString.toString();
     }


### PR DESCRIPTION
Jcstress are generating very good html report, which is however not exactly great for automated comapriosns over various systyems and architectures. This pr is adding junit-like, configurable report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903819](https://bugs.openjdk.org/browse/CODETOOLS-7903819): jcstress do not print structuralised results (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jcstress.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/158.diff">https://git.openjdk.org/jcstress/pull/158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/158#issuecomment-2618757931)
</details>
