### PR TITLE
7903671: jcstress: Update buffer tests for JDK-8318966

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/TargetJvmVersion.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/TargetJvmVersion.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.vm;
+
+public class TargetJvmVersion {
+
+    /**
+     * The "return" message is parsed ond colon and brackets.
+     *
+     * @param args
+     */
+    public static void main(String... args) {
+        try {
+            Runtime.Version version = Runtime.version();
+            System.out.println("Detected: " + version.feature() + " (" + version + ")");
+        } catch (Throwable ex) {
+            System.out.println("Runtime.Version not found, fallback to: 8 (" + System.getProperty("java.version", "unknown)") + ")");
+            System.exit(0);
+        }
+    }
+
+}


### PR DESCRIPTION
part 1:  Detecting jdk of target VM and exuding illegible tests

This is prequel to full fixing of CODETOOLS-7903671. This PR detects target JDK version and then disables illegible tests.
part 2 will be done in templates of affected tests and logic around generating the classes from them. In meantime this should server.

The jdk detection will be most likely used anyway. WDYT? If we agree on similar approach, I will create a new bug for this PR only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903671](https://bugs.openjdk.org/browse/CODETOOLS-7903671): jcstress: Update buffer tests for JDK-8318966 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jcstress.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/159.diff">https://git.openjdk.org/jcstress/pull/159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/159#issuecomment-2685793345)
</details>
