### PR TITLE
7904042: jcstress: Native access warnings when running with JDK 25

### DIFF
--- a/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/JCStress.java
@@ -86,9 +86,9 @@ public class JCStress {
     }
 
     private ConfigsWithScheduler getConfigs() {
-        OSSupport.init();
-
         VMSupport.initFlags(opts);
+
+        OSSupport.init();
 
         VMSupport.detectAvailableVMConfigs(opts.isSplitCompilation(), opts.getJvmArgs(), opts.getJvmArgsPrepend());
         if (VMSupport.getAvailableVMConfigs().isEmpty()) {

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/TestExecutor.java
@@ -285,10 +285,15 @@ public class TestExecutor {
                     command.add("-XX:CompilerDirectivesFile=" + compilerDirectives.getAbsolutePath());
                 }
 
+                boolean localAffinity = task.shClass.mode() == AffinityMode.LOCAL;
+                if (localAffinity && VMSupport.enableNativeAccessAvailable()) {
+                    command.add(VMSupport.enableNativeAccessOpt());
+                }
+
                 command.add(ForkedMain.class.getName());
 
                 // notify the forked VM whether we want the local affinity initialized
-                command.add(Boolean.toString(task.shClass.mode() == AffinityMode.LOCAL));
+                command.add(Boolean.toString(localAffinity));
 
                 command.add(host);
                 command.add(String.valueOf(port));

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
@@ -71,8 +71,6 @@ public class AffinitySupport {
          */
         public static List<String> prepare() {
             System.setProperty("jnidispatch.preserve", "true");
-            // TODO: This causes native access warnings on JDK 25, but it is apparently required
-            // to figure out the JNA libraries paths.
             Native.load("c", CLibrary.class);
 
             File file = new File(System.getProperty("jnidispatch.path"));

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupport.java
@@ -71,6 +71,8 @@ public class AffinitySupport {
          */
         public static List<String> prepare() {
             System.setProperty("jnidispatch.preserve", "true");
+            // TODO: This causes native access warnings on JDK 25, but it is apparently required
+            // to figure out the JNA libraries paths.
             Native.load("c", CLibrary.class);
 
             File file = new File(System.getProperty("jnidispatch.path"));

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupportPrepareMain.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/AffinitySupportPrepareMain.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jcstress.os;
+
+import java.util.List;
+
+public class AffinitySupportPrepareMain {
+
+    public static void main(String... args) {
+        List<String> list = AffinitySupport.prepare();
+        for (String s : list) {
+            System.out.println(OSSupport.AFFINITY_PREPARE_PREFIX + s);
+        }
+    }
+
+}

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/os/OSSupport.java
@@ -61,6 +61,9 @@ public class OSSupport {
 
             // Test the unpacked mode works...
             List<String> test = new ArrayList<>(AFFINITY_ADDITIONAL_OPTIONS);
+            if (VMSupport.enableNativeAccessAvailable()) {
+                test.add(VMSupport.enableNativeAccessOpt());
+            }
             test.add(AffinitySupportTestMain.class.getCanonicalName());
             VMSupport.tryWith(test.toArray(new String[0]));
 

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/util/StringUtils.java
@@ -24,7 +24,9 @@
  */
 package org.openjdk.jcstress.util;
 
+import java.io.BufferedReader;
 import java.io.PrintWriter;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +77,12 @@ public class StringUtils {
             results.add(s);
         }
 
+        return results;
+    }
+
+    public static List<String> splitLines(String src) {
+        List<String> results = new ArrayList<>();
+        new BufferedReader(new StringReader(src)).lines().forEach(results::add);
         return results;
     }
 
@@ -172,5 +180,15 @@ public class StringUtils {
         } else {
             return String.format("%." + prec + "f%%", p);
         }
+    }
+
+    public static List<String> select(String prefix, List<String> src) {
+        List<String> result = new ArrayList<>();
+        for (String s : src) {
+            if (s.startsWith(prefix)) {
+                result.add(s.substring(prefix.length()));
+            }
+        }
+        return result;
     }
 }

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -57,6 +57,9 @@ public class VMSupport {
 
     private static volatile boolean BIASED_LOCKING_AVAILABLE;
 
+    private static volatile boolean ENABLE_NATIVE_ACCESS_AVAILABLE;
+    private static final String ENABLE_NATIVE_ACCESS_OPT = "--enable-native-access=ALL-UNNAMED";
+
     public static boolean spinWaitHintAvailable() {
         return THREAD_SPIN_WAIT_AVAILABLE;
     }
@@ -75,6 +78,14 @@ public class VMSupport {
 
     public static boolean c2Available() {
         return C2_AVAILABLE;
+    }
+
+    public static boolean enableNativeAccessAvailable() {
+        return ENABLE_NATIVE_ACCESS_AVAILABLE;
+    }
+
+    public static String enableNativeAccessOpt() {
+        return ENABLE_NATIVE_ACCESS_OPT;
     }
 
     public static void initFlags(Options opts) {
@@ -117,6 +128,13 @@ public class VMSupport {
                 SimpleTestMain.class,
                 null,
                 "-XX:+UseBiasedLocking"
+        );
+
+        ENABLE_NATIVE_ACCESS_AVAILABLE = detect("Checking for native access warnings",
+                false,
+                SimpleTestMain.class,
+                null,
+                ENABLE_NATIVE_ACCESS_OPT
         );
 
         // Tests are supposed to run in a very tight memory constraints:

--- a/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
+++ b/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java
@@ -506,7 +506,7 @@ public class VMSupport {
         System.out.println();
     }
 
-    public static void tryWith(String... lines) throws VMSupportException {
+    public static String tryWith(String... lines) throws VMSupportException {
         try {
             List<String> commandString = getJavaInvokeLine();
             commandString.addAll(
@@ -530,8 +530,10 @@ public class VMSupport {
             errDrainer.join();
             outDrainer.join();
 
-            if (ecode != 0) {
-                String msg = new String(baos.toByteArray());
+            String msg = baos.toString();
+            if (ecode == 0) {
+                return msg;
+            } else {
                 throw new VMSupportException(msg);
             }
         } catch (IOException | InterruptedException ex) {


### PR DESCRIPTION
Current jcstress uses JNA for affinity setup. It causes lots of warnings when running with JDK 25.

This PR tries to fix most of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904042](https://bugs.openjdk.org/browse/CODETOOLS-7904042): jcstress: Native access warnings when running with JDK 25 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jcstress.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/171.diff">https://git.openjdk.org/jcstress/pull/171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/171#issuecomment-2983617671)
</details>
