### PR TITLE
7904036: jcstress: Enable annotation processors for all test projects

### DIFF
--- a/jcstress-samples/pom.xml
+++ b/jcstress-samples/pom.xml
@@ -52,9 +52,6 @@ questions.
                 <configuration>
                     <source>11</source>
                     <target>11</target>
-                    <annotationProcessors>
-                        <annotationProcessor>org.openjdk.jcstress.infra.processors.JCStressTestProcessor</annotationProcessor>
-                    </annotationProcessors>
                 </configuration>
             </plugin>
         </plugins>

--- a/jcstress-test-base/pom.xml
+++ b/jcstress-test-base/pom.xml
@@ -48,6 +48,11 @@ questions.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessors>
+                        <annotationProcessor>org.openjdk.jcstress.infra.processors.JCStressTestProcessor</annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
[CODETOOLS-7904029](https://bugs.openjdk.org/browse/CODETOOLS-7904029) is incomplete.

```
$ java -jar tests-all/target/jcstress.jar -l | grep 'All matching"
All matching tests - 158
```

Those are only the tests from jcstress-samples. We need to enable annotation processors for all tests projects.

For reference, compiled with JDK 17:

```
$ java -jar tests-all/target/jcstress.jar -l | grep "All matching"
All matching tests - 4552
```