### PR TITLE
7903750: TimeBudget (-tb) does not fulfill its promisses

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -61,7 +61,7 @@ public class JCStress {
             return;
         }
 
-        TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
+        TimeBudget timeBudget = getTimeBudget(config);
         timeBudget.printOn(out);
 
         ConsoleReportPrinter printer = new ConsoleReportPrinter(opts, new PrintWriter(out, true), config.configs.size(), timeBudget);
@@ -83,6 +83,14 @@ public class JCStress {
         out.println();
 
         parseResults();
+    }
+
+    private TimeBudget getTimeBudget(ConfigsWithScheduler config) {
+        if (config == null) {
+            return null;
+        }
+        TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
+        return timeBudget;
     }
 
     private ConfigsWithScheduler getConfigs() {
@@ -249,6 +257,10 @@ public class JCStress {
 
     public int listTests(Options opts) {
         JCStress.ConfigsWithScheduler configsWithScheduler = getConfigs();
+
+        TimeBudget timeBudget = getTimeBudget(configsWithScheduler);
+        timeBudget.printOn(out);
+
         Set<String> testsToPrint = new TreeSet<>();
         for (TestConfig test : configsWithScheduler.configs) {
             if (opts.verbosity().printAllTests()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -86,7 +86,6 @@ public class JCStress {
     }
 
     private TimeBudget getTimeBudget(ConfigsWithScheduler config) {
-        TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
         return new TimeBudget(config.configs.size(), opts.timeBudget());
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -87,7 +87,7 @@ public class JCStress {
 
     private TimeBudget getTimeBudget(ConfigsWithScheduler config) {
         TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
-        return timeBudget;
+        return new TimeBudget(config.configs.size(), opts.timeBudget());
     }
 
     private ConfigsWithScheduler getConfigs() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -86,9 +86,6 @@ public class JCStress {
     }
 
     private TimeBudget getTimeBudget(ConfigsWithScheduler config) {
-        if (config == null) {
-            return null;
-        }
         TimeBudget timeBudget = new TimeBudget(config.configs.size(), opts.timeBudget());
         return timeBudget;
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -134,7 +134,7 @@ public class TimeBudget {
         } else {
             out.println("    Initial completion estimate: " + ReportUtils.msToDate(timeLeftMs(), true));
             out.println("    Initial test time: " + targetTestTimeMs() + " ms");
-            printOvertimeWarning();
+            printOvertimeWarning(out);
         }
         out.println();
     }
@@ -145,23 +145,23 @@ public class TimeBudget {
         return expectedPerTest;
     }
 
-    private boolean printOvertimeWarning() {
+    private boolean printOvertimeWarning(PrintStream out) {
         long expectedPerTest = countEta(DEFAULT_PER_TEST_MS);
         boolean print=false;
         if (expectedPerTest > budget.milliseconds() * 2l) {
-            System.out.println(" + +++ FATAL - your tests will never finish as expected. They will run much longer ");
+            out.println(" + +++ FATAL - your tests will never finish as expected. They will run much longer ");
             print=true;
         }
         if (expectedPerTest * 2 < budget.milliseconds() * 2l) {
-            System.out.println(" + +++ WARNING - your time budget will not be used. Tests will end much sooner.");
+            out.println(" + +++ WARNING - your time budget will not be used. Tests will end much sooner.");
             print=true;
         }
         if (print) {
-            System.out.println(" | For " + expectedTests + " with concurrency factor of " + getConcurentTestsFactor()
+            out.println(" | For " + expectedTests + " with concurrency factor of " + getConcurentTestsFactor()
                     + " You have requested/been given time budget of: " + ReportUtils.getNiceMsTimeDate(budget.milliseconds()));
-            System.out.println(" | That is ~" + budget.milliseconds() / expectedTests + " ms per test");
-            System.out.println(" + +++ However the real time will be converging to: " + ReportUtils.getNiceMsTimeDate(expectedPerTest) + " +++");
-            System.out.println(" | You can play with internal properties name(value/eta):\n"
+            out.println(" | That is ~" + budget.milliseconds() / expectedTests + " ms per test");
+            out.println(" + +++ However the real time will be converging to: " + ReportUtils.getNiceMsTimeDate(expectedPerTest) + " +++");
+            out.println(" | You can play with internal properties name(value/eta):\n"
                     + " |   jcstress.timeBudget.defaultPerTestMs(" + DEFAULT_PER_TEST_MS + "ms/" +
                     ReportUtils.getNiceMsTimeDate(countEta(DEFAULT_PER_TEST_MS)) + ")\n"
                     + " |   jcstress.timeBudget.minTimeMs(" + MIN_TIME_MS + "ms/" +

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -149,27 +149,27 @@ public class TimeBudget {
         long expectedPerTest = countEta(DEFAULT_PER_TEST_MS);
         boolean print=false;
         if (expectedPerTest > budget.milliseconds() * 2l) {
-            out.println(" + FATAL: - your tests will never finish as expected. They will run much longer ");
+            out.println("    FATAL: your tests will never finish as expected. They will run much longer ");
             print=true;
         }
         if (expectedPerTest * 2 < budget.milliseconds() * 2l) {
-            out.println(" + WARNING:  your time budget will not be used. Tests will end much sooner.");
+            out.println("    WARNING:  your time budget will not be used. Tests will end much sooner.");
             print=true;
         }
         if (print) {
-            out.println(" | For " + expectedTests + " with concurrency factor of " + getConcurentTestsFactor()
+            out.println("    For " + expectedTests + " with concurrency factor of " + getConcurentTestsFactor()
                     + " You have requested/been given time budget of: " + ReportUtils.formatMsToDaysAndTime(budget.milliseconds()));
-            out.println(" | That is ~" + budget.milliseconds() / expectedTests + " ms per test");
-            out.println(" + +++ However the real time will be converging to: " + ReportUtils.formatMsToDaysAndTime(expectedPerTest) + " +++");
-            out.println(" | You can play with internal  properties name(value/eta):\n"
-                    + " |   jcstress.timeBudget.defaultPerTestMs(" + DEFAULT_PER_TEST_MS + "ms/" +
+            out.println("    That is ~" + budget.milliseconds() / expectedTests + " ms per test");
+            out.println("    However the real time will be converging to: " + ReportUtils.formatMsToDaysAndTime(expectedPerTest) + " +++");
+            out.println("    You can play with internal  properties name(value/eta):\n"
+                    + "        jcstress.timeBudget.defaultPerTestMs(" + DEFAULT_PER_TEST_MS + "ms/" +
                     ReportUtils.formatMsToDaysAndTime(countEta(DEFAULT_PER_TEST_MS)) + ")\n"
-                    + " |   jcstress.timeBudget.minTimeMs(" + MIN_TIME_MS + "ms/" +
+                    + "        jcstress.timeBudget.minTimeMs(" + MIN_TIME_MS + "ms/" +
                     ReportUtils.formatMsToDaysAndTime(countEta(MIN_TIME_MS)) + ")\n"
-                    + " |   jcstress.timeBudget.maxTimeMs(" + MAX_TIME_MS + "ms/" +
+                    + "        jcstress.timeBudget.maxTimeMs(" + MAX_TIME_MS + "ms/" +
                     ReportUtils.formatMsToDaysAndTime(countEta(MAX_TIME_MS)) + ")\n"
-                    + " | Which are setting up the exact times the individual tests are trying to converage to.\n"
-                    + " + Use with caution! Test run below 100ms is moreover jeopardize the purpose. And will not squeeze the time as you wish.");
+                    + "      Which are setting up the exact times the individual tests are trying to converage to.\n"
+                    + "      Use with caution! Test run below 100ms is moreover jeopardize the purpose. And will not squeeze the time as you wish.");
         }
         return print;
     }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -149,11 +149,11 @@ public class TimeBudget {
         long expectedPerTest = countEta(DEFAULT_PER_TEST_MS);
         boolean print=false;
         if (expectedPerTest > budget.milliseconds() * 2l) {
-            out.println(" + +++ FATAL - your tests will never finish as expected. They will run much longer ");
+            out.println(" + FATAL: - your tests will never finish as expected. They will run much longer ");
             print=true;
         }
         if (expectedPerTest * 2 < budget.milliseconds() * 2l) {
-            out.println(" + +++ WARNING - your time budget will not be used. Tests will end much sooner.");
+            out.println(" + WARNING:  your time budget will not be used. Tests will end much sooner.");
             print=true;
         }
         if (print) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -158,16 +158,16 @@ public class TimeBudget {
         }
         if (print) {
             out.println(" | For " + expectedTests + " with concurrency factor of " + getConcurentTestsFactor()
-                    + " You have requested/been given time budget of: " + ReportUtils.getNiceMsTimeDate(budget.milliseconds()));
+                    + " You have requested/been given time budget of: " + ReportUtils.formatMsToDaysAndTime(budget.milliseconds()));
             out.println(" | That is ~" + budget.milliseconds() / expectedTests + " ms per test");
-            out.println(" + +++ However the real time will be converging to: " + ReportUtils.getNiceMsTimeDate(expectedPerTest) + " +++");
+            out.println(" + +++ However the real time will be converging to: " + ReportUtils.formatMsToDaysAndTime(expectedPerTest) + " +++");
             out.println(" | You can play with internal properties name(value/eta):\n"
                     + " |   jcstress.timeBudget.defaultPerTestMs(" + DEFAULT_PER_TEST_MS + "ms/" +
-                    ReportUtils.getNiceMsTimeDate(countEta(DEFAULT_PER_TEST_MS)) + ")\n"
+                    ReportUtils.formatMsToDaysAndTime(countEta(DEFAULT_PER_TEST_MS)) + ")\n"
                     + " |   jcstress.timeBudget.minTimeMs(" + MIN_TIME_MS + "ms/" +
-                    ReportUtils.getNiceMsTimeDate(countEta(MIN_TIME_MS)) + ")\n"
+                    ReportUtils.formatMsToDaysAndTime(countEta(MIN_TIME_MS)) + ")\n"
                     + " |   jcstress.timeBudget.maxTimeMs(" + MAX_TIME_MS + "ms/" +
-                    ReportUtils.getNiceMsTimeDate(countEta(MAX_TIME_MS)) + ")\n"
+                    ReportUtils.formatMsToDaysAndTime(countEta(MAX_TIME_MS)) + ")\n"
                     + " | Which are setting up the exact times the individual tests are trying to converage to.\n"
                     + " + Use with caution! Test run below 100ms is moreover jeopardize the purpose. And will not squeeze the time as you wish.");
         }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -161,7 +161,7 @@ public class TimeBudget {
                     + " You have requested/been given time budget of: " + ReportUtils.formatMsToDaysAndTime(budget.milliseconds()));
             out.println(" | That is ~" + budget.milliseconds() / expectedTests + " ms per test");
             out.println(" + +++ However the real time will be converging to: " + ReportUtils.formatMsToDaysAndTime(expectedPerTest) + " +++");
-            out.println(" | You can play with internal properties name(value/eta):\n"
+            out.println(" | You can play with internal  properties name(value/eta):\n"
                     + " |   jcstress.timeBudget.defaultPerTestMs(" + DEFAULT_PER_TEST_MS + "ms/" +
                     ReportUtils.formatMsToDaysAndTime(countEta(DEFAULT_PER_TEST_MS)) + ")\n"
                     + " |   jcstress.timeBudget.minTimeMs(" + MIN_TIME_MS + "ms/" +

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TimeBudget.java
@@ -140,8 +140,8 @@ public class TimeBudget {
     }
 
     private void printOvertimeWarning() {
-        System.out.println("For "+expectedTests + " with concurrency factor of " + getConcurentTestsFactor() +" You have requested/been given time budget which have: " + ReportUtils.msToDate(budget.milliseconds(), false));
-        System.out.println("That is ~"  + budget.milliseconds()/expectedTests*getConcurentTestsFactor() + " ms per test");
+        System.out.println("For "+expectedTests + " with concurrency factor of " + getConcurentTestsFactor() +" You have requested/been given time budget of: " + ReportUtils.getNiceMsTimeDate(budget.milliseconds()));
+        System.out.println("That is ~"  + budget.milliseconds()/expectedTests + " ms per test");
         moreAccurateValue(MIN_TIME_MS, "minimal");
         moreAccurateValue(DEFAULT_PER_TEST_MS, "default");
         moreAccurateValue(MAX_TIME_MS, "maximal");
@@ -150,8 +150,8 @@ public class TimeBudget {
     private void moreAccurateValue(int val, String id) {
         long expectedTotalTime = (long) expectedTests * val;
         long expectedPerTest = expectedTotalTime / getConcurentTestsFactor();
-        System.out.println("However the real "+id+" time will have: " + ReportUtils.msToDate(expectedPerTest, false));
-        System.out.println("That is ~" + expectedPerTest/expectedTests*getConcurentTestsFactor() + " ms per test");
+        System.out.println("However the real "+id+" time will be: " + ReportUtils.getNiceMsTimeDate(expectedPerTest));
+        System.out.println("which  is ~" + expectedPerTest/expectedTests*getConcurentTestsFactor() + " ms per test");
     }
 
     public boolean isZero() {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -315,9 +315,7 @@ public class ReportUtils {
             ms -= TimeUnit.DAYS.toMillis(days);
         }
         long hours = TimeUnit.MILLISECONDS.toHours(ms);
-        ms -= TimeUnit.HOURS.toMillis(hours);
         long minutes = TimeUnit.MILLISECONDS.toMinutes(ms);
-        ms -= TimeUnit.MINUTES.toMillis(minutes);
         long seconds = TimeUnit.MILLISECONDS.toSeconds(ms);
         result += String.format("%02d:%02d:%02d", hours, minutes, seconds);
         return result;

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -290,14 +290,25 @@ public class ReportUtils {
 
     public static String msToDate(long ms, boolean finalDate) {
         LocalDateTime ldt = LocalDateTime.now().plus(ms, ChronoUnit.MILLIS);
-
-        String result = "";
-
         boolean overtime = ms < 0;
         if (overtime) {
             ms = -ms;
         }
+        String result = getNiceMsTimeDate(ms);
+        if (overtime) {
+            result = "overtime " + result;
+        }
+        if (!overtime) {
+            result += " left";
+        }
+        if (finalDate) {
+            result += "; at " + ldt.format(DATE_TIME_FORMATTER);
+        }
+        return result;
+    }
 
+    public static String getNiceMsTimeDate(long ms) {
+        String result = "";
         long days = TimeUnit.MILLISECONDS.toDays(ms);
         if (days > 0) {
             result += days + "d+";
@@ -305,22 +316,10 @@ public class ReportUtils {
         }
         long hours = TimeUnit.MILLISECONDS.toHours(ms);
         ms -= TimeUnit.HOURS.toMillis(hours);
-
         long minutes = TimeUnit.MILLISECONDS.toMinutes(ms);
         ms -= TimeUnit.MINUTES.toMillis(minutes);
-
         long seconds = TimeUnit.MILLISECONDS.toSeconds(ms);
-
-        if (overtime) {
-            result += "overtime ";
-        }
         result += String.format("%02d:%02d:%02d", hours, minutes, seconds);
-        if (!overtime) {
-            result += " left";
-        }
-        if (finalDate) {
-            result += "; at " + ldt.format(DATE_TIME_FORMATTER);
-        }
         return result;
     }
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/infra/grading/ReportUtils.java
@@ -294,7 +294,7 @@ public class ReportUtils {
         if (overtime) {
             ms = -ms;
         }
-        String result = getNiceMsTimeDate(ms);
+        String result = formatMsToDaysAndTime(ms);
         if (overtime) {
             result = "overtime " + result;
         }
@@ -307,7 +307,7 @@ public class ReportUtils {
         return result;
     }
 
-    public static String getNiceMsTimeDate(long ms) {
+    public static String formatMsToDaysAndTime(long ms) {
         String result = "";
         long days = TimeUnit.MILLISECONDS.toDays(ms);
         if (days > 0) {


### PR DESCRIPTION
Added warning, when time budget is to small, and final run will run at least two times longer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903750](https://bugs.openjdk.org/browse/CODETOOLS-7903750): TimeBudget (-tb) does not fulfill its promisses (**Bug** - P4)


### Reviewers
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jcstress.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/161.diff">https://git.openjdk.org/jcstress/pull/161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/161#issuecomment-2701370671)
</details>
