### PR TITLE
7904040: jcstress: Drop default stress-fork to 1

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/Options.java
@@ -218,7 +218,7 @@ public class Options {
             this.pretouchHeap = false;
         } else {
             this.forks = 1;
-            this.forksStressMultiplier = 3;
+            this.forksStressMultiplier = 1;
             this.strideSize = 256;
             this.strideCount = 40;
             this.pretouchHeap = true;


### PR DESCRIPTION
With incoming test changes, we have more configurations to run. To keep run time within reasonable bounds, it makes more sense to drop default -fsm to 1. Users could still re-define it to larger values to get more stress out of individual tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904040](https://bugs.openjdk.org/browse/CODETOOLS-7904040): jcstress: Drop default stress-fork to 1 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/jcstress.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/170.diff">https://git.openjdk.org/jcstress/pull/170.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/170#issuecomment-2983418610)
</details>
