### PR TITLE
7904043: jcstress: AdvancedJMM_15_VolatilesAreNotFences.Fences is failing after CODETOOLS-7904033

### DIFF
--- a/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
+++ b/jcstress-samples/src/main/java/org/openjdk/jcstress/samples/jmm/advanced/AdvancedJMM_15_VolatilesAreNotFences.java
@@ -107,7 +107,7 @@ public class AdvancedJMM_15_VolatilesAreNotFences {
         @Actor
         void thread1() {
             x = 1;
-            VarHandle.acquireFence();
+            VarHandle.releaseFence();
             y = 1;
         }
 


### PR DESCRIPTION
In [CODETOOLS-7904033](https://bugs.openjdk.org/browse/CODETOOLS-7904033), I made a little mistake of rewriting Unsafe.storeFence to VarHandle.acquireFence. It should be VarHandle.releaseFence. That subtest is currently failing on AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904043](https://bugs.openjdk.org/browse/CODETOOLS-7904043): jcstress: AdvancedJMM_15_VolatilesAreNotFences.Fences is failing after CODETOOLS-7904033 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcstress.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jcstress.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcstress/pull/173.diff">https://git.openjdk.org/jcstress/pull/173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcstress/pull/173#issuecomment-2987465649)
</details>
