### PR TITLE
7904028: jcstress: Address s.m.Unsafe use warnings which fail build on JDK 23+

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
@@ -181,18 +181,21 @@ public class AdvancedJMM_02_MultiCopyAtomic {
         public int x;
         public int y;
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor1() {
             UNSAFE.fullFence(); // "SeqCst" store
             x = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor2() {
             UNSAFE.fullFence(); // "SeqCst" store
             y = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor3(IIII_Result r) {
             r.r1 = x;
@@ -201,6 +204,7 @@ public class AdvancedJMM_02_MultiCopyAtomic {
             UNSAFE.loadFence(); // "SeqCst" load y
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor4(IIII_Result r) {
             r.r3 = y;
@@ -247,18 +251,21 @@ public class AdvancedJMM_02_MultiCopyAtomic {
         public int x;
         public int y;
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor1() {
             UNSAFE.fullFence(); // "SeqCst" store
             x = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor2() {
             UNSAFE.fullFence(); // "SeqCst" store
             y = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor3(IIII_Result r) {
             UNSAFE.fullFence(); // "SeqCst" load x, part 1
@@ -268,6 +275,7 @@ public class AdvancedJMM_02_MultiCopyAtomic {
             UNSAFE.loadFence(); // "SeqCst" load y, part 2
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor4(IIII_Result r) {
             UNSAFE.fullFence();

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_14_SynchronizedAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_14_SynchronizedAreNotFences.java
@@ -101,6 +101,7 @@ public class AdvancedJMM_14_SynchronizedAreNotFences {
     public static class Fenced {
         int x, y;
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor1() {
             x = 1;
@@ -108,6 +109,7 @@ public class AdvancedJMM_14_SynchronizedAreNotFences {
             y = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void actor2(II_Result r) {
             r.r1 = y;

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
@@ -103,6 +103,7 @@ public class AdvancedJMM_15_VolatilesAreNotFences {
     public static class Fences {
         int x, y;
 
+        @SuppressWarnings("removal")
         @Actor
         void thread1() {
             x = 1;
@@ -110,6 +111,7 @@ public class AdvancedJMM_15_VolatilesAreNotFences {
             y = 1;
         }
 
+        @SuppressWarnings("removal")
         @Actor
         void thread2(II_Result r) {
             r.r1 = y;

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
@@ -268,17 +268,21 @@ public class BasicJMM_02_AccessAtomicity {
     public static class UnsafeCrossCacheLine {
 
         public static final int SIZE = 256;
+        @SuppressWarnings("removal")
         public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+        @SuppressWarnings("removal")
         public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
 
         byte[] ss = new byte[SIZE];
         long off = ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE * ThreadLocalRandom.current().nextInt(SIZE - 4);
 
+        @SuppressWarnings("removal")
         @Actor
         public void writer() {
             UNSAFE.putInt(ss, off, 0xFFFFFFFF);
         }
 
+        @SuppressWarnings("removal")
         @Actor
         public void reader(I_Result r) {
             r.r1 = UNSAFE.getInt(ss, off);

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/UnsafeIntAtomicityTest.java
@@ -52,7 +52,9 @@ public class UnsafeIntAtomicityTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
+    @SuppressWarnings("removal")
     public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    @SuppressWarnings("removal")
     public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
@@ -68,6 +70,7 @@ public class UnsafeIntAtomicityTest {
         offset = ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE*index;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         UNSAFE.putInt(bytes, offset, 0xFFFFFFFF);
@@ -75,6 +78,7 @@ public class UnsafeIntAtomicityTest {
 
     @Actor
     public void actor2(BBBB_Result r) {
+        @SuppressWarnings("removal")
         int t = UNSAFE.getInt(bytes, offset);
         r.r1 = (byte) ((t >> 0) & 0xFF);
         r.r2 = (byte) ((t >> 8) & 0xFF);

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
@@ -53,6 +53,7 @@ public class FencedAcquireReleaseTest {
     int x;
     int y; // acq/rel var
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         x = 1;
@@ -62,6 +63,7 @@ public class FencedAcquireReleaseTest {
         x = 3;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor2(II_Result r) {
         int sy = y;

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
@@ -49,6 +49,7 @@ public class FencedDekkerTest {
     int a;
     int b;
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1(II_Result r) {
         a = 1;
@@ -56,6 +57,7 @@ public class FencedDekkerTest {
         r.r1 = b;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor2(II_Result r) {
         b = 1;

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
@@ -52,6 +52,7 @@ public class FencedPublicationTest {
         int x;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         Data d = new Data();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
@@ -53,6 +53,7 @@ public class FencedReadTwiceTest {
     int x;
     int y;
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         x = 1;
@@ -60,6 +61,7 @@ public class FencedReadTwiceTest {
         y = 1;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor2(III_Result r) {
         r.r1 = x;

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
@@ -43,6 +43,7 @@ public class BooleanFencedTest {
     public static class Shell {
         boolean x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = true;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ByteFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ByteFencedTest.java
@@ -43,6 +43,7 @@ public class ByteFencedTest {
     public static class Shell {
         byte x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = (byte) 0xFF;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
@@ -43,6 +43,7 @@ public class CharFencedTest {
     public static class Shell {
         char x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = 1;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
@@ -43,6 +43,7 @@ public class DoubleFencedTest {
     public static class Shell {
         double x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL);
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
@@ -43,6 +43,7 @@ public class FloatFencedTest {
     public static class Shell {
         float x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = Float.intBitsToFloat(0xFFFFFFFF);
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/IntFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/IntFencedTest.java
@@ -43,6 +43,7 @@ public class IntFencedTest {
     public static class Shell {
         int x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = 0xFFFFFFFF;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
@@ -43,6 +43,7 @@ public class LongFencedTest {
     public static class Shell {
         long x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = 0xFFFFFFFFFFFFFFFFL;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
@@ -43,6 +43,7 @@ public class ShortFencedTest {
     public static class Shell {
         short x;
 
+        @SuppressWarnings("removal")
         public Shell() {
             this.x = (short) 0xFFFF;
             UNSAFE.storeFence();

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/UnsafeBusyLoopTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/UnsafeBusyLoopTest.java
@@ -34,6 +34,7 @@ import org.openjdk.jcstress.annotations.State;
 
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
+@SuppressWarnings("removal")
 @JCStressTest(Mode.Termination)
 @Outcome(id = "TERMINATED", expect = Expect.ACCEPTABLE, desc = "The thread had sucessfully terminated.")
 @Outcome(id = "STALE",      expect = Expect.ACCEPTABLE_INTERESTING, desc = "Thread had failed to respond.")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeArrayInterleaveTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeArrayInterleaveTest.java
@@ -44,11 +44,14 @@ public class UnsafeArrayInterleaveTest {
     /** Array size: 256 bytes inevitably crosses the cache line on most implementations */
     public static final int SIZE = 256;
 
+    @SuppressWarnings("removal")
     public static final int ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    @SuppressWarnings("removal")
     public static final int ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
 
     byte[] ss = new byte[SIZE];
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         for (int i = 0; i < ss.length; i += 2) {
@@ -56,6 +59,7 @@ public class UnsafeArrayInterleaveTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor2() {
         for (int i = 1; i < ss.length; i += 2) {

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/UnsafeIntTearingTest.java
@@ -52,7 +52,9 @@ public class UnsafeIntTearingTest {
     public static final int SIZE = 256;
 
     public static final Random RANDOM = new Random();
+    @SuppressWarnings("removal")
     public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    @SuppressWarnings("removal")
     public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
     public static final int COMPONENT_SIZE = 4;
 
@@ -70,16 +72,19 @@ public class UnsafeIntTearingTest {
         offset2 = offset1 + COMPONENT_SIZE;
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor1() {
         UNSAFE.putInt(bytes, offset1, 0xAAAAAAAA);
     }
 
+    @SuppressWarnings("removal")
     @Actor
     public void actor2() {
         UNSAFE.putInt(bytes, offset2, 0x55555555);
     }
 
+    @SuppressWarnings("removal")
     @Arbiter
     public void arbiter1(II_Result r) {
         r.r1 = UNSAFE.getInt(bytes, offset1);

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong1.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong1.java
@@ -34,6 +34,7 @@ import org.openjdk.jcstress.infra.results.JJ_Result;
 
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
+@SuppressWarnings("removal")
 @JCStressTest
 @Description("Tests if Unsafe.getAndAddLong is racy")
 @Outcome(id = "1, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong42.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeAddLong42.java
@@ -34,6 +34,7 @@ import org.openjdk.jcstress.infra.results.JJ_Result;
 
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
+@SuppressWarnings("removal")
 @JCStressTest
 @Description("Tests if Unsafe.getAndAddLong is racy")
 @Outcome(id = "1, 4398046511104", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafePutOrderedTwice.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafePutOrderedTwice.java
@@ -29,6 +29,7 @@ import org.openjdk.jcstress.infra.results.II_Result;
 
 import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
+@SuppressWarnings("removal")
 @JCStressTest
 @Description("Tests if Unsafe.putOrderedInt is in-order")
 @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeReadTwiceOverVolatileReadTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/unsafe/UnsafeReadTwiceOverVolatileReadTest.java
@@ -34,6 +34,7 @@ import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
  *
  * @author Aleksey Shipilev (shade@redhat.com)
  */
+@SuppressWarnings("removal")
 @JCStressTest
 @Outcome(id = "0, 0, 0", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Observers are allowed to see the default value for the field, because there is the data race between reader and writer.")
 @Outcome(id = "0, 1, 0", expect = Expect.FORBIDDEN,  desc = "Volatile write to $y had happened, and update to $x had been lost.")


### PR DESCRIPTION
Here I propose a simple, symptomatic solution to fix build failures on JDK 23+ caused by treating "deprecated for removal" warnings as errors.

In the patch, I tried to keep the scope of `@SuppressWarnings` to a minimum. However, in a few cases I had to broaden it. This is because this annotation cannot be applied to a static initializer or an assignment within it.

Instead of extracting code into methods for the sake of annotating those, I annotated the smallest annotatable outer element, which was the top-level class. For example, see: `UnsafeBusyLoopTest`, `UnsafeAddLong1`, `UnsafeAddLong42`. 

I note that in JBS @shipilev suggested another approach to address the warnings. Namely, to move from `Unsafe` to `VarHandle`. However, such an approach is beyond my competence. And if chosen, it should be done by someone else. Thanks.