### PR TITLE
7903671: jcstress: Update buffer tests for JDK-8318966

### DIFF
--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleByteArrayViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleByteArrayViewAtomicityTest.java.template
@@ -44,7 +44,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $name$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
     static final VarHandle VH = MethodHandles.byteArrayViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     byte[] xs = new byte[OFF + 8];

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleDirectByteBufferViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleDirectByteBufferViewAtomicityTest.java.template
@@ -47,7 +47,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer buf = ByteBuffer.allocateDirect(16);
-    int off = buf.alignmentOffset(0, 8);
+    int off = buf.alignmentOffset(0, 1);
 
     @Actor
     public void actor1() {

--- a/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleHeapByteBufferViewAtomicityTest.java.template
+++ b/jcstress-test-gen/src/main/resources/accessAtomic/X-VarHandleHeapByteBufferViewAtomicityTest.java.template
@@ -47,7 +47,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer buf = ByteBuffer.allocate(16);
-    int off = buf.alignmentOffset(0, 8);
+    int off = buf.alignmentOffset(0, 1);
 
     @Actor
     public void actor1() {

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleByteArrayViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleByteArrayViewAcqRelTest.java.template
@@ -55,7 +55,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $name$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
     static final VarHandle VH = MethodHandles.byteArrayViewVarHandle($typeG$[].class, ByteOrder.$byteOrder$);
 
     $typeV$ v;

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleDirectByteBufferViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleDirectByteBufferViewAcqRelTest.java.template
@@ -58,7 +58,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($typeG$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer g = ByteBuffer.allocateDirect(16);
-    int off = g.alignmentOffset(0, 8);
+    int off = g.alignmentOffset(0, 1);
 
     $typeV$ v;
 

--- a/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleHeapByteBufferViewAcqRelTest.java.template
+++ b/jcstress-test-gen/src/main/resources/acqrel/X-VarHandleHeapByteBufferViewAcqRelTest.java.template
@@ -58,7 +58,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($typeG$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer g = ByteBuffer.allocate(16);
-    int off = g.alignmentOffset(0, 8);
+    int off = g.alignmentOffset(0, 1);
 
     $typeV$ v;
 

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleByteArrayViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleByteArrayViewCoherenceTest.java.template
@@ -45,7 +45,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $name$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
     static final VarHandle VH = MethodHandles.byteArrayViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     byte[] xs = new byte[OFF + 8];

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleDirectByteBufferViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleDirectByteBufferViewCoherenceTest.java.template
@@ -48,7 +48,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer buf = ByteBuffer.allocateDirect(16);
-    int off = buf.alignmentOffset(0, 8);
+    int off = buf.alignmentOffset(0, 1);
 
     @Actor
     public void actor1() {

--- a/jcstress-test-gen/src/main/resources/coherence/X-VarHandleHeapByteBufferViewCoherenceTest.java.template
+++ b/jcstress-test-gen/src/main/resources/coherence/X-VarHandleHeapByteBufferViewCoherenceTest.java.template
@@ -48,7 +48,7 @@ public class $name$ {
     static final VarHandle VH = MethodHandles.byteBufferViewVarHandle($type$[].class, ByteOrder.$byteOrder$);
 
     ByteBuffer buf = ByteBuffer.allocate(16);
-    int off = buf.alignmentOffset(0, 8);
+    int off = buf.alignmentOffset(0, 1);
 
     @Actor
     public void actor1() {

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-CAETest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-CAETest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-CASTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-CASTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-GetAndAddTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-GetAndAddTest.java.template
@@ -48,7 +48,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-GetAndSetTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-GetAndSetTest.java.template
@@ -49,7 +49,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-WeakCASContendStrongTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-WeakCASContendStrongTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-WeakCASTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteArray/X-WeakCASTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 8);
+    static final int OFF = ByteBuffer.wrap(new byte[128]).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-CAETest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-CAETest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-CASTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-CASTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-GetAndAddTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-GetAndAddTest.java.template
@@ -48,7 +48,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-GetAndSetTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-GetAndSetTest.java.template
@@ -49,7 +49,7 @@ import org.openjdk.jcstress.infra.results.$T$$T$$T$_Result;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-WeakCASContendStrongTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-WeakCASContendStrongTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 

--- a/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-WeakCASTest.java.template
+++ b/jcstress-test-gen/src/main/resources/operationAtomic/byteBuffer/X-WeakCASTest.java.template
@@ -50,7 +50,7 @@ import org.openjdk.jcstress.infra.results.*;
 @State
 public class $TestClassName$ {
 
-    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 8);
+    static final int OFF = $buffer_allocate$(128).alignmentOffset(0, 1);
 
     static final VarHandle vh;
 


### PR DESCRIPTION
This is another possible fix for  https://bugs.openjdk.org/browse/CODETOOLS-7903671 - : jcstress: Update buffer tests for JDK-8318966 (Bug - P4)
This one is attempting  Experimental reduction of (0, 8) -> (0, 1) in all affected calls. Brief experiments seesm the change works. But whether it is still testing what it should.. I try to decrypt it, but up to now now proof.

I have not yet tested all affected tests. That is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [CODETOOLS-7903671](https://bugs.openjdk.org/browse/CODETOOLS-7903671): jcstress: Update buffer tests for JDK-8318966 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jcstress.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/160.diff">https://git.openjdk.org/jcstress/pull/160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/160#issuecomment-2686010555)
</details>
