### PR TITLE
7904034: jcstress: Run with global int/C1/C2 modes even with split compilation

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -197,12 +197,18 @@ public class JCStress {
             // Do not skip unified modes
             return false;
         }
-        if (!config.runtimes().hasC2() && CompileMode.hasC2(cm, info.threads())) {
-            // No C2 runtime is available, skip split compilation tests with C2
+        // No C1/C2 runtime is available? Skip split compilation tests with C1/C2.
+        if (!config.availableRuntimes().hasC2() && CompileMode.hasC2(cm, info.threads())) {
             return true;
         }
-        if (!config.runtimes().hasC1() && CompileMode.hasC1(cm, info.threads())) {
-            // No C1 runtime is available, skip split compilation tests with C1
+        if (!config.availableRuntimes().hasC1() && CompileMode.hasC1(cm, info.threads())) {
+            return true;
+        }
+        // Config should be executed only when C1/C2 is available? Skip split compilation tests without them.
+        if (config.limitRuntimes().hasC2() && !CompileMode.hasC2(cm, info.threads())) {
+            return true;
+        }
+        if (config.limitRuntimes().hasC1() && !CompileMode.hasC1(cm, info.threads())) {
             return true;
         }
         // Do not skip by default.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -192,9 +192,20 @@ public class JCStress {
         return configs;
     }
 
+    private boolean skipMode(int cc, VMSupport.Config config, TestInfo info) {
+        switch (config.minCompiler()) {
+            case INT: {
+                if (!CompileMode.hasC2(cc, info.threads())
+            }
+        }
+    }
+
     private void forkedSplit(List<TestConfig> testConfigs, VMSupport.Config config, TestInfo info, SchedulingClass scl) {
         for (int cc : CompileMode.casesFor(info.threads(), VMSupport.c1Available(), VMSupport.c2Available())) {
-            if (config.onlyIfC2() && !CompileMode.hasC2(cc, info.threads())) {
+            if (skipMode(cc, config)) {
+                continue;
+            }
+            if (config.minCompiler() == VMSupport.Config.Compiler.C2 && !CompileMode.hasC2(cc, info.threads())) {
                 // This configuration is expected to run only when C2 is enabled,
                 // but compilation mode does not include C2. Can skip it to optimize
                 // testing time.

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -192,23 +192,23 @@ public class JCStress {
         return configs;
     }
 
-    private boolean skipMode(int cm, VMSupport.Config config, TestInfo info) {
+    private boolean skipMode(int cm, VMSupport.Config config, int threads) {
         if (CompileMode.isUnified(cm)) {
-            // Do not skip unified modes
+            // Do not skip unified modes.
             return false;
         }
         // No C1/C2 runtime is available? Skip split compilation tests with C1/C2.
-        if (!config.availableRuntimes().hasC2() && CompileMode.hasC2(cm, info.threads())) {
+        if (!config.availableRuntimes().hasC2() && CompileMode.hasC2(cm, threads)) {
             return true;
         }
-        if (!config.availableRuntimes().hasC1() && CompileMode.hasC1(cm, info.threads())) {
+        if (!config.availableRuntimes().hasC1() && CompileMode.hasC1(cm, threads)) {
             return true;
         }
         // Config should be executed only when C1/C2 is available? Skip split compilation tests without them.
-        if (config.limitRuntimes().hasC2() && !CompileMode.hasC2(cm, info.threads())) {
+        if (config.requiredRuntimes().hasC2() && !CompileMode.hasC2(cm, threads)) {
             return true;
         }
-        if (config.limitRuntimes().hasC1() && !CompileMode.hasC1(cm, info.threads())) {
+        if (config.requiredRuntimes().hasC1() && !CompileMode.hasC1(cm, threads)) {
             return true;
         }
         // Do not skip by default.
@@ -217,8 +217,7 @@ public class JCStress {
 
     private void forkedSplit(List<TestConfig> testConfigs, VMSupport.Config config, TestInfo info, SchedulingClass scl) {
         for (int cm : CompileMode.casesFor(info.threads(), VMSupport.c1Available(), VMSupport.c2Available())) {
-            if (skipMode(cm, config, info)) {
-                // Skip unnecessary modes to optimize testing time.
+            if (skipMode(cm, config, info.threads())) {
                 continue;
             }
             int forks = opts.getForks() * (config.stress() ? opts.getForksStressMultiplier() : 1);

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/CompileMode.java
@@ -75,6 +75,10 @@ public class CompileMode {
         return (mode != UNIFIED) && (actorMode(mode, actor) == MODE_C2);
     }
 
+    public static boolean isUnified(int mode) {
+        return mode == UNIFIED;
+    }
+
     public static boolean hasC2(int mode, int actors) {
         if (mode == UNIFIED) {
             return true;
@@ -85,7 +89,7 @@ public class CompileMode {
         return false;
     }
 
-    private static boolean hasC1(int mode, int actors) {
+    public static boolean hasC1(int mode, int actors) {
         if (mode == UNIFIED) {
             return true;
         }


### PR DESCRIPTION
WIP.

[JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997) shows there is a gap in current configuration coverage with jcstress. When split compilation is enabled, harness asks to int/C1/C2 each actor method separately. Unfortunately, there are cases in Hotspot where the barrier scheme depends on whether C2 is globally enabled. [JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997) would fail split int/C1 test with C2 globally disabled.

Therefore, harness should run with global int/C1/C2 modes even with split compilation. This complicates testing matrix quite a bit, but it should capture bugs like [JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997) more reliably.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904034](https://bugs.openjdk.org/browse/CODETOOLS-7904034): jcstress: Run with global int/C1/C2 modes even with split compilation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.org/jcstress.git pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/168.diff">https://git.openjdk.org/jcstress/pull/168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/168#issuecomment-2981698545)
</details>
