### PR TITLE
7904033: jcstress: Upgrade Unsafe tests to use VarHandles

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_02_MultiCopyAtomic.java
@@ -34,7 +34,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class AdvancedJMM_02_MultiCopyAtomic {
 
@@ -183,30 +182,30 @@ public class AdvancedJMM_02_MultiCopyAtomic {
 
         @Actor
         public void actor1() {
-            UNSAFE.fullFence(); // "SeqCst" store
+            VarHandle.fullFence(); // "SeqCst" store
             x = 1;
         }
 
         @Actor
         public void actor2() {
-            UNSAFE.fullFence(); // "SeqCst" store
+            VarHandle.fullFence(); // "SeqCst" store
             y = 1;
         }
 
         @Actor
         public void actor3(IIII_Result r) {
             r.r1 = x;
-            UNSAFE.loadFence(); // "SeqCst" load x
+            VarHandle.acquireFence(); // "SeqCst" load x
             r.r2 = y;
-            UNSAFE.loadFence(); // "SeqCst" load y
+            VarHandle.acquireFence(); // "SeqCst" load y
         }
 
         @Actor
         public void actor4(IIII_Result r) {
             r.r3 = y;
-            UNSAFE.loadFence(); // "SeqCst" load y
+            VarHandle.acquireFence(); // "SeqCst" load y
             r.r4 = x;
-            UNSAFE.loadFence(); // "SeqCst" load x
+            VarHandle.acquireFence(); // "SeqCst" load x
         }
 
     }
@@ -249,32 +248,32 @@ public class AdvancedJMM_02_MultiCopyAtomic {
 
         @Actor
         public void actor1() {
-            UNSAFE.fullFence(); // "SeqCst" store
+            VarHandle.fullFence(); // "SeqCst" store
             x = 1;
         }
 
         @Actor
         public void actor2() {
-            UNSAFE.fullFence(); // "SeqCst" store
+            VarHandle.fullFence(); // "SeqCst" store
             y = 1;
         }
 
         @Actor
         public void actor3(IIII_Result r) {
-            UNSAFE.fullFence(); // "SeqCst" load x, part 1
+            VarHandle.fullFence(); // "SeqCst" load x, part 1
             r.r1 = x;
-            UNSAFE.fullFence(); // "SeqCst" load x, part 2 (subsumed); "SeqCst" load y, part 1
+            VarHandle.fullFence(); // "SeqCst" load x, part 2 (subsumed); "SeqCst" load y, part 1
             r.r2 = y;
-            UNSAFE.loadFence(); // "SeqCst" load y, part 2
+            VarHandle.acquireFence(); // "SeqCst" load y, part 2
         }
 
         @Actor
         public void actor4(IIII_Result r) {
-            UNSAFE.fullFence();
+            VarHandle.fullFence();
             r.r3 = y;
-            UNSAFE.fullFence(); // subsumes loadFence
+            VarHandle.fullFence(); // subsumes loadFence
             r.r4 = x;
-            UNSAFE.loadFence();
+            VarHandle.acquireFence();
         }
 
     }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_14_SynchronizedAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_14_SynchronizedAreNotFences.java
@@ -30,8 +30,9 @@ import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
 
+import java.lang.invoke.VarHandle;
+
 import static org.openjdk.jcstress.annotations.Expect.*;
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class AdvancedJMM_14_SynchronizedAreNotFences {
 
@@ -83,7 +84,7 @@ public class AdvancedJMM_14_SynchronizedAreNotFences {
     /*
        ----------------------------------------------------------------------------------------------------------
 
-        If fence-like effects are required in low-level concurrency code, then Unsafe.*Fence should be used instead.
+        If fence-like effects are required in low-level concurrency code, then VarHandle.*Fence should be used instead.
 
         Indeed, this provides the effect we are after, on all platforms:
           RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
@@ -104,14 +105,14 @@ public class AdvancedJMM_14_SynchronizedAreNotFences {
         @Actor
         public void actor1() {
             x = 1;
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
             y = 1;
         }
 
         @Actor
         public void actor2(II_Result r) {
             r.r1 = y;
-            UNSAFE.loadFence();
+            VarHandle.acquireFence();
             r.r2 = x;
         }
     }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
@@ -31,8 +31,9 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.III_Result;
 import org.openjdk.jcstress.infra.results.II_Result;
 
+import java.lang.invoke.VarHandle;
+
 import static org.openjdk.jcstress.annotations.Expect.*;
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class AdvancedJMM_15_VolatilesAreNotFences {
 
@@ -106,14 +107,14 @@ public class AdvancedJMM_15_VolatilesAreNotFences {
         @Actor
         void thread1() {
             x = 1;
-            UNSAFE.storeFence();
+            VarHandle.acquireFence();
             y = 1;
         }
 
         @Actor
         void thread2(II_Result r) {
             r.r1 = y;
-            UNSAFE.loadFence();
+            VarHandle.acquireFence();
             r.r2 = x;
         }
     }

--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/basic/BasicJMM_02_AccessAtomicity.java
@@ -31,10 +31,10 @@ import org.openjdk.jcstress.infra.results.J_Result;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 public class BasicJMM_02_AccessAtomicity {
 
@@ -265,177 +265,24 @@ public class BasicJMM_02_AccessAtomicity {
     @Outcome(id = "-1", expect = ACCEPTABLE, desc = "Seeing the full value.")
     @Outcome(expect = ACCEPTABLE_INTERESTING, desc = "Other cases are allowed, because reads/writes are not atomic.")
     @State
-    public static class UnsafeCrossCacheLine {
+    public static class CrossCacheLine {
+        private static final VarHandle VH = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
 
-        public static final int SIZE = 256;
-        public static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
-        public static final long ARRAY_BASE_SCALE = UNSAFE.arrayIndexScale(byte[].class);
+        private static final int BYTE_SIZE = 256;
 
-        byte[] ss = new byte[SIZE];
-        long off = ARRAY_BASE_OFFSET + ARRAY_BASE_SCALE * ThreadLocalRandom.current().nextInt(SIZE - 4);
+        int off = ThreadLocalRandom.current().nextInt(BYTE_SIZE - Integer.BYTES);
+
+        byte[] ss = new byte[BYTE_SIZE];
 
         @Actor
         public void writer() {
-            UNSAFE.putInt(ss, off, 0xFFFFFFFF);
+            VH.set(ss, off, 0xFFFFFFFF);
         }
 
         @Actor
         public void reader(I_Result r) {
-            r.r1 = UNSAFE.getInt(ss, off);
+            r.r1 = (int)VH.get(ss, off);
         }
     }
-
-
-    // ======================================= EARLY VALHALLA EXAMPLES BELOW =======================================
-    // These require Valhalla JDK builds.
-
-    /*
-      ----------------------------------------------------------------------------------------------------------
-
-        While most modern hardware implementation provide access atomicity for all Java primitive types,
-        the issue with access atomicity raises it ugly head again with Project Valhalla, which strives
-        to introduce multi-field classes that behave like primitives. There, reading the entirety of
-        the "inlined" ("flattened") primitive type is sometimes not possible, because the effective
-        data type width is too large. Therefore, we would normally see access atomicity violations.
-
-        Indeed, on x86_64 this happens:
-          RESULT        SAMPLES     FREQ       EXPECT  DESCRIPTION
-            0, 0    790,816,955   22.90%   Acceptable  Seeing the default value: writer had not acted yet.
-            0, 1      2,154,875    0.06%  Interesting  Other cases are allowed, because reads/writes are not ato...
-            1, 0      2,385,714    0.07%  Interesting  Other cases are allowed, because reads/writes are not ato...
-            1, 1  2,658,516,120   76.97%   Acceptable  Seeing the full value.
-     */
-
-    /*
-    @JCStressTest
-    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
-    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Seeing the full value.")
-    @Outcome(expect = ACCEPTABLE_INTERESTING, desc = "Other cases are allowed, because reads/writes are not atomic.")
-    @State
-    public static class Values {
-        static primitive class Value {
-            long x;
-            long y;
-            public Value(long x, long y) {
-                this.x = x;
-                this.y = y;
-            }
-        }
-
-        Value v = Value.default;
-
-        @Actor
-        public void writer() {
-            v = new Value(1, 1);
-        }
-
-        @Actor
-        public void reader(JJ_Result r) {
-            Value tv = v;
-            r.r1 = tv.x;
-            r.r2 = tv.y;
-        }
-    }
-     */
-
-    /*
-      ----------------------------------------------------------------------------------------------------------
-
-        As usual, marking the primitive field "volatile" regains the access atomicity. In current implementations,
-        this happens by forbidding the "flattening" of the inline type.
-
-        x86_64:
-          RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
-            0, 0  2,780,487,683   84.19%  Acceptable  Seeing the default value: writer had not acted yet.
-            1, 1    522,202,621   15.81%  Acceptable  Seeing the full value.
-     */
-
-    /*
-
-    @JCStressTest
-    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
-    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Seeing the full value.")
-    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
-    @State
-    public static class VolatileValues {
-        static primitive class Value {
-            long x;
-            long y;
-            public Value(long x, long y) {
-                this.x = x;
-                this.y = y;
-            }
-        }
-
-        volatile Value v = Value.default;
-
-        @Actor
-        public void writer() {
-            v = new Value(1, 1);
-        }
-
-        @Actor
-        public void reader(JJ_Result r) {
-            Value tv = v;
-            r.r1 = tv.x;
-            r.r2 = tv.y;
-        }
-    }
-     */
-
-    /*
-      ----------------------------------------------------------------------------------------------------------
-
-        The awkward case is when the primitive field is not marked specifically, so field layouter flattens
-        the type, but then the the primitive field is used as "opaque". In this case, the implementation
-        has to enforce atomicity by e.g. locking.
-
-        x86_64:
-            RESULT        SAMPLES     FREQ      EXPECT  DESCRIPTION
-              0, 0    542,416,624   25.36%  Acceptable  Seeing the default value: writer had not acted yet.
-              1, 1  1,596,364,560   74.64%  Acceptable  Seeing the full value.
-     */
-
-    /*
-    @JCStressTest
-    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
-    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Seeing the full value.")
-    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
-    @State
-    public static class OpaqueValues {
-        static primitive class Value {
-            long x;
-            long y;
-            public Value(long x, long y) {
-                this.x = x;
-                this.y = y;
-            }
-        }
-
-        Value v = Value.default;
-
-        static final VarHandle VH;
-
-        static {
-            try {
-                VH = MethodHandles.lookup().findVarHandle(OpaqueValues.class, "v", Value.class);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-
-        @Actor
-        public void writer() {
-            VH.setOpaque(this, new Value(1, 1));
-        }
-
-        @Actor
-        public void reader(JJ_Result r) {
-            Value tv = (Value) VH.getOpaque(this);
-            r.r1 = tv.x;
-            r.r2 = tv.y;
-        }
-    }
-    */
 
 }

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/VarHandleIntAtomicityTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/atomicity/crosscache/VarHandleIntAtomicityTest.java
@@ -25,16 +25,12 @@
 package org.openjdk.jcstress.tests.atomicity.crosscache;
 
 import org.openjdk.jcstress.annotations.*;
-import org.openjdk.jcstress.infra.results.BBBB_Result;
 import org.openjdk.jcstress.infra.results.I_Result;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @Description("Tests if VarHandle breaks the atomicity while doing cross cache-line reads/writes.")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedAcquireReleaseTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.fences;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Expect;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if acquire-release fences induce proper happens-before.
@@ -57,7 +57,7 @@ public class FencedAcquireReleaseTest {
     public void actor1() {
         x = 1;
         x = 2;
-        UNSAFE.storeFence();
+        VarHandle.releaseFence();
         y = 1;
         x = 3;
     }
@@ -65,7 +65,7 @@ public class FencedAcquireReleaseTest {
     @Actor
     public void actor2(II_Result r) {
         int sy = y;
-        UNSAFE.loadFence();
+        VarHandle.acquireFence();
         int sx = x;
         r.r1 = sy;
         r.r2 = sx;

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedDekkerTest.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jcstress.tests.fences;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Description;
 import org.openjdk.jcstress.annotations.Expect;
@@ -31,8 +33,6 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if read-after-write using fences preserves SC
@@ -52,14 +52,14 @@ public class FencedDekkerTest {
     @Actor
     public void actor1(II_Result r) {
         a = 1;
-        UNSAFE.fullFence();
+        VarHandle.fullFence();
         r.r1 = b;
     }
 
     @Actor
     public void actor2(II_Result r) {
         b = 1;
-        UNSAFE.fullFence();
+        VarHandle.fullFence();
         r.r2 = a;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedPublicationTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.fences;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Expect;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.II_Result;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Tests if release fence before publication ensures non-default read
@@ -56,7 +56,7 @@ public class FencedPublicationTest {
     public void actor1() {
         Data d = new Data();
         d.x = 1;
-        UNSAFE.storeFence();
+        VarHandle.releaseFence();
         data = d;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/fences/FencedReadTwiceTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.fences;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.Expect;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.III_Result;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 /**
  * Test if acquire/release forces re-read
@@ -56,7 +56,7 @@ public class FencedReadTwiceTest {
     @Actor
     public void actor1() {
         x = 1;
-        UNSAFE.storeFence();
+        VarHandle.releaseFence();
         y = 1;
     }
 
@@ -64,7 +64,7 @@ public class FencedReadTwiceTest {
     public void actor2(III_Result r) {
         r.r1 = x;
         r.r2 = y;
-        UNSAFE.loadFence();
+        VarHandle.acquireFence();
         r.r3 = x;
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/BooleanFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.I_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class BooleanFencedTest {
 
         public Shell() {
             this.x = true;
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/CharFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.C_Result;
 import org.openjdk.jcstress.tests.init.Grading_CharShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_CharShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class CharFencedTest {
 
         public Shell() {
             this.x = 1;
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/DoubleFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.D_Result;
 import org.openjdk.jcstress.tests.init.Grading_DoubleShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_DoubleShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class DoubleFencedTest {
 
         public Shell() {
             this.x = Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL);
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/FloatFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.F_Result;
 import org.openjdk.jcstress.tests.init.Grading_FloatShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_FloatShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class FloatFencedTest {
 
         public Shell() {
             this.x = Float.intBitsToFloat(0xFFFFFFFF);
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/LongFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.J_Result;
 import org.openjdk.jcstress.tests.init.Grading_LongShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_LongShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class LongFencedTest {
 
         public Shell() {
             this.x = 0xFFFFFFFFFFFFFFFFL;
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/init/primitives/fenced/ShortFencedTest.java
@@ -24,14 +24,14 @@
  */
 package org.openjdk.jcstress.tests.init.primitives.fenced;
 
+import java.lang.invoke.VarHandle;
+
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressMeta;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.S_Result;
 import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @JCStressTest
 @JCStressMeta(Grading_IntShouldSeeFull.class)
@@ -45,7 +45,7 @@ public class ShortFencedTest {
 
         public Shell() {
             this.x = (short) 0xFFFF;
-            UNSAFE.storeFence();
+            VarHandle.releaseFence();
         }
     }
 

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/VarHandleBusyLoopTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/VarHandleBusyLoopTest.java
@@ -25,12 +25,9 @@
 package org.openjdk.jcstress.tests.interrupt;
 
 import org.openjdk.jcstress.annotations.*;
-import org.openjdk.jcstress.tests.varhandles.AddLong1;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
 
 @Outcome(id = "TERMINATED", expect = Expect.ACCEPTABLE, desc = "The thread had successfully terminated.")
 @Outcome(id = "STALE",      expect = Expect.FORBIDDEN,  desc = "Thread had failed to respond.")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/VarHandleBusyLoopTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/interrupt/VarHandleBusyLoopTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.tests.interrupt;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.tests.varhandles.AddLong1;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
+
+@Outcome(id = "TERMINATED", expect = Expect.ACCEPTABLE, desc = "The thread had successfully terminated.")
+@Outcome(id = "STALE",      expect = Expect.FORBIDDEN,  desc = "Thread had failed to respond.")
+public class VarHandleBusyLoopTest {
+    static final VarHandle VH;
+
+    static {
+        try {
+            VH = MethodHandles.lookup().findVarHandle(VarHandleBusyLoopTest.class, "isStopped", boolean.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private boolean isStopped;
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Opaque_Opaque extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setOpaque(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getOpaque(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Opaque_Acquire extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setOpaque(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getAcquire(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Opaque_Volatile extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setOpaque(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getVolatile(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Release_Opaque extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setRelease(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getOpaque(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Release_Acquire extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setRelease(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getAcquire(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Release_Volatile extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setRelease(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getVolatile(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Volatile_Opaque extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setVolatile(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getOpaque(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Volatile_Acquire extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setVolatile(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getAcquire(this)); }
+    }
+
+    @JCStressTest(Mode.Termination)
+    @JCStressMeta(VarHandleBusyLoopTest.class)
+    @State
+    public static class Volatile_Volatile extends VarHandleBusyLoopTest {
+        @Signal public void signal() { VH.setVolatile(this, true); }
+        @Actor  public void actor1() { while (!(boolean) VH.getVolatile(this)); }
+    }
+
+}

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/VarHandleArrayInterleaveTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/VarHandleArrayInterleaveTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.tests.tearing;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.III_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+@Description("Tests the word-tearing guarantees for byte[] via VarHandles.")
+@Outcome(id = "0, 128, 128", expect = Expect.ACCEPTABLE, desc = "Seeing all updates intact.")
+@State
+public class VarHandleArrayInterleaveTest {
+
+    private static final VarHandle VH = MethodHandles.arrayElementVarHandle(byte[].class);
+
+    /** Array size: 256 bytes inevitably crosses the cache line on most implementations */
+    public static final int SIZE = 256;
+
+    byte[] ss = new byte[SIZE];
+
+    public void summary(III_Result r) {
+        for (byte s : ss) {
+            switch (s) {
+                case 0:
+                    r.r1++;
+                    break;
+                case 1:
+                    r.r2++;
+                    break;
+                case 2:
+                    r.r3++;
+                    break;
+                default:
+                    throw new IllegalStateException(String.valueOf(s));
+            }
+        }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Plain_Plain extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.set(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.set(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Plain_Opaque extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.set(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setOpaque(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Plain_Release extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.set(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setRelease(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Plain_Volatile extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.set(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setVolatile(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Opaque_Opaque extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setOpaque(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setOpaque(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Opaque_Release extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setOpaque(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setRelease(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Opaque_Volatile extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setOpaque(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setVolatile(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Release_Release extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setRelease(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setRelease(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Release_Volatile extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setRelease(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setVolatile(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleArrayInterleaveTest.class)
+    @State
+    public static class Volatile_Volatile extends VarHandleArrayInterleaveTest {
+        @Actor public void actor1() { for (int i = 0; i < ss.length; i += 2) VH.setVolatile(ss, i, (byte) 1); }
+        @Actor public void actor2() { for (int i = 1; i < ss.length; i += 2) VH.setVolatile(ss, i, (byte) 2); }
+        @Arbiter public void arbiter(III_Result r) { summary(r); }
+    }
+}

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/VarHandleIntTearingTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/tearing/VarHandleIntTearingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.tests.tearing;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.II_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Description("Tests the word-tearing guarantees for byte[] via VarHandle.")
+@Outcome(id = "-1431655766, 1431655765", expect = Expect.ACCEPTABLE, desc = "Seeing all updates intact.")
+public class VarHandleIntTearingTest {
+
+    private static final VarHandle VH = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+
+    /** Array size: 256 bytes inevitably crosses the cache line on most implementations */
+    private static final int SIZE = 256;
+
+    int offset1;
+    int offset2;
+
+    byte[] bytes;
+
+    public VarHandleIntTearingTest() {
+        bytes = new byte[SIZE];
+        offset1 = ThreadLocalRandom.current().nextInt(SIZE - Integer.BYTES*2);
+        offset1 = offset1 / Integer.BYTES * Integer.BYTES;
+        offset2 = offset1 + Integer.BYTES;
+    }
+
+    public void summary(II_Result r) {
+        r.r1 = (int)VH.get(bytes, offset1);
+        r.r2 = (int)VH.get(bytes, offset2);
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Plain_Plain extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.set(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.set(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Plain_Opaque extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.set(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setOpaque(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Plain_Release extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.set(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setRelease(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Plain_Volatile extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.set(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setVolatile(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Opaque_Opaque extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setOpaque(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setOpaque(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Opaque_Release extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setOpaque(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setRelease(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Opaque_Volatile extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setOpaque(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setVolatile(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Release_Release extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setRelease(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setRelease(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Release_Volatile extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setRelease(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setVolatile(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+    @JCStressTest
+    @JCStressMeta(VarHandleIntTearingTest.class)
+    @State
+    public static class Volatile_Volatile extends VarHandleIntTearingTest {
+        @Actor public void actor1() { VH.setVolatile(bytes, offset1, 0xAAAAAAAA); }
+        @Actor public void actor2() { VH.setVolatile(bytes, offset2, 0x55555555); }
+        @Arbiter public void arbiter1(II_Result r) { summary(r); }
+    }
+
+}

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/AddLong1.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/AddLong1.java
@@ -35,8 +35,6 @@ import org.openjdk.jcstress.infra.results.JJ_Result;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-import static org.openjdk.jcstress.util.UnsafeHolder.UNSAFE;
-
 @JCStressTest
 @Description("Tests if VarHandle.getAndAddLong is racy")
 @Outcome(id = "1, 2", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/AddLong42.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/AddLong42.java
@@ -22,42 +22,45 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.jcstress.tests.init.primitives.fenced;
+package org.openjdk.jcstress.tests.varhandles;
 
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.JJ_Result;
+
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-import org.openjdk.jcstress.annotations.Actor;
-import org.openjdk.jcstress.annotations.JCStressMeta;
-import org.openjdk.jcstress.annotations.JCStressTest;
-import org.openjdk.jcstress.annotations.State;
-import org.openjdk.jcstress.infra.results.B_Result;
-import org.openjdk.jcstress.tests.init.Grading_IntShouldSeeFull;
-
 @JCStressTest
-@JCStressMeta(Grading_IntShouldSeeFull.class)
+@Description("Tests if VarHandle.getAndAddLong is racy")
+@Outcome(id = "1, 4398046511104", expect = Expect.ACCEPTABLE, desc = "T1 -> T2 execution")
+@Outcome(id = "0, 0",             expect = Expect.ACCEPTABLE, desc = "T2 -> T1 execution")
+@Outcome(id = "0, 4398046511104", expect = Expect.ACCEPTABLE, desc = "T2 reads the result early")
 @State
-public class ByteFencedTest {
+public class AddLong42 {
 
-    Shell shell;
+    static final VarHandle VH;
 
-    public static class Shell {
-        byte x;
-
-        public Shell() {
-            this.x = (byte) 0xFF;
-            VarHandle.releaseFence();
+    static {
+        try {
+            VH = MethodHandles.lookup().findVarHandle(AddLong42.class, "x", long.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
         }
     }
 
+    long x;
+    volatile int written;
+
     @Actor
     public void actor1() {
-        shell = new Shell();
+        VH.getAndAdd(this, 1L << 42);
+        written = 1;
     }
 
     @Actor
-    public void actor2(B_Result r) {
-        Shell sh = shell;
-        r.r1 = (sh == null) ? 42 : sh.x;
+    public void actor2(JJ_Result r) {
+        r.r1 = written;
+        r.r2 = (long)VH.get(this);
     }
 
 }

--- a/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/ReadTwiceOverVolatileReadTest.java
+++ b/tests-custom/src/main/java/org/openjdk/jcstress/tests/varhandles/ReadTwiceOverVolatileReadTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.tests.varhandles;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.III_Result;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+/**
+ * Test if volatile write-read induces happens-before if in between two non-volatile reads.
+ *
+ * @author Aleksey Shipilev (shade@redhat.com)
+ */
+@JCStressTest
+@Outcome(id = "0, 0, 0", expect = Expect.ACCEPTABLE, desc = "Default value for the fields. Observers are allowed to see the default value for the field, because there is the data race between reader and writer.")
+@Outcome(id = "0, 1, 0", expect = Expect.FORBIDDEN,  desc = "Volatile write to $y had happened, and update to $x had been lost.")
+@Outcome(id = "1, 1, 0", expect = Expect.FORBIDDEN,  desc = "Volatile write to $y had happened, and update to $x had been lost.")
+@Outcome(id = "1, 0, 0", expect = Expect.ACCEPTABLE, desc = "Write to $y is still in flight, can see inconsistent $x.")
+@Outcome(id = "0, 0, 1", expect = Expect.ACCEPTABLE, desc = "Write to $y is still in flight, $x is arriving late.")
+@Outcome(id = "1, 0, 1", expect = Expect.ACCEPTABLE, desc = "Write to $y is still in flight, $x has arrived.")
+@Outcome(id = "0, 1, 1", expect = Expect.ACCEPTABLE, desc = "The writes appear the the writers' order.")
+@Outcome(id = "1, 1, 1", expect = Expect.ACCEPTABLE, desc = "Both updates are visible.")
+@Ref("https://bugs.openjdk.java.net/browse/JDK-8175887")
+@State
+public class ReadTwiceOverVolatileReadTest {
+
+    static final VarHandle VH;
+
+    static {
+        try {
+            VH = MethodHandles.lookup().findVarHandle(ReadTwiceOverVolatileReadTest.class, "y", int.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    int x;
+    volatile int y;
+
+    @Actor
+    public void actor1() {
+        x = 1;
+        VH.setVolatile(this, 1);
+    }
+
+    @Actor
+    public void actor2(III_Result r) {
+        r.r1 = x;
+        r.r2 = (int) VH.getVolatile(this);
+        r.r3 = x;
+    }
+
+}


### PR DESCRIPTION
With Unsafe being deprecated, we need to rewrite some of the tests to VarHandles.

Public samples and fences tests have been rewritten to VarHandles. VarHandle fences are simple wrappers over Unsafe, we expect no surprises. Other tests were copied and reimplemented with VarHandles to still have more coverage for Unsafe paths, until Unsafe is completely removed.