### PR TITLE
7904041: jcstress: Amend seqcst tests with reference types

### DIFF
--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0bTestGenerator.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/chapters/Chapter0bTestGenerator.java
@@ -41,8 +41,12 @@ public class Chapter0bTestGenerator {
 
         SeqCstTraceGenerator.generate(
                 dst,
-                "org.openjdk.jcstress.tests.seqcst.volatiles",
-                Target.VOLATILE);
+                "org.openjdk.jcstress.tests.seqcst.volatiles.prim",
+                Target.VOLATILE_PRIM);
+        SeqCstTraceGenerator.generate(
+                dst,
+                "org.openjdk.jcstress.tests.seqcst.volatiles.ref",
+                Target.VOLATILE_REF);
     }
 
 }

--- a/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/Target.java
+++ b/jcstress-test-gen/src/main/java/org/openjdk/jcstress/generator/seqcst/Target.java
@@ -25,6 +25,7 @@
 package org.openjdk.jcstress.generator.seqcst;
 
 public enum Target {
-    VOLATILE,
+    VOLATILE_PRIM,
+    VOLATILE_REF,
     SYNCHRONIZED,
 }


### PR DESCRIPTION
[JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997) shows there is a gap in testing: we only verify seqcst scenarios over primitive volatiles. We need to extend this to reference types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904041](https://bugs.openjdk.org/browse/CODETOOLS-7904041): jcstress: Amend seqcst tests with reference types (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/jcstress.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/172.diff">https://git.openjdk.org/jcstress/pull/172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/172#issuecomment-2983620337)
</details>
